### PR TITLE
fix: Discord以外でのログイン時の警告文をクローズドβテスト向けに修正

### DIFF
--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -47,7 +47,7 @@ const next = $derived(data.next ?? "/");
 
 			{#if data.error === 'not_member'}
 				<div class="flash-error">
-					このDiscordサーバーのメンバーのみ参加できます。サーバーに参加してから、もう一度お試しください。
+					このサービスは現在、クローズドβテスト中です。テストに参加しているメンバーのみ利用できます。
 				</div>
 			{/if}
 


### PR DESCRIPTION
## Summary

- `not_member` エラー時の表示メッセージを「Discordサーバーのメンバーのみ参加できます」から「このサービスは現在、クローズドβテスト中です。テストに参加しているメンバーのみ利用できます。」に変更
- Discordサーバー限定という表現をやめ、クローズドβテストの文脈に合わせた文言に統一

## Test plan

- [x] Discord以外のプロバイダーでログインを試みたとき、新しいエラーメッセージが表示されること
- [x] `not_member` エラーが発生するシナリオで正しいメッセージが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)