### PR TITLE
fix(design): アニメ詳細のメタチップ・アクションバーのUI改善 (close #71 close #72)

### DIFF
--- a/src/routes/anime/[id]/+page.svelte
+++ b/src/routes/anime/[id]/+page.svelte
@@ -614,7 +614,7 @@ $effect(() => {
 
 			{#if data.user}
 				<div class="action-bar">
-					<a href="/?quote_anime={data.anime.id}#compose" class="action-bar-btn">
+					<a href="/?quote_anime={data.anime.id}#compose" class="action-bar-btn action-bar-btn--link">
 						<svg
 							width="18"
 							height="18"
@@ -626,9 +626,10 @@ $effect(() => {
 							stroke-linejoin="round"
 							aria-hidden="true"
 						>
-							<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+							<path d="M12 20h9" />
+							<path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
 						</svg>
-						<span>投稿</span>
+						<span>投稿する</span>
 					</a>
 					<button
 						type="button"
@@ -1590,6 +1591,8 @@ $effect(() => {
 }
 .meta-chip--link {
 	text-decoration: none;
+	color: var(--accent);
+	background: color-mix(in srgb, var(--accent) 10%, var(--color-surface-hover));
 	transition:
 		background 0.15s,
 		color 0.15s;
@@ -2113,6 +2116,9 @@ a.relation-card:hover {
 .action-bar-btn.active {
 	background: var(--accent);
 	color: #fff;
+}
+.action-bar-btn--link {
+	border-style: dashed;
 }
 .action-panel {
 	width: 100%;


### PR DESCRIPTION
## Summary

**Issue #71 - クリック可能なチップを視覚的に区別**
- `meta-chip--link` にアクセントカラーのテキスト色と薄いアクセント背景を追加
- ホバー前からクリック可能と分かるように

**Issue #72 - アクションバーのラベル・挙動の明確化**
- 「投稿」ラベルを「投稿する」に変更（「投稿を見る」と誤解されないよう）
- アイコンをチャットバブル（閲覧を連想）→ 鉛筆アイコン（書く動作）に変更
- リンク型ボタン（ページ遷移する）を `border-style: dashed` で視覚的に区別

## Test plan

- [x] アニメ詳細ページで `meta-chip--link`（放送シーズン等）がアクセントカラーで表示されることを確認
- [x] ホバー時にフルアクセント色に変わることを確認
- [x] アクションバー「投稿する」ボタンに鉛筆アイコンが表示されることを確認
- [x] 「投稿する」リンクボタンが破線ボーダーで表示されることを確認
- [x] `pnpm check` 通過確認済み

Closes #71
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)