### PR TITLE
feat(perf): カーソルページネーション対応 (close #35)

### DIFF
--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -1081,7 +1081,7 @@ export async function getTimelinePostsWithReposts(
 	supabase: SupabaseClient<Database>,
 	profiles: ProfileRepostContext[],
 	currentUserId: string | null,
-	options: { limit?: number; select?: string } = {},
+	options: { limit?: number; select?: string; before?: string } = {},
 ): Promise<TimelinePostsWithRepostsResult> {
 	if (profiles.length === 0) return { posts: [], error: null };
 
@@ -1093,10 +1093,18 @@ export async function getTimelinePostsWithReposts(
 	const profileById = new Map(profiles.map((profile) => [profile.id, profile]));
 
 	const buildProfileFilter = <
-		T extends { eq: (column: string, value: string) => T; in: (column: string, values: string[]) => T },
+		T extends {
+			eq: (column: string, value: string) => T;
+			in: (column: string, values: string[]) => T;
+			lt: (column: string, value: string) => T;
+		},
 	>(
 		query: T,
-	) => (profileIds.length === 1 ? query.eq("user_id", firstProfileId) : query.in("user_id", profileIds));
+	) => {
+		let q = profileIds.length === 1 ? query.eq("user_id", firstProfileId) : query.in("user_id", profileIds);
+		if (options.before) q = q.lt("created_at", options.before);
+		return q;
+	};
 
 	const ownPostsQuery = buildProfileFilter(
 		supabase

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -29,15 +29,19 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 	const tab = url.searchParams.get("tab") === "following" && user ? "following" : "all";
 	const quoteAnimeId = url.searchParams.get("quote_anime");
 	const shareExchangeId = url.searchParams.get("share_exchange");
+	const beforeParam = url.searchParams.get("before") ?? undefined;
+	const before = beforeParam && /^\d{4}-\d{2}-\d{2}T/.test(beforeParam) ? beforeParam : undefined;
 	const followingProfiles = tab === "following" && user ? await getFollowingProfiles(supabase, user.id) : null;
 
 	const buildPostsQuery = (select: string) => {
-		return supabase
+		let q = supabase
 			.from("posts")
 			.select(select)
 			.is("parent_id", null)
 			.order("created_at", { ascending: false })
 			.limit(50);
+		if (before) q = q.lt("created_at", before);
+		return q;
 	};
 
 	const fetchPosts = async (): Promise<Post[]> => {
@@ -46,6 +50,7 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 				const result = await getTimelinePostsWithReposts(supabase, followingProfiles, user?.id ?? null, {
 					select,
 					limit: 50,
+					...(before ? { before } : {}),
 				});
 				if (!result.error) return result.posts;
 			}
@@ -145,6 +150,8 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		animeTrending,
 		profile,
 		tab,
+		before: before ?? null,
+		hasMore: posts.length >= 50,
 		initialAnime: quoteAnimeResult.data ? { ...quoteAnimeResult.data, id: String(quoteAnimeResult.data.id) } : null,
 		initialExchangeId: exchangeShare ? shareExchangeId : null,
 		initialExchangeShare: exchangeShare,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,6 +27,11 @@ function closeModal() {
 	composeOpen.set(false);
 }
 
+function loadMoreHref(lastCreatedAt: string): string {
+	const base = data.tab === "following" ? "/?tab=following" : "/";
+	return `${base}&before=${encodeURIComponent(lastCreatedAt)}`.replace("/?&", "/?");
+}
+
 $effect(() => {
 	if ((data.initialAnime || data.initialExchangeShare) && data.profile) {
 		if (window.matchMedia("(max-width: 960px)").matches) {
@@ -196,6 +201,11 @@ $effect(() => {
 				<PostCardSkeleton />
 			{/each}
 		{:then posts}
+			{#if data.before}
+				<a href={data.tab === "following" ? "/?tab=following" : "/"} class="timeline-back-link"
+					>← 新しい投稿に戻る</a
+				>
+			{/if}
 			{#if posts.length === 0}
 				<div class="empty-state">
 					{#if data.tab === 'following'}
@@ -208,6 +218,12 @@ $effect(() => {
 				{#each posts as post (post.id)}
 					<PostCard {post} currentUserId={data.user?.id ?? null} />
 				{/each}
+				{#if data.hasMore}
+					{@const lastPost = posts[posts.length - 1]}
+					{#if lastPost}
+						<a href={loadMoreHref(lastPost.created_at)} class="load-more-btn"> さらに読み込む </a>
+					{/if}
+				{/if}
 			{/if}
 		{/await}
 	</main>
@@ -476,5 +492,33 @@ $effect(() => {
 		display: flex;
 		padding: 24px 16px;
 	}
+}
+
+.timeline-back-link {
+	display: block;
+	padding: 10px 16px;
+	text-align: center;
+	font-size: 0.88rem;
+	color: var(--color-accent);
+	text-decoration: none;
+	border-bottom: 1px solid var(--color-border);
+}
+.timeline-back-link:hover {
+	background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+}
+
+.load-more-btn {
+	display: block;
+	padding: 14px 16px;
+	text-align: center;
+	font-size: 0.9rem;
+	font-weight: 500;
+	color: var(--color-accent);
+	text-decoration: none;
+	border-top: 1px solid var(--color-border);
+	transition: background 0.12s;
+}
+.load-more-btn:hover {
+	background: color-mix(in srgb, var(--color-accent) 6%, transparent);
 }
 </style>


### PR DESCRIPTION
## Summary

ホームタイムラインに **`before=<ISO8601 timestamp>`** によるキーセットページネーションを追加。OFFSET を一切使わずに「続きを読む」を実現し、データ量増加に伴う退行を防止。

- `getTimelinePostsWithReposts()` に `before?: string` オプションを追加（`.lt("created_at", before)` を付与）
- ホームページ `load()` で `?before=` パラメータを読み取り、ISO8601 形式のみ受け付ける
- 50件以上ある場合に `hasMore: true` を返す
- UI: 「さらに読み込む」リンク（末尾）と「← 新しい投稿に戻る」リンク（先頭）を追加

## Test plan

- [ ] タイムラインに50件以上の投稿がある場合、「さらに読み込む」ボタンが表示されることを確認
- [ ] クリック後に `?before=...` 付き URL に遷移し、古い投稿が表示されることを確認
- [ ] 「← 新しい投稿に戻る」で最新タイムラインに戻れることを確認
- [ ] フォロー中タブでも同様に動作することを確認
- [ ] `?before=invalid` 等の不正値が無視されることを確認
- [ ] `pnpm check` 通過確認済み

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)