### PR TITLE
[codex] 主コンテンツをmainランドマーク化 (#41)

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -84,9 +84,9 @@ function handleFabClick() {
 		{pendingReportsCount}
 		extraAccounts={data.extraAccounts}
 	/>
-	<div class="app-main" id="main-content" tabindex="-1">
+	<main class="app-main" id="main-content" tabindex="-1">
 		{@render children()}
-	</div>
+	</main>
 </div>
 
 <MobileBottomNav session={data.session} {unreadNotificationCount} />


### PR DESCRIPTION
## 変更内容

- グローバルレイアウトの主コンテンツ要素を `<div>` から `<main>` へ変更
- `class="app-main"`、`id="main-content"`、`tabindex="-1"` は維持

## 効果

スキップリンクの移動先を正式なmainランドマークにし、スクリーンリーダーのランドマークナビゲーションに対応します。

## 検証

- `PUBLIC_SUPABASE_URL=https://example.supabase.co DISCORD_BOT_TOKEN=dummy DISCORD_GUILD_ID=dummy pnpm check`

Closes #41