### PR TITLE
[codex] モバイルナビの現在地を明示 (#42)

### DIFF
--- a/src/lib/components/MobileBottomNav.svelte
+++ b/src/lib/components/MobileBottomNav.svelte
@@ -17,7 +17,13 @@ function isActive(path: string): boolean {
 
 <nav class="mobile-bottom-nav" aria-label="モバイルナビゲーション">
 	{#if session}
-		<a href="/" class="mobile-tab" class:active={isActive('/')} aria-label="ホーム">
+		<a
+			href="/"
+			class="mobile-tab"
+			class:active={isActive('/')}
+			aria-label="ホーム"
+			aria-current={isActive('/') ? 'page' : undefined}
+		>
 			<svg
 				width="22"
 				height="22"
@@ -35,7 +41,13 @@ function isActive(path: string): boolean {
 			<span class="mobile-tab-label">ホーム</span>
 		</a>
 
-		<a href="/search" class="mobile-tab" class:active={isActive('/search')} aria-label="検索">
+		<a
+			href="/search"
+			class="mobile-tab"
+			class:active={isActive('/search')}
+			aria-label="検索"
+			aria-current={isActive('/search') ? 'page' : undefined}
+		>
 			<svg
 				width="22"
 				height="22"
@@ -58,6 +70,7 @@ function isActive(path: string): boolean {
 			class="mobile-tab"
 			class:active={isActive('/schedule') || isActive('/events')}
 			aria-label="カレンダー"
+			aria-current={isActive('/schedule') || isActive('/events') ? 'page' : undefined}
 		>
 			<svg
 				width="22"
@@ -76,7 +89,13 @@ function isActive(path: string): boolean {
 			<span class="mobile-tab-label">カレンダー</span>
 		</a>
 
-		<a href="/notifications" class="mobile-tab" class:active={isActive('/notifications')} aria-label="通知">
+		<a
+			href="/notifications"
+			class="mobile-tab"
+			class:active={isActive('/notifications')}
+			aria-label="通知"
+			aria-current={isActive('/notifications') ? 'page' : undefined}
+		>
 			<span class="mobile-tab-icon-wrap">
 				<svg
 					width="22"
@@ -101,7 +120,13 @@ function isActive(path: string): boolean {
 			<span class="mobile-tab-label">通知</span>
 		</a>
 
-		<a href="/mylist" class="mobile-tab" class:active={isActive('/mylist')} aria-label="マイリスト">
+		<a
+			href="/mylist"
+			class="mobile-tab"
+			class:active={isActive('/mylist')}
+			aria-label="マイリスト"
+			aria-current={isActive('/mylist') ? 'page' : undefined}
+		>
 			<svg
 				width="22"
 				height="22"
@@ -118,7 +143,13 @@ function isActive(path: string): boolean {
 			<span class="mobile-tab-label">マイリスト</span>
 		</a>
 	{:else}
-		<a href="/" class="mobile-tab" class:active={isActive('/')} aria-label="ホーム">
+		<a
+			href="/"
+			class="mobile-tab"
+			class:active={isActive('/')}
+			aria-label="ホーム"
+			aria-current={isActive('/') ? 'page' : undefined}
+		>
 			<svg
 				width="22"
 				height="22"
@@ -136,7 +167,13 @@ function isActive(path: string): boolean {
 			<span class="mobile-tab-label">ホーム</span>
 		</a>
 
-		<a href="/search" class="mobile-tab" class:active={isActive('/search')} aria-label="検索">
+		<a
+			href="/search"
+			class="mobile-tab"
+			class:active={isActive('/search')}
+			aria-label="検索"
+			aria-current={isActive('/search') ? 'page' : undefined}
+		>
 			<svg
 				width="22"
 				height="22"
@@ -159,6 +196,7 @@ function isActive(path: string): boolean {
 			class="mobile-tab"
 			class:active={isActive('/schedule') || isActive('/events')}
 			aria-label="カレンダー"
+			aria-current={isActive('/schedule') || isActive('/events') ? 'page' : undefined}
 		>
 			<svg
 				width="22"
@@ -177,12 +215,24 @@ function isActive(path: string): boolean {
 			<span class="mobile-tab-label">カレンダー</span>
 		</a>
 
-		<a href="/anime" class="mobile-tab" class:active={isActive('/anime')} aria-label="アニメ">
+		<a
+			href="/anime"
+			class="mobile-tab"
+			class:active={isActive('/anime')}
+			aria-label="アニメ"
+			aria-current={isActive('/anime') ? 'page' : undefined}
+		>
 			<span class="anipolis-logo-icon" aria-hidden="true"></span>
 			<span class="mobile-tab-label">アニメ</span>
 		</a>
 
-		<a href="/auth" class="mobile-tab" class:active={isActive('/auth')} aria-label="ログイン">
+		<a
+			href="/auth"
+			class="mobile-tab"
+			class:active={isActive('/auth')}
+			aria-label="ログイン"
+			aria-current={isActive('/auth') ? 'page' : undefined}
+		>
 			<svg
 				width="22"
 				height="22"
@@ -238,6 +288,10 @@ function isActive(path: string): boolean {
 .mobile-tab-label {
 	font-size: 10px;
 	line-height: 1;
+}
+
+.mobile-tab.active .mobile-tab-label {
+	font-weight: 700;
 }
 
 .mobile-tab-icon-wrap {


### PR DESCRIPTION
## 変更内容

- ログイン済み・未ログイン双方のモバイルナビリンクへ、既存の `isActive()` 判定に基づく `aria-current="page"` を追加
- アクティブ項目のラベルを太字にし、色だけに依存しない視覚表現を追加

## 効果

スクリーンリーダーへ現在地を伝え、色覚に依存せずアクティブ項目を判別できるようにします。

## 検証

- `PUBLIC_SUPABASE_URL=https://example.supabase.co DISCORD_BOT_TOKEN=dummy DISCORD_GUILD_ID=dummy pnpm check`

Closes #42