### PR TITLE
[codex] ライトモードのアカウントメニューフォーカス色を修正 (#52)

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1182,9 +1182,8 @@ function isActive(path: string): boolean {
 
 .account-menu-item:hover,
 .account-menu-item:focus {
-	background: var(--surface-hover, #263348);
-	color: var(--fg, #f1f5f9);
-	text-decoration: none;
+	background: var(--color-surface-hover);
+	color: var(--color-text);
 }
 
 .account-menu-item:focus {
@@ -1192,7 +1191,7 @@ function isActive(path: string): boolean {
 }
 
 .account-menu-item:focus-visible {
-	outline: 2px solid var(--accent, #6366f1);
+	outline: 2px solid var(--color-accent);
 	outline-offset: -3px;
 }
 

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1170,7 +1170,7 @@ function isActive(path: string): boolean {
 	width: 100%;
 	padding: 10px 16px;
 	font-size: 0.9rem;
-	color: var(--fg, #f1f5f9);
+	color: var(--color-text);
 	background: none;
 	border: none;
 	cursor: pointer;
@@ -1183,7 +1183,10 @@ function isActive(path: string): boolean {
 .account-menu-item:hover,
 .account-menu-item:focus {
 	background: var(--color-surface-hover);
-	color: var(--color-text);
+}
+
+.account-menu-item:active {
+	background: color-mix(in srgb, var(--color-accent) 14%, var(--color-surface));
 }
 
 .account-menu-item:focus {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1177,10 +1177,23 @@ function isActive(path: string): boolean {
 	text-decoration: none;
 	text-align: left;
 	transition: background 0.12s;
+	-webkit-tap-highlight-color: transparent;
 }
 
-.account-menu-item:hover {
+.account-menu-item:hover,
+.account-menu-item:focus {
 	background: var(--surface-hover, #263348);
+	color: var(--fg, #f1f5f9);
+	text-decoration: none;
+}
+
+.account-menu-item:focus {
+	outline: none;
+}
+
+.account-menu-item:focus-visible {
+	outline: 2px solid var(--accent, #6366f1);
+	outline-offset: -3px;
 }
 
 .account-menu-current {


### PR DESCRIPTION
## 変更内容

- アカウントメニュー項目の hover / focus 背景と文字色をテーマ変数で明示
- タップ時のブラウザ既定ハイライトを無効化
- キーボード操作時は `:focus-visible` でアクセント色の2pxリングを表示

## 理由

ライトモードで「アカウントを追加」へフォーカスした際、ブラウザ側の濃色状態が露出して文字とのコントラストが崩れていました。ライト・ダーク双方で既存テーマに沿う状態色へ統一します。

## 検証

- Issue添付画像と対象セレクタを確認
- `PUBLIC_SUPABASE_URL=https://example.supabase.co DISCORD_BOT_TOKEN=dummy DISCORD_GUILD_ID=dummy pnpm check`

Closes #52