### PR TITLE
perf: enrichPostsWithCounts を get_post_counts 単一RPCに統合 (#30)

### DIFF
--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -150,29 +150,16 @@ export async function enrichPostsWithCounts(
 
 	const postIds = visibleRawPosts.map((p) => p.id as string);
 
-	// ── 並列バッチクエリ ──────────────────────────────────────────
-	const [countsRes, myLikesRes, myRepostsRes, myBookmarksRes] = await Promise.all([
-		supabase.rpc("get_post_engagement_counts", { target_post_ids: postIds }),
-		// ログイン中ユーザーのいいね一覧
-		userId
-			? supabase.from("likes").select("post_id").eq("user_id", userId).in("post_id", postIds)
-			: Promise.resolve({ data: [] as { post_id: string }[] }),
+	// ── 件数＋自分のリアクション有無を単一RPCで取得（DB往復 4→1）──────
+	// get_post_counts は like/repost/reply の件数に加え、
+	// liked_by_me / reposted_by_me / bookmarked_by_me を1クエリで返す。
+	// p_user_id が NULL（未ログイン）の場合は各 *_by_me が全て false になる。
+	const { data: countsData } = await supabase.rpc("get_post_counts", {
+		p_post_ids: postIds,
+		p_user_id: userId,
+	});
 
-		// ログイン中ユーザーのリポスト一覧
-		userId
-			? supabase.from("reposts").select("post_id").eq("user_id", userId).in("post_id", postIds)
-			: Promise.resolve({ data: [] as { post_id: string }[] }),
-
-		userId
-			? supabase.from("bookmarks").select("post_id").eq("user_id", userId).in("post_id", postIds)
-			: Promise.resolve({ data: [] as { post_id: string }[] }),
-	]);
-
-	const countsByPostId = new Map((countsRes.data ?? []).map((row) => [row.post_id, row]));
-
-	const likedSet = new Set((myLikesRes.data ?? []).map((r) => r.post_id));
-	const repostedSet = new Set((myRepostsRes.data ?? []).map((r) => r.post_id));
-	const bookmarkedSet = new Set((myBookmarksRes.data ?? []).map((r) => r.post_id));
+	const countsByPostId = new Map((countsData ?? []).map((row) => [row.post_id, row]));
 
 	// ── アニメ引用がある投稿のスコアを一括取得 ────────────────────
 	const animeIds = Array.from(new Set(visibleRawPosts.map((p) => p.anime_id).filter((n): n is number => n != null)));
@@ -193,9 +180,9 @@ export async function enrichPostsWithCounts(
 			like_count: countsByPostId.get(raw["id"])?.like_count ?? 0,
 			repost_count: countsByPostId.get(raw["id"])?.repost_count ?? 0,
 			reply_count: countsByPostId.get(raw["id"])?.reply_count ?? 0,
-			liked_by_me: likedSet.has(raw["id"]),
-			reposted_by_me: repostedSet.has(raw["id"]),
-			bookmarked_by_me: bookmarkedSet.has(raw["id"]),
+			liked_by_me: countsByPostId.get(raw["id"])?.liked_by_me ?? false,
+			reposted_by_me: countsByPostId.get(raw["id"])?.reposted_by_me ?? false,
+			bookmarked_by_me: countsByPostId.get(raw["id"])?.bookmarked_by_me ?? false,
 		});
 		if (post.anime_quote && post.anime_id) {
 			post.anime_quote.user_score = normalizeScore(userScoreMap.get(post.anime_id));

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1020,6 +1020,18 @@ export type Database = {
 					reply_count: number;
 				}[];
 			};
+			get_post_counts: {
+				Args: { p_post_ids: string[]; p_user_id?: string | null };
+				Returns: {
+					post_id: string;
+					like_count: number;
+					repost_count: number;
+					reply_count: number;
+					liked_by_me: boolean;
+					reposted_by_me: boolean;
+					bookmarked_by_me: boolean;
+				}[];
+			};
 			create_anime_exchange: {
 				Args: { p_anime_id: number; p_comment?: string | null };
 				Returns: {

--- a/supabase/migrations/040_get_post_counts_rpc.sql
+++ b/supabase/migrations/040_get_post_counts_rpc.sql
@@ -11,6 +11,12 @@
 --   p_post_ids  : カウント対象の投稿IDリスト
 --   p_user_id   : ログイン中ユーザーのID（NULLの場合はliked/reposted/bookmarked は全てfalse）
 --
+-- セキュリティ:
+--   SECURITY DEFINER のため RLS をバイパスする。user_likes/user_reposts/user_bookmarks
+--   各CTEに AND p_user_id = auth.uid() を追加することで、呼び出し元が自分以外の
+--   UUID を p_user_id に渡しても *_by_me が常に false になるよう防御している。
+--   （NULL = auth.uid() は NULL であり偽になるため、未ログイン時も安全）
+--
 -- 返り値（1行 = 1投稿）:
 --   post_id, like_count, repost_count, reply_count,
 --   liked_by_me, reposted_by_me, bookmarked_by_me
@@ -60,18 +66,21 @@ AS $$
         FROM likes
         WHERE user_id = p_user_id
           AND post_id = ANY(p_post_ids)
+          AND p_user_id = auth.uid()
     ),
     user_reposts AS (
         SELECT post_id
         FROM reposts
         WHERE user_id = p_user_id
           AND post_id = ANY(p_post_ids)
+          AND p_user_id = auth.uid()
     ),
     user_bookmarks AS (
         SELECT post_id
         FROM bookmarks
         WHERE user_id = p_user_id
           AND post_id = ANY(p_post_ids)
+          AND p_user_id = auth.uid()
     )
     SELECT
         ids.id                          AS post_id,


### PR DESCRIPTION
## 概要

Close #30

`enrichPostsWithCounts` のエンゲージメント取得を、既存の未使用RPC `get_post_counts`（migration 040）に置き換え、**DB往復を 4→1** に削減しました。全投稿一覧系（ホーム・プロフィール・ハッシュタグ・検索・詳細・放送ルーム）の共通パスに効きます。

## 変更点

- `get_post_engagement_counts`（件数のみ）+ `likes`/`reposts`/`bookmarks` の3クエリ → `get_post_counts` 単一RPCに統合
- `database.types.ts` に `get_post_counts` のシグネチャを追加（既存のカスタムRPCと同じ流儀で追記）
- 未ログイン時（`p_user_id = NULL`）は `liked_by_me` / `reposted_by_me` / `bookmarked_by_me` が全て `false` になる挙動を踏襲

## 確認

- `pnpm check` ✅（型エラー 0）
- `pnpm test` ✅（20 passed）

> [!NOTE]
> `get_post_counts` は migration 040 で定義済みです。リモートSupabaseに適用済みであることを前提としています。未適用の場合はダッシュボードのSQLエディタで `supabase/migrations/040_get_post_counts_rpc.sql` を実行してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)