### PR TITLE
[codex] authのクローズドβ判定を共通化 (#57)

### DIFF
--- a/src/routes/auth/+page.server.ts
+++ b/src/routes/auth/+page.server.ts
@@ -39,7 +39,7 @@ export const load: PageServerLoad = async ({ url, locals: { safeGetSession } }) 
 	return {
 		mode,
 		next,
-		closedBeta: publicEnv["PUBLIC_CLOSED_BETA"] === "true",
+		closedBeta: isClosedBeta(),
 		error: url.searchParams.get("error"),
 	};
 };


### PR DESCRIPTION
## 変更内容

- `load()` の `PUBLIC_CLOSED_BETA` 直接比較を既存の `isClosedBeta()` 呼び出しへ統一

## 理由

同じ判定ロジックが複数箇所に散らばる状態を解消し、環境変数名や判定条件を変更した際の修正漏れを防ぎます。

## 検証

- `PUBLIC_SUPABASE_URL=https://example.supabase.co DISCORD_BOT_TOKEN=dummy DISCORD_GUILD_ID=dummy pnpm check`

Closes #57