### PR TITLE
fix: スマホでプロフィール編集モーダルのボタンが見切れる/タブ裏に隠れる問題を修正 (#90)

### DIFF
--- a/src/routes/profile/[username]/+page.svelte
+++ b/src/routes/profile/[username]/+page.svelte
@@ -409,7 +409,12 @@ const grouped = $derived(
 						</button>
 					</div>
 
-					<form method="POST" action="?/updateProfile" use:enhance={handleProfileSubmit}>
+					<form
+						class="profile-edit-modal-form"
+						method="POST"
+						action="?/updateProfile"
+						use:enhance={handleProfileSubmit}
+					>
 						<div class="profile-edit-modal-body">
 							{#if form?.success}
 								<div class="flash-success">プロフィールを更新しました。</div>
@@ -815,9 +820,11 @@ const grouped = $derived(
 }
 
 .profile-edit-modal-card {
+	display: flex;
+	flex-direction: column;
 	width: min(100%, 520px);
-	max-height: calc(100vh - 32px);
-	overflow: auto;
+	max-height: calc(100dvh - 32px);
+	overflow: hidden;
 	border: 1px solid var(--color-border, var(--border, #334155));
 	border-radius: 8px;
 	background: var(--color-surface, var(--surface, #1e293b));
@@ -827,6 +834,7 @@ const grouped = $derived(
 .profile-edit-modal-header,
 .profile-edit-modal-footer {
 	display: flex;
+	flex-shrink: 0;
 	align-items: center;
 	justify-content: space-between;
 	gap: 12px;
@@ -867,11 +875,22 @@ const grouped = $derived(
 	opacity: 0.55;
 }
 
+.profile-edit-modal-form {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
 .profile-edit-modal-body {
 	display: flex;
+	flex: 1 1 auto;
 	flex-direction: column;
 	gap: 16px;
+	min-height: 0;
 	padding: 14px;
+	overflow-y: auto;
 }
 
 .profile-header-editor {

--- a/src/routes/profile/[username]/+page.svelte
+++ b/src/routes/profile/[username]/+page.svelte
@@ -716,7 +716,7 @@ const grouped = $derived(
 .report-modal-overlay {
 	position: fixed;
 	inset: 0;
-	z-index: 100;
+	z-index: 1000;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -811,7 +811,7 @@ const grouped = $derived(
 .profile-edit-modal-overlay {
 	position: fixed;
 	inset: 0;
-	z-index: 100;
+	z-index: 1000;
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
## 概要

Closes #90

スマホ版のプロフィール編集モーダルで、上部のバツボタンと下部の保存/キャンセルボタンが画面外に見切れたり、トップ/ボトムのタブバーの裏に隠れて押せなかった問題を修正します。

## 原因

2つの独立した原因がありました。

1. **見切れ**: モーダルカードが `max-height: calc(100vh - 32px)` で縦中央寄せされていた。モバイルブラウザの `100vh` はアドレスバー等のクロムを含むため実表示領域より大きく、中央寄せされたカードが画面の上下にはみ出してヘッダー/フッターが隠れていた。
2. **タブ裏に隠れる（本質）**: モーダル overlay が `z-index: 100` で、ボトムナビ(`150`)・サイドバー/上部ヘッダー(`140〜180`)より背面に描画されていた。

## 修正内容

`src/routes/profile/[username]/+page.svelte`:

- カードを `100dvh` 基準の flex カラムへ変更（モバイルの実ビューポートに追従）
- ヘッダー/フッターを `flex-shrink: 0` で常に表示・操作可能に固定し、本文(body)のみ内部スクロール
- overlay の `z-index` を `100 → 1000` に引き上げ、ナビバーより前面に表示（他モーダル MyListModal/AnimeEditRow/PostCard と同値で統一）
- 同一画面で同じ不具合を持っていた通報モーダルも併せて修正

`.app-layout` / `.app-main` は stacking context を作らないため、overlay の z-index 引き上げでルートのナビより確実に前面化します。

## 確認

- `svelte-check`: 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)