### PR TITLE
[codex] キーボードフォーカスを明確に表示 (#40)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -549,6 +549,11 @@ textarea {
 	color: var(--color-text-muted);
 }
 
+.composer-textarea:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
 .composer-footer {
 	display: flex;
 	align-items: center;
@@ -1201,6 +1206,11 @@ textarea {
 	border-color: var(--color-accent);
 }
 
+.global-search-input:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
 .global-search-input::placeholder {
 	color: var(--color-text-muted);
 }
@@ -1671,6 +1681,11 @@ textarea {
 	border-color: var(--color-accent);
 }
 
+.field-input:not(.has-prefix):focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
 .field-input::placeholder {
 	color: var(--color-text-muted);
 }
@@ -1732,6 +1747,11 @@ textarea {
 	border-color: var(--color-accent);
 }
 
+.field-input-prefix:has(.field-input:focus-visible) {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
 .field-input-prefix:has(.field-error) {
 	border-color: var(--color-danger);
 }
@@ -1776,6 +1796,11 @@ textarea {
 .field-textarea:focus {
 	outline: none;
 	border-color: var(--color-accent);
+}
+
+.field-textarea:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
 }
 
 .field-textarea::placeholder {
@@ -2836,6 +2861,10 @@ textarea {
 .anime-search-input:focus {
 	border-color: var(--color-primary);
 }
+.anime-search-input:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
 .anime-search-results {
 	overflow-y: auto;
 	flex: 1;
@@ -3053,6 +3082,11 @@ form + .repost-menu-item {
 .quote-modal-textarea:focus {
 	outline: none;
 	border-color: var(--color-accent, #89b4fa);
+}
+
+.quote-modal-textarea:focus-visible {
+	outline: 2px solid var(--color-accent, #89b4fa);
+	outline-offset: 2px;
 }
 
 .quote-preview {

--- a/src/lib/components/AnimeEditRow.svelte
+++ b/src/lib/components/AnimeEditRow.svelte
@@ -236,6 +236,11 @@ function confirmRemove() {
 	outline: none;
 }
 
+.edit-select:focus-visible {
+	outline: 2px solid var(--accent, #6366f1);
+	outline-offset: 2px;
+}
+
 .score-select {
 	min-width: 70px;
 }

--- a/src/lib/components/AnimeRegisterForm.svelte
+++ b/src/lib/components/AnimeRegisterForm.svelte
@@ -607,6 +607,12 @@ async function handleFileChange(e: Event) {
 .rf-select:focus {
 	border-color: var(--color-accent);
 }
+.rf-input:focus-visible,
+.rf-textarea:focus-visible,
+.rf-select:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
 .rf-textarea {
 	resize: vertical;
 }

--- a/src/lib/components/MyListModal.svelte
+++ b/src/lib/components/MyListModal.svelte
@@ -353,6 +353,10 @@ form {
 	border-color: #14b8a6;
 	box-shadow: 0 0 0 3px rgb(20 184 166 / 15%);
 }
+.stepper input:focus-visible {
+	outline: 2px solid #14b8a6;
+	outline-offset: 2px;
+}
 .episode-total {
 	color: var(--text-muted, #a1a1aa);
 	font-size: 0.82rem;

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -1189,6 +1189,10 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	border-color: var(--color-accent);
 	box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 15%, transparent);
 }
+.search-input:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
 .search-btn {
 	padding: 9px 18px;
 	border-radius: 8px;
@@ -1267,6 +1271,11 @@ function isAiringToday(anime: AnimeListItem): boolean {
 .filter-input:focus {
 	border-color: var(--color-accent);
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 15%, transparent);
+}
+.filter-select:focus-visible,
+.filter-input:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
 }
 
 .filter-clear {
@@ -1851,6 +1860,10 @@ function isAiringToday(anime: AnimeListItem): boolean {
 .filter-sheet-input:focus {
 	border-color: var(--accent);
 	box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent);
+}
+.filter-sheet-input:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
 }
 .filter-sheet-clear {
 	align-self: flex-start;

--- a/src/routes/exchange/+page.svelte
+++ b/src/routes/exchange/+page.svelte
@@ -520,6 +520,12 @@ const handleExchangeSubmit: SubmitFunction = () => {
 	border-color: var(--color-accent);
 }
 
+.exchange-input:focus-visible,
+.exchange-comment-input:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
 .anime-results {
 	position: absolute;
 	z-index: 20;


### PR DESCRIPTION
## 変更内容

- 投稿コンポーザ、検索、認証・設定フォーム、引用投稿、交換募集、アニメ登録・編集、マイリスト入力へ`:focus-visible`の2pxリングを追加
- マウス操作時の既存表示は維持し、キーボードフォーカス時のみ明確なインジケータを表示
- 接頭辞付きフォームは入力内部ではなく外側のコンテナへリングを表示
- ダーク・ライト両テーマで既存のaccent tokenを使用

## 検証

- in-app browserで`/anime`検索入力をキーボードフォーカスし、ライト/ダーク両方で2px solid・offset 2pxを確認
- `/auth`メールアドレス入力でも同じリングを確認
- `git diff --check`
- `PUBLIC_SUPABASE_URL=https://example.supabase.co DISCORD_BOT_TOKEN=dummy DISCORD_GUILD_ID=dummy pnpm check`

`pnpm check`は成功。既存の`src/app.css`にある`!important`警告2件のみです。

Closes #40