### PR TITLE
fix: 選択中チップのホバー破綻修正・マイリストのアクセントカラー統一

### DIFF
--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -1313,6 +1313,10 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	color: #fff;
 	border-color: var(--color-accent);
 }
+.tab-btn.active:hover {
+	background: var(--color-accent-hover);
+	border-color: var(--color-accent-hover);
+}
 
 .anime-list-surface {
 	display: flex;
@@ -1833,6 +1837,10 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	background: var(--accent);
 	border-color: var(--accent);
 	color: #fff;
+}
+.season-chip--active:hover {
+	background: var(--accent);
+	border-color: var(--accent);
 }
 .filter-sheet-input {
 	padding: 9px 12px;

--- a/src/routes/mylist/+page.svelte
+++ b/src/routes/mylist/+page.svelte
@@ -579,8 +579,8 @@ $effect(() => {
 }
 
 .status-tab.active {
-	background: color-mix(in srgb, var(--accent, #6366f1) 20%, transparent);
-	color: var(--accent, #6366f1);
+	background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+	color: var(--color-accent);
 }
 
 .status-tab--watching.active {
@@ -668,8 +668,8 @@ $effect(() => {
 	}
 
 	.mobile-visibility-btn.active {
-		background: color-mix(in srgb, var(--accent, #6366f1) 16%, transparent);
-		color: var(--accent, #6366f1);
+		background: color-mix(in srgb, var(--color-accent) 16%, transparent);
+		color: var(--color-accent);
 		cursor: default;
 		opacity: 1;
 	}
@@ -692,8 +692,8 @@ $effect(() => {
 	}
 
 	.mobile-view-btn.active {
-		background: color-mix(in srgb, var(--accent, #6366f1) 16%, transparent);
-		color: var(--accent, #6366f1);
+		background: color-mix(in srgb, var(--color-accent) 16%, transparent);
+		color: var(--color-accent);
 	}
 
 	.status-tab-bar {


### PR DESCRIPTION
## Summary

- **#75** `+page.svelte`: `.season-chip--active:hover` と `.tab-btn.active:hover` を追加し、選択中のチップ/タブにホバーしたときに `--hover-bg`（ライトモードでは白に近い色）で背景が上書きされ白テキストが見えなくなる問題を修正
- **#76** `mylist/+page.svelte`: `var(--accent, #6366f1)` のフォールバック `#6366f1`（紫）を削除し `var(--color-accent)` に統一。アニメページとマイリストページのアクセントカラーが一致するように

Close #75, Close #76

## Test plan

- [ ] ライトモードで放送シーズンチップを選択してホバー → 背景色が壊れないこと
- [ ] ライトモードでタブをホバー → アクティブタブがホバーで白背景にならないこと
- [ ] アニメページとマイリストページのアクセントカラーが一致すること
- [ ] `pnpm check` 通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)