### PR TITLE
[codex] カレンダー先頭列の設定メニュー見切れを修正 (#24)

### DIFF
--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -1192,9 +1192,11 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	gap: 8px;
 }
 
-.day-col:first-child .room-alert-menu {
-	left: 4px;
-	right: auto;
+@media (min-width: 961px) {
+	.day-col:first-child .room-alert-menu {
+		left: 4px;
+		right: auto;
+	}
 }
 
 .notify-toggle {

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -1191,6 +1191,12 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	flex-direction: column;
 	gap: 8px;
 }
+
+.day-col:first-child .room-alert-menu {
+	left: 4px;
+	right: auto;
+}
+
 .notify-toggle {
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
## 変更内容

- 先頭曜日列のルーム設定メニューだけ、右揃えから左揃えへ反転

## 理由

メニュー幅は240px、カレンダー列の最小幅は132pxです。日曜の先頭列で右揃えすると左側へはみ出し、横スクロールコンテナの境界でクリップされていました。先頭列だけカード左端基準にすることで、コンテナ内へ展開します。

## 検証

- Issue添付画像と `.schedule-grid` / `.room-alert-menu` の配置を照合
- `PUBLIC_SUPABASE_URL=https://example.supabase.co DISCORD_BOT_TOKEN=dummy DISCORD_GUILD_ID=dummy pnpm check`

Closes #24