### PR TITLE
fix: カレンダーの週切り替えで日付が更新されない問題を修正 (#91)

### DIFF
--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -57,12 +57,20 @@ function addDays(date: Date, days: number): Date {
 	return next;
 }
 
+function getWeekCenterDate(): Date {
+	// Anchor the rolling 7-day window to the displayed week instead of the
+	// real-world today, so week navigation updates the dates. The center is the
+	// day in the displayed week that matches today's weekday (the default
+	// selected day), keeping the current week's dates identical to before.
+	const weekStart = new Date(`${data.weekStart}T00:00:00`);
+	return addDays(weekStart, getCurrentBroadcastDate().getDay());
+}
+
 function getDisplayDateForDay(dayIdx: number, fallbackDate: string): string {
 	const displayPos = getDisplayDayOrder().indexOf(dayIdx);
 	if (displayPos === -1) return fallbackDate;
 
-	const centerDate = getCurrentBroadcastDate();
-	return toDateInputValue(addDays(centerDate, displayPos - 3));
+	return toDateInputValue(addDays(getWeekCenterDate(), displayPos - 3));
 }
 
 function getDisplayDayItems() {
@@ -80,7 +88,6 @@ function getDisplayDayItems() {
 }
 
 let selectedDayIndex = $state(getDefaultDayIndex());
-let lastWeekStart = $state(untrack(() => data.weekStart));
 let dayTabBar = $state<HTMLElement | null>(null);
 
 $effect(() => {
@@ -108,12 +115,6 @@ $effect(() => {
 	subscribedIds = new Set<string>(data.subscriptions);
 	mutedAnimeIds = new Set<string>(data.mutedAnimeIds);
 	roomMuteSettings = data.roomMuteSettings;
-});
-
-$effect(() => {
-	if (data.weekStart === lastWeekStart) return;
-	lastWeekStart = data.weekStart;
-	selectedDayIndex = getDefaultDayIndex();
 });
 
 function formatDate(value: string) {


### PR DESCRIPTION
## 概要
Issue #91 — アニメカレンダー（/schedule）で週を切り替えても日付表示が正しく更新されない問題を修正します。

Closes #91

## 不具合
- **PC版**: 放送当日の曜日（今日の曜日）の日付が週を切り替えても変わらない（例: 土曜が6/27から動かない）。他の曜日は変わる。
- **スマホ版**: 週の日付タブが一切変わらず、今週（例: 6/24〜6/30）で固定される。

## 原因
`getDisplayDateForDay` がローリング7日ウィンドウの基準を表示中の週ではなく `getCurrentBroadcastDate()`（実世界の今日）で計算していたため、週ナビゲーションを無視して常に今日固定になっていた。
- スマホのタブは全日付をこの関数から取得 → 今日固定。
- PCは選択中の日のみこの関数を使用 → 今日の曜日だけ固定。

## 修正
1. ローリングウィンドウの中心を**表示中の週（`data.weekStart`）**に紐付け（`getWeekCenterDate`）。`data` はリアクティブなため週切り替えで日付が追従する。今週の表示は従来と完全に一致（デグレなし）。
2. 週切り替え時に選択曜日を今日の曜日へリセットしていた `$effect` を削除。選択中の曜日を維持するようにした（土曜を見ていれば切替先の週でも土曜に留まる＝直感的な挙動）。

## 検証
- `svelte-check`: 0 errors / 0 warnings（572ファイル）
- 日付計算シミュレーション: 今週 6/24–6/30（従来一致）、翌週 7/1–7/7、前週 6/17–6/23 と正しく追従。

🤖 Generated with [Claude Code](https://claude.com/claude-code)