### PR TITLE
[codex] アニメカードのタイトル高を固定 (#23)

### DIFF
--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -1518,6 +1518,7 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	font-size: 0.85rem;
 	font-weight: 600;
 	line-height: 1.3;
+	min-height: calc(0.85rem * 1.3 * 2);
 	margin: 0;
 	display: -webkit-box;
 	-webkit-line-clamp: 2;

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -767,12 +767,18 @@ function isAiringToday(anime: AnimeListItem): boolean {
 									{anime.title_en ?? '\u00A0'}
 								</p>
 								<div class="anime-meta">
-									<span class="anime-status-badge status-{anime.computed_broadcast_status}"
-										>{animeStatusBadge(anime)}</span
+									<div class="anime-status-slot">
+										<span class="anime-status-badge status-{anime.computed_broadcast_status}"
+											>{animeStatusBadge(anime)}</span
+										>
+									</div>
+									<span
+										class="anime-season"
+										class:anime-season--placeholder={!anime.season}
+										aria-hidden={anime.season ? undefined : "true"}
 									>
-									{#if anime.season}
-										<span class="anime-season">{anime.season}</span>
-									{/if}
+										{anime.season ?? '\u00A0'}
+									</span>
 								</div>
 								<div class="mylist-badge-slot">
 									{#if anime.user_entry}
@@ -1523,7 +1529,7 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	font-size: 0.85rem;
 	font-weight: 600;
 	line-height: 1.3;
-	min-height: calc(0.85rem * 1.3 * 2);
+	height: calc(0.85rem * 1.3 * 2);
 	margin: 0;
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
@@ -1534,7 +1540,7 @@ function isAiringToday(anime: AnimeListItem): boolean {
 .anime-title-en {
 	font-size: 0.72rem;
 	line-height: 1.2;
-	min-height: calc(0.72rem * 1.2);
+	height: calc(0.72rem * 1.2);
 	color: var(--text-muted);
 	margin: 0;
 	overflow: hidden;
@@ -1545,20 +1551,23 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	visibility: hidden;
 }
 .anime-meta {
-	display: flex;
-	flex-wrap: nowrap;
+	display: grid;
+	grid-template-rows: repeat(2, calc(0.72rem * 1.6 + 2px));
 	gap: 4px;
-	align-items: center;
-	margin-top: auto;
-	min-height: calc(0.72rem * 1.6 + 2px);
+	min-width: 0;
+}
+.anime-status-slot {
+	display: flex;
+	align-items: flex-start;
 	min-width: 0;
 }
 .anime-status-badge {
-	flex-shrink: 0;
 	font-size: 0.7rem;
 	padding: 1px 5px;
 	border-radius: 3px;
 	font-weight: 600;
+	line-height: 1.6;
+	white-space: nowrap;
 }
 .status-airing {
 	background: color-mix(in srgb, var(--status-watching) 15%, transparent);
@@ -1593,23 +1602,29 @@ function isAiringToday(anime: AnimeListItem): boolean {
 
 .anime-season {
 	font-size: 0.72rem;
+	line-height: 1.6;
 	color: var(--color-text-muted);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+.anime-season--placeholder {
+	visibility: hidden;
+}
 .mylist-badge-slot {
 	display: flex;
 	align-items: flex-start;
-	min-height: calc(0.7rem * 1.6 + 2px);
+	height: calc(0.7rem * 1.6 + 2px);
 }
 .mylist-badge {
 	font-size: 0.7rem;
+	line-height: 1.6;
 	padding: 1px 5px;
 	border-radius: 3px;
 	background: var(--accent-muted, #19448e22);
 	color: var(--accent);
 	width: fit-content;
+	white-space: nowrap;
 }
 
 .empty-state {

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -1464,6 +1464,12 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	}
 }
 
+@media (max-width: 420px) {
+	.anime-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
 @media (max-width: 768px) and (orientation: landscape) {
 	.anime-list-surface {
 		padding-bottom: 0;

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -759,9 +759,13 @@ function isAiringToday(anime: AnimeListItem): boolean {
 							</div>
 							<div class="anime-info">
 								<p class="anime-title">{anime.title}</p>
-								{#if anime.title_en}
-									<p class="anime-title-en">{anime.title_en}</p>
-								{/if}
+								<p
+									class="anime-title-en"
+									class:anime-title-en--placeholder={!anime.title_en}
+									aria-hidden={anime.title_en ? undefined : "true"}
+								>
+									{anime.title_en ?? '\u00A0'}
+								</p>
 								<div class="anime-meta">
 									<span class="anime-status-badge status-{anime.computed_broadcast_status}"
 										>{animeStatusBadge(anime)}</span
@@ -770,11 +774,13 @@ function isAiringToday(anime: AnimeListItem): boolean {
 										<span class="anime-season">{anime.season}</span>
 									{/if}
 								</div>
-								{#if anime.user_entry}
-									<span class="mylist-badge"
-										>{statusLabels[anime.user_entry.status as AnimeStatus]}</span
-									>
-								{/if}
+								<div class="mylist-badge-slot">
+									{#if anime.user_entry}
+										<span class="mylist-badge"
+											>{statusLabels[anime.user_entry.status as AnimeStatus]}</span
+										>
+									{/if}
+								</div>
 							</div>
 						</a>
 					{/each}
@@ -1512,7 +1518,6 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	flex-direction: column;
 	gap: 4px;
 	flex: 1;
-	min-height: calc(0.85rem * 1.3 * 2 + 0.72rem * 1.2 + 28px);
 }
 .anime-title {
 	font-size: 0.85rem;
@@ -1529,20 +1534,27 @@ function isAiringToday(anime: AnimeListItem): boolean {
 .anime-title-en {
 	font-size: 0.72rem;
 	line-height: 1.2;
+	min-height: calc(0.72rem * 1.2);
 	color: var(--text-muted);
 	margin: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+.anime-title-en--placeholder {
+	visibility: hidden;
+}
 .anime-meta {
 	display: flex;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 	gap: 4px;
 	align-items: center;
 	margin-top: auto;
+	min-height: calc(0.72rem * 1.6 + 2px);
+	min-width: 0;
 }
 .anime-status-badge {
+	flex-shrink: 0;
 	font-size: 0.7rem;
 	padding: 1px 5px;
 	border-radius: 3px;
@@ -1582,6 +1594,14 @@ function isAiringToday(anime: AnimeListItem): boolean {
 .anime-season {
 	font-size: 0.72rem;
 	color: var(--color-text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.mylist-badge-slot {
+	display: flex;
+	align-items: flex-start;
+	min-height: calc(0.7rem * 1.6 + 2px);
 }
 .mylist-badge {
 	font-size: 0.7rem;


### PR DESCRIPTION
## 変更内容

- アニメカードのタイトル領域に2行分の `min-height` を設定
- 既存の2行クランプは維持

## 理由

短いタイトルは1行、長いタイトルは2行となるため、最下段のカード高に応じてページネーションバーが上下していました。タイトル領域を常に2行分確保し、ページ切替時の位置ずれを防ぎます。

## 検証

- Issue添付動画をフレーム確認し、最下段カードとページネーションの上下変動を確認
- `PUBLIC_SUPABASE_URL=https://example.supabase.co DISCORD_BOT_TOKEN=dummy DISCORD_GUILD_ID=dummy pnpm check`

Closes #23