### PR TITLE
fix(a11y): モーダルにフォーカストラップ・初期フォーカス・復帰を実装 (close #39)

### DIFF
--- a/src/lib/actions/trapFocus.ts
+++ b/src/lib/actions/trapFocus.ts
@@ -20,9 +20,9 @@ export function trapFocus(node: HTMLElement) {
 	function handleKeydown(e: KeyboardEvent) {
 		if (e.key !== "Tab") return;
 		const focusable = getFocusable(node);
-		if (focusable.length === 0) return;
-		const first = focusable[0]!;
-		const last = focusable[focusable.length - 1]!;
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		if (!first || !last) return;
 		if (e.shiftKey) {
 			if (document.activeElement === first) {
 				e.preventDefault();

--- a/src/lib/actions/trapFocus.ts
+++ b/src/lib/actions/trapFocus.ts
@@ -1,0 +1,47 @@
+const FOCUSABLE = [
+	"a[href]",
+	"button:not([disabled])",
+	"input:not([disabled])",
+	"select:not([disabled])",
+	"textarea:not([disabled])",
+	'[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+function getFocusable(node: HTMLElement): HTMLElement[] {
+	return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((el) => !el.closest("[inert]"));
+}
+
+export function trapFocus(node: HTMLElement) {
+	const previouslyFocused = document.activeElement as HTMLElement | null;
+
+	const firstFocusable = getFocusable(node)[0] ?? node;
+	firstFocusable.focus();
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key !== "Tab") return;
+		const focusable = getFocusable(node);
+		if (focusable.length === 0) return;
+		const first = focusable[0]!;
+		const last = focusable[focusable.length - 1]!;
+		if (e.shiftKey) {
+			if (document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			}
+		} else {
+			if (document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+
+	node.addEventListener("keydown", handleKeydown);
+
+	return {
+		destroy() {
+			node.removeEventListener("keydown", handleKeydown);
+			previouslyFocused?.focus();
+		},
+	};
+}

--- a/src/lib/components/MyListModal.svelte
+++ b/src/lib/components/MyListModal.svelte
@@ -2,6 +2,7 @@
 import type { SubmitFunction } from "@sveltejs/kit";
 import { enhance } from "$app/forms";
 import { invalidateAll } from "$app/navigation";
+import { trapFocus } from "$lib/actions/trapFocus";
 import type { AnimeStatus, UserAnimeEntry } from "$lib/types";
 
 type Props = {
@@ -111,6 +112,7 @@ $effect(() => {
 			aria-modal="true"
 			aria-labelledby="mylist-modal-title"
 			tabindex="-1"
+			use:trapFocus
 			onclick={(e) => e.stopPropagation()}
 		>
 			<header class="modal-header">

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -2,6 +2,7 @@
 import type { SubmitFunction } from "@sveltejs/kit";
 import { enhance } from "$app/forms";
 import { goto } from "$app/navigation";
+import { trapFocus } from "$lib/actions/trapFocus";
 import AnimeExchangeResult from "$lib/components/AnimeExchangeResult.svelte";
 import ReactionUsersPopover from "$lib/components/ReactionUsersPopover.svelte";
 import { buildAnimeRoomLabel, type Post, type ReactionType, type ReactionUser } from "$lib/types";
@@ -551,6 +552,7 @@ async function submitReport() {
 					aria-modal="true"
 					aria-labelledby="quote-modal-title"
 					tabindex="-1"
+					use:trapFocus
 					onclick={(e) => e.stopPropagation()}
 					onkeydown={(e) => e.stopPropagation()}
 				>
@@ -612,6 +614,7 @@ async function submitReport() {
 					aria-modal="true"
 					aria-labelledby="exchange-result-modal-title"
 					tabindex="-1"
+					use:trapFocus
 					onclick={(e) => e.stopPropagation()}
 				>
 					<div class="exchange-result-modal-header">
@@ -649,6 +652,7 @@ async function submitReport() {
 				aria-modal="true"
 				aria-label="画像拡大表示"
 				tabindex="-1"
+				use:trapFocus
 			>
 				<button
 					type="button"
@@ -675,6 +679,7 @@ async function submitReport() {
 					aria-modal="true"
 					aria-labelledby="report-modal-title"
 					tabindex="-1"
+					use:trapFocus
 					onclick={(e) => e.stopPropagation()}
 				>
 					<div class="report-modal-header">
@@ -735,6 +740,7 @@ async function submitReport() {
 					aria-modal="true"
 					aria-labelledby="delete-modal-title"
 					tabindex="-1"
+					use:trapFocus
 					onclick={(e) => e.stopPropagation()}
 				>
 					<div class="delete-modal-header">

--- a/src/lib/components/PostComposer.svelte
+++ b/src/lib/components/PostComposer.svelte
@@ -3,6 +3,7 @@ import type { SubmitFunction } from "@sveltejs/kit";
 import { enhance } from "$app/forms";
 import { replaceState } from "$app/navigation";
 import { page } from "$app/state";
+import { trapFocus } from "$lib/actions/trapFocus";
 import type { AnimeExchangeShare } from "$lib/types";
 import { charCountClass } from "$lib/utils/format";
 import AnimeExchangeResult from "./AnimeExchangeResult.svelte";
@@ -569,6 +570,7 @@ const handleSubmit: SubmitFunction = () => {
 		aria-modal="true"
 		aria-label="アニメ検索"
 		tabindex="-1"
+		use:trapFocus
 	>
 		<div class="anime-search-modal">
 			<div class="anime-search-header">
@@ -629,6 +631,7 @@ const handleSubmit: SubmitFunction = () => {
 		aria-modal="true"
 		aria-label="ネタバレ作品を選択"
 		tabindex="-1"
+		use:trapFocus
 	>
 		<div class="anime-search-modal">
 			<div class="anime-search-header">


### PR DESCRIPTION
## Summary

- `src/lib/actions/trapFocus.ts` を新規作成 — `use:trapFocus` Svelte アクション
  - モーダルを開いた際、最初のフォーカス可能要素に自動フォーカス
  - Tab/Shift+Tab キーをダイアログ内に閉じ込めるフォーカストラップ
  - モーダルを閉じた際、発火元要素（`document.activeElement`）へフォーカスを返す
- `PostCard.svelte` の5つのモーダルすべて（引用リポスト・交換結果・ライトボックス・通報・削除）に `use:trapFocus` を追加
- `MyListModal.svelte` のモーダルカードに `use:trapFocus` を追加
- `PostComposer.svelte` のアニメ検索・ネタバレ作品選択モーダルに `use:trapFocus` を追加

## Test plan

- [ ] モーダルを開いた際に最初のボタン/入力にフォーカスが移ることを確認
- [ ] Tab キーでダイアログ外に抜けられないことを確認
- [ ] Shift+Tab も同様にトラップされることを確認
- [ ] モーダルを閉じた後、元のボタンにフォーカスが戻ることを確認
- [ ] `pnpm check` 通過確認済み（警告は既存の `!important` 2件のみ）

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)