### PR TITLE
クローズドβ中のGoogle/メールログインを完全に遮断 (#14)

### DIFF
--- a/src/routes/auth/+page.server.ts
+++ b/src/routes/auth/+page.server.ts
@@ -8,6 +8,12 @@ import type { Actions, PageServerLoad } from "./$types";
 
 const MIN_PASSWORD_LENGTH = 6;
 
+// クローズドβ中は Discord ログインのみ許可する。
+// UI は非表示だがアクションエンドポイントは直接 POST 可能なため、サーバー側でも遮断する。
+function isClosedBeta(): boolean {
+	return publicEnv["PUBLIC_CLOSED_BETA"] === "true";
+}
+
 function getSafeNext(raw: FormDataEntryValue | string | null): string {
 	const next = typeof raw === "string" ? raw : "/";
 	return next.startsWith("/") && !next.startsWith("//") && !next.includes(":/") ? next : "/";
@@ -40,6 +46,9 @@ export const load: PageServerLoad = async ({ url, locals: { safeGetSession } }) 
 
 export const actions: Actions = {
 	login: async ({ request, locals: { supabase } }) => {
+		if (isClosedBeta()) {
+			return fail(403, { mode: "login", email: "", message: "現在はDiscordログインのみご利用いただけます" });
+		}
 		const form = await request.formData();
 		const email = (form.get("email") as string | null)?.trim() ?? "";
 		const password = (form.get("password") as string | null) ?? "";
@@ -63,6 +72,15 @@ export const actions: Actions = {
 	},
 
 	register: async ({ request, locals: { supabase } }) => {
+		if (isClosedBeta()) {
+			return fail(403, {
+				mode: "register",
+				email: "",
+				username: "",
+				display_name: "",
+				message: "現在はDiscordログインのみご利用いただけます",
+			});
+		}
 		const form = await request.formData();
 		const email = (form.get("email") as string | null)?.trim() ?? "";
 		const password = (form.get("password") as string | null) ?? "";
@@ -271,6 +289,9 @@ export const actions: Actions = {
 	},
 
 	google: async ({ request, url, locals: { supabase } }) => {
+		if (isClosedBeta()) {
+			return fail(403, { mode: "login", email: "", message: "現在はDiscordログインのみご利用いただけます" });
+		}
 		const form = await request.formData();
 		const next = getSafeNext(form.get("next"));
 		const redirectTo = `${url.origin}/auth/callback?next=${encodeURIComponent(next)}`;

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,6 +1,7 @@
 import { redirect } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
-import { verifyGuildMembership } from "$lib/server/discord";
+import { env as publicEnv } from "$env/dynamic/public";
+import { isBetaMember, verifyGuildMembership } from "$lib/server/discord";
 import { createServiceRoleClient } from "$lib/server/supabase-admin";
 import type { RequestHandler } from "./$types";
 
@@ -10,7 +11,9 @@ import type { RequestHandler } from "./$types";
  *
  * Discord ログイン時のみ、対象サーバーへの所属を Bot トークンで検証し、
  * メンバーであれば app_metadata.beta_member=true を付与する。
- * google / メールログインはこの検証をスキップする（β中はゲートで弾かれる）。
+ * クローズドβ中は、Discord 所属検証を通っていないユーザー（Google / メール等）の
+ * セッションをここで破棄する。hooks のゲートは遷移を弾くだけでログアウトはさせず、
+ * セッションが残ると「ログインできてしまう」状態になるため、明示的に signOut する。
  */
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 	const code = url.searchParams.get("code");
@@ -26,6 +29,9 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 		data: { user },
 	} = await supabase.auth.getUser();
 	if (!user) redirect(303, "/");
+
+	// 既に beta_member を持つ既存ユーザーは検証通過済みとして扱う（再ログイン時）
+	let betaGranted = isBetaMember(user);
 
 	// Discord ログインのみ所属検証を行う
 	const discordIdentity = user.identities?.find((identity) => identity.provider === "discord");
@@ -63,6 +69,15 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 			await supabase.auth.signOut();
 			redirect(303, "/auth?error=not_member");
 		}
+
+		betaGranted = true;
+	}
+
+	// クローズドβ：所属検証を通っていないユーザー（Google / メール等）は
+	// セッションを破棄してログインを成立させない。
+	if (publicEnv["PUBLIC_CLOSED_BETA"] === "true" && !betaGranted) {
+		await supabase.auth.signOut();
+		redirect(303, "/auth?error=not_member");
 	}
 
 	redirect(303, safeNext);


### PR DESCRIPTION
## 概要

Issue #14「Googleでログインができてしまう問題」を修正します。

Discord 認証へ切り替えた後も Google／メールログインでセッションが確立してしまい、
「エラーが表示されるのに実際はログインできている（自分のプロフィールが出現する）」状態になっていました。

## 原因

1. **callback がセッションを破棄しない** — `src/routes/auth/callback/+server.ts` は Discord identity のときだけ所属検証し、非メンバーなら `signOut()` していた。一方 Google／メールログインは検証をスキップして**有効なセッションのまま**リダイレクトしていた。`hooks.server.ts` のゲートはページ遷移を `/auth?error=not_member` へ弾くだけで**セッション自体は消さない**ため、`+layout.server.ts` がプロフィールを取得しナビにログイン状態が表示されていた。
2. UI 側（`PUBLIC_CLOSED_BETA` 未設定で Google ボタン／メール欄が残存）は `.env` への `PUBLIC_CLOSED_BETA=true` 追加で別途解消済み。

## 変更内容

- **callback**: `betaGranted` で「Discord 所属検証通過」または「既存 `beta_member` 保持」を追跡し、β中かつ未資格なら最終リダイレクト前に `signOut()` してセッションを破棄。
- **auth actions**: `login` / `register` / `google` をβ中は `fail(403)` で遮断。UI は非表示だがエンドポイントは直接 POST 可能なため多層防御。

## テスト

- `pnpm check`（biome + svelte-check + tsc）すべてパス。

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)