### PR TITLE
fix(a11y): role=menu / role=menuitem をケバブメニューから削除 (close #44)

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -348,12 +348,11 @@ async function submitReport() {
 								role="presentation"
 								onclick={(e) => { e.stopPropagation(); showKebabMenu = false; }}
 							></div>
-							<div class="post-kebab-menu" role="menu">
+							<div class="post-kebab-menu">
 								{#if isOwn}
 									<button
 										type="button"
 										class="post-kebab-item post-kebab-item--danger"
-										role="menuitem"
 										onclick={(e) => { e.stopPropagation(); showKebabMenu = false; showDeleteModal = true; }}
 									>
 										<span class="i-lucide-trash-2" aria-hidden="true"></span>
@@ -363,7 +362,6 @@ async function submitReport() {
 									<button
 										type="button"
 										class="post-kebab-item"
-										role="menuitem"
 										onclick={(e) => { e.stopPropagation(); showKebabMenu = false; showReportModal = true; }}
 									>
 										<span class="i-lucide-flag" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary

- `PostCard.svelte` のケバブメニュー `<div>` から `role="menu"` を削除
- 内部の `<button>` から `role="menuitem"` を削除
- キーボードナビゲーション（矢印キー、Escapeキー）未実装のまま `role="menu"` を付与すると、スクリーンリーダーユーザーが期待する操作に応答できないため削除

## Test plan

- [ ] ケバブメニューが正常に表示・動作することを確認
- [ ] `pnpm check` 通過確認済み

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)