### PR TITLE
Add room experiment analytics

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -37,16 +37,18 @@ function fallbackRoomTag(title: string) {
 	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
 }
 
-function getRoomTagCandidates(anime: Post["anime_quote"]) {
-	if (!anime?.room_href) return [];
+function getRoomTagCandidates(post: Post) {
+	const anime = post.anime_quote;
+	if (!post.broadcast_room_session_id || !anime?.room_href) return [];
 	return [
 		...(anime.official_hashtag ?? []).map(normalizeRoomTag),
 		normalizeRoomTag(fallbackRoomTag(anime.title)),
 	].filter((tag) => tag.length > 0);
 }
 
-function hideTrailingRoomTag(content: string, anime: Post["anime_quote"]) {
-	const roomTags = getRoomTagCandidates(anime);
+function hideTrailingRoomTag(post: Post) {
+	const content = post.content;
+	const roomTags = getRoomTagCandidates(post);
 	if (roomTags.length === 0) return content;
 	const trimmed = content.trimEnd();
 	const normalized = trimmed.toLowerCase();
@@ -60,7 +62,7 @@ function hideTrailingRoomTag(content: string, anime: Post["anime_quote"]) {
 	return content;
 }
 
-const displayContent = $derived(hideTrailingRoomTag(post.content, post.anime_quote));
+const displayContent = $derived(hideTrailingRoomTag(post));
 const parts = $derived(parseContentParts(displayContent));
 const relativeTime = $derived(formatRelativeTime(post.created_at));
 const broadcastRelativeTime = $derived(

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -29,7 +29,39 @@ let {
 	broadcastStartAt = null,
 }: Props = $props();
 
-const parts = $derived(parseContentParts(post.content));
+function normalizeRoomTag(value: string) {
+	return value.trim().replace(/^#+/, "").toLowerCase();
+}
+
+function fallbackRoomTag(title: string) {
+	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
+}
+
+function getRoomTagCandidates(anime: Post["anime_quote"]) {
+	if (!anime?.room_href) return [];
+	return [
+		...(anime.official_hashtag ?? []).map(normalizeRoomTag),
+		normalizeRoomTag(fallbackRoomTag(anime.title)),
+	].filter((tag) => tag.length > 0);
+}
+
+function hideTrailingRoomTag(content: string, anime: Post["anime_quote"]) {
+	const roomTags = getRoomTagCandidates(anime);
+	if (roomTags.length === 0) return content;
+	const trimmed = content.trimEnd();
+	const normalized = trimmed.toLowerCase();
+	for (const tag of roomTags) {
+		const suffix = `#${tag}`;
+		if (!normalized.endsWith(suffix)) continue;
+		const before = trimmed.slice(0, trimmed.length - suffix.length);
+		if (before.length > 0 && !/\s$/.test(before)) continue;
+		return before.trimEnd();
+	}
+	return content;
+}
+
+const displayContent = $derived(hideTrailingRoomTag(post.content, post.anime_quote));
+const parts = $derived(parseContentParts(displayContent));
 const relativeTime = $derived(formatRelativeTime(post.created_at));
 const broadcastRelativeTime = $derived(
 	broadcastStartAt ? formatBroadcastRelativeTime(post.created_at, broadcastStartAt) : null,
@@ -50,7 +82,7 @@ const effectiveRoomContext = $derived(
 const showsContextStack = $derived(!isDetailView && (!!post.repost_context || (!!effectiveRoomContext && !insideRoom)));
 const cwContentId = $derived(`post-cw-content-${post.id}`);
 
-const isLong = $derived(post.content.length > 300 || (post.content.match(/\n/g)?.length ?? 0) >= 5);
+const isLong = $derived(displayContent.length > 300 || (displayContent.match(/\n/g)?.length ?? 0) >= 5);
 let collapsed = $state(true);
 let cwRevealed = $state(false);
 
@@ -579,7 +611,7 @@ async function submitReport() {
 								<span class="quote-preview-name">{post.display_name || post.username}</span>
 								<span class="quote-preview-at">@{post.username}</span>
 							</div>
-							<p class="quote-preview-content">{post.content}</p>
+							<p class="quote-preview-content">{displayContent}</p>
 						</div>
 						{#if quoteError}
 							<p class="flash-error" role="alert" style="margin-top:8px;">{quoteError}</p>

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -67,6 +67,7 @@ export async function insertPostWithHashtags(
 	exchangeShare: AnimeExchangeShare | null = null,
 	broadcastRoomSessionId: string | null = null,
 	cwAnimeId: string | null = null,
+	additionalHashtags: string[] = [],
 ) {
 	const moderationFailure = await ensureAccountCanWrite(supabase, userId);
 	if (moderationFailure) return moderationFailure;
@@ -109,7 +110,10 @@ export async function insertPostWithHashtags(
 	// ハッシュタグを一括登録（既存タグは ON CONFLICT DO NOTHING）。
 	// タグごとの insert+select ループは実況時の余分な往復になるため一括化している。
 	// メンション通知は DB トリガー notify_on_mention（migration 026）が生成する。
-	const tags = extractHashtags(postContent);
+	const additionalTags = additionalHashtags
+		.map((tag) => tag.trim().replace(/^#+/, "").toLowerCase())
+		.filter((tag) => tag.length > 0);
+	const tags = [...new Set([...extractHashtags(postContent), ...additionalTags])];
 	if (tags.length > 0) {
 		await supabase.from("hashtags").upsert(
 			tags.map((name) => ({ name })),

--- a/src/lib/server/rate-limit.test.ts
+++ b/src/lib/server/rate-limit.test.ts
@@ -9,20 +9,20 @@ describe("isRateLimited", () => {
 		vi.useRealTimers();
 	});
 
-	it("制限内のリクエストは許可される", () => {
+	it("allows requests within the limit", () => {
 		const key = `test-${Math.random()}`;
 		expect(isRateLimited(key, 3, 1000)).toBe(false);
 		expect(isRateLimited(key, 3, 1000)).toBe(false);
 		expect(isRateLimited(key, 3, 1000)).toBe(false);
 	});
 
-	it("制限を超えたリクエストは拒否される", () => {
+	it("blocks requests over the limit", () => {
 		const key = `test-${Math.random()}`;
 		for (let i = 0; i < 3; i += 1) isRateLimited(key, 3, 1000);
 		expect(isRateLimited(key, 3, 1000)).toBe(true);
 	});
 
-	it("ウィンドウが過ぎるとカウントがリセットされる", () => {
+	it("resets counts after the window", () => {
 		const key = `test-${Math.random()}`;
 		for (let i = 0; i < 4; i += 1) isRateLimited(key, 3, 1000);
 		expect(isRateLimited(key, 3, 1000)).toBe(true);
@@ -30,7 +30,7 @@ describe("isRateLimited", () => {
 		expect(isRateLimited(key, 3, 1000)).toBe(false);
 	});
 
-	it("キーごとに独立してカウントされる", () => {
+	it("counts each key independently", () => {
 		const keyA = `test-a-${Math.random()}`;
 		const keyB = `test-b-${Math.random()}`;
 		for (let i = 0; i < 4; i += 1) isRateLimited(keyA, 3, 1000);
@@ -39,19 +39,19 @@ describe("isRateLimited", () => {
 });
 
 describe("isApiRateLimited", () => {
-	it("ルールにマッチしないパスは制限されない", () => {
+	it("does not limit unmatched paths", () => {
 		for (let i = 0; i < 100; i += 1) {
 			expect(isApiRateLimited("/api/unknown", "GET", "ip-x")).toBe(false);
 		}
 	});
 
-	it("メソッド指定のあるルールは他メソッドに適用されない", () => {
+	it("does not apply method-specific rules to other methods", () => {
 		for (let i = 0; i < 100; i += 1) {
 			expect(isApiRateLimited("/api/posts", "GET", "ip-method-test")).toBe(false);
 		}
 	});
 
-	it("アップロードは10回/分を超えると429相当になる", () => {
+	it("limits uploads over 10 requests per minute", () => {
 		const ip = `ip-${Math.random()}`;
 		for (let i = 0; i < 10; i += 1) {
 			expect(isApiRateLimited("/api/upload", "POST", ip)).toBe(false);
@@ -59,11 +59,30 @@ describe("isApiRateLimited", () => {
 		expect(isApiRateLimited("/api/upload", "POST", ip)).toBe(true);
 	});
 
-	it("検索はIPごとに独立して制限される", () => {
+	it("keeps search limits isolated by IP", () => {
 		const ipA = `ip-a-${Math.random()}`;
 		const ipB = `ip-b-${Math.random()}`;
 		for (let i = 0; i < 31; i += 1) isApiRateLimited("/api/anime/search", "GET", ipA);
 		expect(isApiRateLimited("/api/anime/search", "GET", ipA)).toBe(true);
 		expect(isApiRateLimited("/api/anime/search", "GET", ipB)).toBe(false);
+	});
+
+	it("limits room experiment visit creation by POST", () => {
+		const ip = `ip-room-experiment-create-${Math.random()}`;
+		for (let i = 0; i < 60; i += 1) {
+			expect(isApiRateLimited("/api/room-experiment-visits", "POST", ip)).toBe(false);
+		}
+		expect(isApiRateLimited("/api/room-experiment-visits", "POST", ip)).toBe(true);
+		expect(isApiRateLimited("/api/room-experiment-visits", "GET", ip)).toBe(false);
+	});
+
+	it("shares a bucket for room experiment heartbeat and exit", () => {
+		const ip = `ip-room-experiment-update-${Math.random()}`;
+		const visitId = "00000000-0000-4000-8000-000000000001";
+		for (let i = 0; i < 180; i += 1) {
+			expect(isApiRateLimited(`/api/room-experiment-visits/${visitId}/heartbeat`, "POST", ip)).toBe(false);
+		}
+		expect(isApiRateLimited(`/api/room-experiment-visits/${visitId}/exit`, "POST", ip)).toBe(true);
+		expect(isApiRateLimited(`/api/room-experiment-visits/${visitId}/heartbeat`, "GET", ip)).toBe(false);
 	});
 });

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -52,6 +52,20 @@ export const API_RATE_RULES: RateRule[] = [
 	{ name: "search", pattern: /^\/api\/(anime|users)\/search/, limit: 30, windowMs: 10_000 },
 	{ name: "anime-count", pattern: /^\/api\/anime\/count$/, limit: 30, windowMs: 10_000 },
 	{ name: "room-posts", pattern: /^\/api\/rooms\/posts$/, limit: 60, windowMs: 60_000 },
+	{
+		name: "room-experiment-visit",
+		pattern: /^\/api\/room-experiment-visits$/,
+		methods: ["POST"],
+		limit: 60,
+		windowMs: 60_000,
+	},
+	{
+		name: "room-experiment-visit-update",
+		pattern: /^\/api\/room-experiment-visits\/[^/]+\/(heartbeat|exit)$/,
+		methods: ["POST"],
+		limit: 180,
+		windowMs: 60_000,
+	},
 	{ name: "account-switch", pattern: /^\/api\/account-switch$/, methods: ["POST"], limit: 10, windowMs: 60_000 },
 ];
 

--- a/src/lib/server/room-experiment-metrics.test.ts
+++ b/src/lib/server/room-experiment-metrics.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "vitest";
+import { calculateRoomExperimentMetrics, filterRoomExperimentPosts } from "./room-experiment-metrics";
+
+type CalculatedRoom = ReturnType<typeof calculateRoomExperimentMetrics>["rooms"][number];
+
+const runStartedAt = "2026-06-27T10:00:00.000Z";
+const runEndedAt = "2026-06-27T11:00:00.000Z";
+const roomClosesAt = "2026-06-27T10:30:00.000Z";
+
+function firstRoom(metrics: ReturnType<typeof calculateRoomExperimentMetrics>): CalculatedRoom {
+	const [room] = metrics.rooms;
+	if (!room) throw new Error("expected at least one room metric");
+	return room;
+}
+
+describe("calculateRoomExperimentMetrics", () => {
+	it("calculates stay, active, bounce, and early-exit metrics", () => {
+		const metrics = calculateRoomExperimentMetrics(
+			{
+				id: "run-1",
+				started_at: runStartedAt,
+				ended_at: null,
+				rooms: [
+					{
+						broadcast_room_session_id: "session-1",
+						room_title: "2026-06-27",
+						scheduled_at: runStartedAt,
+						posting_closes_at: roomClosesAt,
+						visits: [
+							{
+								user_id: "u1",
+								entered_at: "2026-06-27T10:00:00.000Z",
+								last_seen_at: "2026-06-27T10:05:00.000Z",
+								exited_at: "2026-06-27T10:05:00.000Z",
+							},
+							{
+								user_id: "u2",
+								entered_at: "2026-06-27T10:10:00.000Z",
+								last_seen_at: "2026-06-27T10:10:30.000Z",
+								exited_at: "2026-06-27T10:10:30.000Z",
+							},
+							{
+								user_id: "u3",
+								entered_at: "2026-06-27T10:20:00.000Z",
+								last_seen_at: "2026-06-27T10:29:30.000Z",
+								exited_at: null,
+							},
+						],
+						posts: [
+							{ user_id: "u1", created_at: "2026-06-27T10:06:00.000Z" },
+							{ user_id: "u1", created_at: "2026-06-27T10:07:00.000Z" },
+						],
+					},
+				],
+			},
+			new Date("2026-06-27T10:30:00.000Z"),
+			90_000,
+		);
+
+		const room = firstRoom(metrics);
+		expect(room.visit_count).toBe(3);
+		expect(room.unique_visitor_count).toBe(3);
+		expect(room.active_visit_count).toBe(1);
+		expect(room.poster_count).toBe(1);
+		expect(room.posting_rate).toBeCloseTo(1 / 3);
+		expect(room.posts_per_poster).toBe(2);
+		expect(room.posts_per_unique_visitor).toBeCloseTo(2 / 3);
+		expect(room.average_stay_seconds).toBeCloseTo((300 + 30 + 570) / 3);
+		expect(room.bounce_rate_under_60s).toBeCloseTo(1 / 2);
+		expect(room.early_exit_rate).toBe(1);
+	});
+
+	it("caps stay at posting close and run end", () => {
+		const metrics = calculateRoomExperimentMetrics(
+			{
+				id: "run-1",
+				started_at: runStartedAt,
+				ended_at: "2026-06-27T10:20:00.000Z",
+				rooms: [
+					{
+						broadcast_room_session_id: "session-1",
+						room_title: "2026-06-27",
+						scheduled_at: runStartedAt,
+						posting_closes_at: roomClosesAt,
+						visits: [
+							{
+								user_id: "u1",
+								entered_at: "2026-06-27T10:00:00.000Z",
+								last_seen_at: "2026-06-27T10:40:00.000Z",
+								exited_at: null,
+							},
+						],
+						posts: [],
+					},
+				],
+			},
+			new Date("2026-06-27T10:25:00.000Z"),
+		);
+
+		const room = firstRoom(metrics);
+		expect(room.active_visit_count).toBe(0);
+		expect(room.average_stay_seconds).toBe(20 * 60);
+	});
+
+	it("uses last_seen without early-exit rate when posting close is missing", () => {
+		const metrics = calculateRoomExperimentMetrics({
+			id: "run-1",
+			started_at: runStartedAt,
+			ended_at: null,
+			rooms: [
+				{
+					broadcast_room_session_id: "session-1",
+					room_title: "2026-06-27",
+					scheduled_at: runStartedAt,
+					posting_closes_at: null,
+					visits: [
+						{
+							user_id: "u1",
+							entered_at: "2026-06-27T10:00:00.000Z",
+							last_seen_at: "2026-06-27T10:02:00.000Z",
+							exited_at: null,
+						},
+					],
+					posts: [],
+				},
+			],
+		});
+
+		const room = firstRoom(metrics);
+		expect(room.average_stay_seconds).toBe(120);
+		expect(room.early_exit_rate).toBeNull();
+	});
+
+	it("excludes visits entered after posting close from stay denominators", () => {
+		const metrics = calculateRoomExperimentMetrics({
+			id: "run-1",
+			started_at: runStartedAt,
+			ended_at: null,
+			rooms: [
+				{
+					broadcast_room_session_id: "session-1",
+					room_title: "2026-06-27",
+					scheduled_at: runStartedAt,
+					posting_closes_at: roomClosesAt,
+					visits: [
+						{
+							user_id: "u1",
+							entered_at: "2026-06-27T10:31:00.000Z",
+							last_seen_at: "2026-06-27T10:40:00.000Z",
+							exited_at: "2026-06-27T10:40:00.000Z",
+						},
+					],
+					posts: [],
+				},
+			],
+		});
+
+		const room = firstRoom(metrics);
+		expect(room.visit_count).toBe(1);
+		expect(room.average_stay_seconds).toBeNull();
+		expect(room.bounce_rate_under_60s).toBeNull();
+		expect(room.early_exit_rate).toBeNull();
+	});
+
+	it("deduplicates summary visitors and posters across rooms", () => {
+		const metrics = calculateRoomExperimentMetrics({
+			id: "run-1",
+			started_at: runStartedAt,
+			ended_at: null,
+			rooms: [
+				{
+					broadcast_room_session_id: "session-1",
+					room_title: "1",
+					scheduled_at: runStartedAt,
+					posting_closes_at: roomClosesAt,
+					visits: [
+						{
+							user_id: "u1",
+							entered_at: "2026-06-27T10:00:00.000Z",
+							last_seen_at: "2026-06-27T10:02:00.000Z",
+							exited_at: "2026-06-27T10:02:00.000Z",
+						},
+					],
+					posts: [
+						{ user_id: "u1", created_at: "2026-06-27T10:03:00.000Z" },
+						{ user_id: "u2", created_at: "2026-06-27T10:04:00.000Z" },
+					],
+				},
+				{
+					broadcast_room_session_id: "session-2",
+					room_title: "2",
+					scheduled_at: runStartedAt,
+					posting_closes_at: roomClosesAt,
+					visits: [
+						{
+							user_id: "u1",
+							entered_at: "2026-06-27T10:05:00.000Z",
+							last_seen_at: "2026-06-27T10:06:00.000Z",
+							exited_at: "2026-06-27T10:06:00.000Z",
+						},
+						{
+							user_id: "u2",
+							entered_at: "2026-06-27T10:07:00.000Z",
+							last_seen_at: "2026-06-27T10:08:00.000Z",
+							exited_at: "2026-06-27T10:08:00.000Z",
+						},
+					],
+					posts: [{ user_id: "u1", created_at: "2026-06-27T10:09:00.000Z" }],
+				},
+			],
+		});
+
+		expect(metrics.rooms.reduce((sum, room) => sum + room.unique_visitor_count, 0)).toBe(3);
+		expect(metrics.summary.unique_visitor_count).toBe(2);
+		expect(metrics.summary.poster_count).toBe(2);
+		expect(metrics.summary.posting_rate).toBe(1);
+		expect(metrics.summary.posts_per_poster).toBeCloseTo(3 / 2);
+		expect(metrics.summary.posts_per_unique_visitor).toBeCloseTo(3 / 2);
+	});
+
+	it("returns zero ratios when poster or visitor denominators are empty", () => {
+		const metrics = calculateRoomExperimentMetrics({
+			id: "run-1",
+			started_at: runStartedAt,
+			ended_at: null,
+			rooms: [
+				{
+					broadcast_room_session_id: "session-1",
+					room_title: "1",
+					scheduled_at: runStartedAt,
+					posting_closes_at: roomClosesAt,
+					visits: [
+						{
+							user_id: "u1",
+							entered_at: "2026-06-27T10:00:00.000Z",
+							last_seen_at: "2026-06-27T10:01:00.000Z",
+							exited_at: "2026-06-27T10:01:00.000Z",
+						},
+					],
+					posts: [],
+				},
+				{
+					broadcast_room_session_id: "session-2",
+					room_title: "2",
+					scheduled_at: runStartedAt,
+					posting_closes_at: roomClosesAt,
+					visits: [],
+					posts: [{ user_id: "u2", created_at: "2026-06-27T10:02:00.000Z" }],
+				},
+			],
+		});
+
+		const [withVisitorNoPosts, withPostNoVisitors] = metrics.rooms;
+		if (!withVisitorNoPosts || !withPostNoVisitors) throw new Error("expected two room metrics");
+		expect(withVisitorNoPosts.posts_per_poster).toBe(0);
+		expect(withVisitorNoPosts.posting_rate).toBe(0);
+		expect(withPostNoVisitors.posting_rate).toBe(0);
+		expect(withPostNoVisitors.posts_per_unique_visitor).toBe(0);
+	});
+});
+
+describe("filterRoomExperimentPosts", () => {
+	it("filters by run window, top-level status, and hidden flag", () => {
+		const posts = filterRoomExperimentPosts(
+			[
+				{
+					id: "before",
+					user_id: "u1",
+					broadcast_room_session_id: "session-1",
+					created_at: "2026-06-27T09:59:00.000Z",
+					parent_id: null,
+					hidden_by_admin: false,
+				},
+				{
+					id: "visible",
+					user_id: "u1",
+					broadcast_room_session_id: "session-1",
+					created_at: "2026-06-27T10:05:00.000Z",
+					parent_id: null,
+					hidden_by_admin: false,
+				},
+				{
+					id: "reply",
+					user_id: "u2",
+					broadcast_room_session_id: "session-1",
+					created_at: "2026-06-27T10:06:00.000Z",
+					parent_id: "parent",
+					hidden_by_admin: false,
+				},
+				{
+					id: "hidden",
+					user_id: "u3",
+					broadcast_room_session_id: "session-1",
+					created_at: "2026-06-27T10:07:00.000Z",
+					parent_id: null,
+					hidden_by_admin: true,
+				},
+				{
+					id: "other-session",
+					user_id: "u4",
+					broadcast_room_session_id: "session-2",
+					created_at: "2026-06-27T10:08:00.000Z",
+					parent_id: null,
+					hidden_by_admin: false,
+				},
+				{
+					id: "ended",
+					user_id: "u5",
+					broadcast_room_session_id: "session-1",
+					created_at: runEndedAt,
+					parent_id: null,
+					hidden_by_admin: false,
+				},
+			],
+			{ sessionId: "session-1", runStartedAt, runEndedAt },
+		);
+
+		expect(posts).toEqual([{ user_id: "u1", created_at: "2026-06-27T10:05:00.000Z" }]);
+	});
+
+	it("treats nullable hidden_by_admin as visible unless it is true", () => {
+		const posts = filterRoomExperimentPosts(
+			[
+				{
+					id: "nullable-visible",
+					user_id: "u1",
+					broadcast_room_session_id: "session-1",
+					created_at: "2026-06-27T10:05:00.000Z",
+					parent_id: null,
+					hidden_by_admin: null,
+				},
+			],
+			{ sessionId: "session-1", runStartedAt, runEndedAt: null },
+		);
+
+		expect(posts).toHaveLength(1);
+	});
+});

--- a/src/lib/server/room-experiment-metrics.ts
+++ b/src/lib/server/room-experiment-metrics.ts
@@ -1,0 +1,289 @@
+export const ROOM_EXPERIMENT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const ROOM_EXPERIMENT_STALE_AFTER_MS = 90_000;
+export const ROOM_EXPERIMENT_BOUNCE_SECONDS = 60;
+
+export type ExperimentVisitInput = {
+	user_id: string;
+	entered_at: string;
+	last_seen_at: string;
+	exited_at: string | null;
+};
+
+export type ExperimentPostCandidate = {
+	id: string;
+	user_id: string;
+	broadcast_room_session_id: string | null;
+	created_at: string;
+	parent_id: string | null;
+	hidden_by_admin: boolean | null;
+};
+
+export type ExperimentPostInput = {
+	user_id: string;
+	created_at: string;
+};
+
+export type ExperimentRoomInput = {
+	broadcast_room_session_id: string;
+	room_title: string | null;
+	episode_number?: number | null;
+	scheduled_at: string | null;
+	posting_closes_at: string | null;
+	visits: ExperimentVisitInput[];
+	posts: ExperimentPostInput[];
+};
+
+export type ExperimentRunInput = {
+	id: string;
+	started_at: string;
+	ended_at: string | null;
+	rooms: ExperimentRoomInput[];
+};
+
+export type ExperimentRoomMetric = {
+	broadcast_room_session_id: string;
+	room_title: string | null;
+	episode_number: number | null;
+	scheduled_at: string | null;
+	posting_closes_at: string | null;
+	visit_count: number;
+	unique_visitor_count: number;
+	active_visit_count: number;
+	post_count: number;
+	poster_count: number;
+	posting_rate: number;
+	posts_per_poster: number;
+	posts_per_unique_visitor: number;
+	average_stay_seconds: number | null;
+	bounce_rate_under_60s: number | null;
+	early_exit_rate: number | null;
+};
+
+export type ExperimentSummaryMetric = Omit<
+	ExperimentRoomMetric,
+	"broadcast_room_session_id" | "room_title" | "episode_number" | "scheduled_at" | "posting_closes_at"
+>;
+
+export type ExperimentCalculatedMetrics = {
+	rooms: ExperimentRoomMetric[];
+	summary: ExperimentSummaryMetric;
+};
+
+function toMs(value: string | null | undefined): number | null {
+	if (!value) return null;
+	const ms = new Date(value).getTime();
+	return Number.isFinite(ms) ? ms : null;
+}
+
+function ratio(numerator: number, denominator: number): number {
+	if (denominator <= 0) return 0;
+	return numerator / denominator;
+}
+
+function boundedEndMs(visit: ExperimentVisitInput, runEndedMs: number | null, postingClosesMs: number | null) {
+	const seenEndMs = toMs(visit.exited_at) ?? toMs(visit.last_seen_at) ?? toMs(visit.entered_at) ?? 0;
+	return Math.min(
+		seenEndMs,
+		...(runEndedMs == null ? [] : [runEndedMs]),
+		...(postingClosesMs == null ? [] : [postingClosesMs]),
+	);
+}
+
+function isVisitActive(visit: ExperimentVisitInput, nowMs: number, runEndedMs: number | null, staleAfterMs: number) {
+	if (runEndedMs != null) return false;
+	if (visit.exited_at) return false;
+	const lastSeenMs = toMs(visit.last_seen_at);
+	return lastSeenMs != null && lastSeenMs >= nowMs - staleAfterMs;
+}
+
+function isStayEligible(visit: ExperimentVisitInput, postingClosesMs: number | null) {
+	const enteredMs = toMs(visit.entered_at);
+	if (enteredMs == null) return false;
+	return postingClosesMs == null || enteredMs < postingClosesMs;
+}
+
+function visitStaySeconds(visit: ExperimentVisitInput, runEndedMs: number | null, postingClosesMs: number | null) {
+	const enteredMs = toMs(visit.entered_at);
+	if (enteredMs == null) return null;
+	if (!isStayEligible(visit, postingClosesMs)) return null;
+	const endMs = boundedEndMs(visit, runEndedMs, postingClosesMs);
+	return Math.max(0, Math.floor((endMs - enteredMs) / 1000));
+}
+
+function calculateVisitStats(
+	visits: ExperimentVisitInput[],
+	runEndedMs: number | null,
+	postingClosesMs: number | null,
+	nowMs: number,
+	staleAfterMs: number,
+) {
+	let stayTotal = 0;
+	let stayCount = 0;
+	let inactiveEligibleCount = 0;
+	let bounceCount = 0;
+	let earlyExitCount = 0;
+	let activeCount = 0;
+
+	for (const visit of visits) {
+		const active = isVisitActive(visit, nowMs, runEndedMs, staleAfterMs);
+		if (active) activeCount += 1;
+
+		const staySeconds = visitStaySeconds(visit, runEndedMs, postingClosesMs);
+		if (staySeconds != null) {
+			stayTotal += staySeconds;
+			stayCount += 1;
+		}
+
+		if (active || staySeconds == null) continue;
+		inactiveEligibleCount += 1;
+		if (staySeconds < ROOM_EXPERIMENT_BOUNCE_SECONDS) bounceCount += 1;
+
+		if (postingClosesMs != null) {
+			const endMs = boundedEndMs(visit, runEndedMs, null);
+			if (endMs < postingClosesMs) earlyExitCount += 1;
+		}
+	}
+
+	return {
+		activeCount,
+		averageStaySeconds: stayCount > 0 ? stayTotal / stayCount : null,
+		bounceRate: inactiveEligibleCount > 0 ? bounceCount / inactiveEligibleCount : null,
+		earlyExitRate:
+			postingClosesMs == null || inactiveEligibleCount === 0 ? null : earlyExitCount / inactiveEligibleCount,
+	};
+}
+
+function calculateAggregateVisitStats(
+	rooms: ExperimentRoomInput[],
+	runEndedMs: number | null,
+	nowMs: number,
+	staleAfterMs: number,
+) {
+	let stayTotal = 0;
+	let stayCount = 0;
+	let inactiveEligibleCount = 0;
+	let bounceCount = 0;
+	let earlyExitEligibleCount = 0;
+	let earlyExitCount = 0;
+	let activeCount = 0;
+
+	for (const room of rooms) {
+		const postingClosesMs = toMs(room.posting_closes_at);
+		for (const visit of room.visits) {
+			const active = isVisitActive(visit, nowMs, runEndedMs, staleAfterMs);
+			if (active) activeCount += 1;
+
+			const staySeconds = visitStaySeconds(visit, runEndedMs, postingClosesMs);
+			if (staySeconds != null) {
+				stayTotal += staySeconds;
+				stayCount += 1;
+			}
+
+			if (active || staySeconds == null) continue;
+			inactiveEligibleCount += 1;
+			if (staySeconds < ROOM_EXPERIMENT_BOUNCE_SECONDS) bounceCount += 1;
+
+			if (postingClosesMs != null) {
+				earlyExitEligibleCount += 1;
+				const endMs = boundedEndMs(visit, runEndedMs, null);
+				if (endMs < postingClosesMs) earlyExitCount += 1;
+			}
+		}
+	}
+
+	return {
+		activeCount,
+		averageStaySeconds: stayCount > 0 ? stayTotal / stayCount : null,
+		bounceRate: inactiveEligibleCount > 0 ? bounceCount / inactiveEligibleCount : null,
+		earlyExitRate: earlyExitEligibleCount > 0 ? earlyExitCount / earlyExitEligibleCount : null,
+	};
+}
+
+export function filterRoomExperimentPosts(
+	posts: ExperimentPostCandidate[],
+	options: {
+		sessionId: string;
+		runStartedAt: string;
+		runEndedAt: string | null;
+	},
+): ExperimentPostInput[] {
+	const runStartedMs = toMs(options.runStartedAt);
+	const runEndedMs = toMs(options.runEndedAt);
+	if (runStartedMs == null) return [];
+
+	return posts
+		.filter((post) => {
+			if (post.broadcast_room_session_id !== options.sessionId) return false;
+			if (post.parent_id !== null) return false;
+			if (post.hidden_by_admin === true) return false;
+			const createdMs = toMs(post.created_at);
+			if (createdMs == null || createdMs < runStartedMs) return false;
+			if (runEndedMs != null && createdMs >= runEndedMs) return false;
+			return true;
+		})
+		.map((post) => ({ user_id: post.user_id, created_at: post.created_at }));
+}
+
+function calculateRoomMetric(
+	room: ExperimentRoomInput,
+	runEndedMs: number | null,
+	nowMs: number,
+	staleAfterMs: number,
+): ExperimentRoomMetric {
+	const visitorIds = new Set(room.visits.map((visit) => visit.user_id));
+	const posterIds = new Set(room.posts.map((post) => post.user_id));
+	const postingClosesMs = toMs(room.posting_closes_at);
+	const visitStats = calculateVisitStats(room.visits, runEndedMs, postingClosesMs, nowMs, staleAfterMs);
+
+	return {
+		broadcast_room_session_id: room.broadcast_room_session_id,
+		room_title: room.room_title,
+		episode_number: room.episode_number ?? null,
+		scheduled_at: room.scheduled_at,
+		posting_closes_at: room.posting_closes_at,
+		visit_count: room.visits.length,
+		unique_visitor_count: visitorIds.size,
+		active_visit_count: visitStats.activeCount,
+		post_count: room.posts.length,
+		poster_count: posterIds.size,
+		posting_rate: ratio(posterIds.size, visitorIds.size),
+		posts_per_poster: ratio(room.posts.length, posterIds.size),
+		posts_per_unique_visitor: ratio(room.posts.length, visitorIds.size),
+		average_stay_seconds: visitStats.averageStaySeconds,
+		bounce_rate_under_60s: visitStats.bounceRate,
+		early_exit_rate: visitStats.earlyExitRate,
+	};
+}
+
+export function calculateRoomExperimentMetrics(
+	run: ExperimentRunInput,
+	now = new Date(),
+	staleAfterMs = ROOM_EXPERIMENT_STALE_AFTER_MS,
+): ExperimentCalculatedMetrics {
+	const nowMs = now.getTime();
+	const runEndedMs = toMs(run.ended_at);
+	const rooms = run.rooms.map((room) => calculateRoomMetric(room, runEndedMs, nowMs, staleAfterMs));
+
+	const allVisits = run.rooms.flatMap((room) => room.visits);
+	const allPosts = run.rooms.flatMap((room) => room.posts);
+	const visitorIds = new Set(allVisits.map((visit) => visit.user_id));
+	const posterIds = new Set(allPosts.map((post) => post.user_id));
+	const summaryStats = calculateAggregateVisitStats(run.rooms, runEndedMs, nowMs, staleAfterMs);
+
+	return {
+		rooms,
+		summary: {
+			visit_count: allVisits.length,
+			unique_visitor_count: visitorIds.size,
+			active_visit_count: summaryStats.activeCount,
+			post_count: allPosts.length,
+			poster_count: posterIds.size,
+			posting_rate: ratio(posterIds.size, visitorIds.size),
+			posts_per_poster: ratio(allPosts.length, posterIds.size),
+			posts_per_unique_visitor: ratio(allPosts.length, visitorIds.size),
+			average_stay_seconds: summaryStats.averageStaySeconds,
+			bounce_rate_under_60s: summaryStats.bounceRate,
+			early_exit_rate: summaryStats.earlyExitRate,
+		},
+	};
+}

--- a/src/lib/server/room-experiments.ts
+++ b/src/lib/server/room-experiments.ts
@@ -13,9 +13,6 @@ import {
 	ROOM_EXPERIMENT_STALE_AFTER_MS,
 } from "./room-experiment-metrics";
 
-// biome-ignore lint/suspicious/noExplicitAny: new room experiment tables may lag behind linked Supabase type generation
-type AnySupabase = SupabaseClient<any>;
-
 type RunRow = {
 	id: string;
 	anime_id: number;
@@ -87,10 +84,6 @@ type SessionInfo = {
 	scheduled_at: string;
 	posting_closes_at: string | null;
 };
-
-function asAny(supabase: SupabaseClient<Database>): AnySupabase {
-	return supabase as unknown as AnySupabase;
-}
 
 export function createRoomExperimentServiceClient(): SupabaseClient<Database> | null {
 	try {
@@ -176,7 +169,7 @@ export async function getActiveRoomExperimentRunForAnime(
 	supabase: SupabaseClient<Database>,
 	animeId: string | number,
 ): Promise<RoomExperimentRun | null> {
-	const { data, error } = await asAny(supabase)
+	const { data, error } = await supabase
 		.from("room_experiment_runs")
 		.select(
 			"id, anime_id, started_at, ended_at, label, notes, anime:anime!room_experiment_runs_anime_id_fkey ( title, cover_url )",
@@ -208,13 +201,13 @@ export async function searchRoomExperimentAnime(
 	if (!trimmed) return [];
 
 	const [{ data: animeRows }, { data: activeRuns }] = await Promise.all([
-		asAny(supabase)
+		supabase
 			.from("anime")
 			.select("id, title, cover_url, room_type")
 			.or(buildTitleSearchFilter(trimmed))
 			.order("title", { ascending: true })
 			.limit(10),
-		asAny(supabase).from("room_experiment_runs").select("id, anime_id").is("ended_at", null),
+		supabase.from("room_experiment_runs").select("id, anime_id").is("ended_at", null),
 	]);
 
 	const activeRunByAnime = new Map(
@@ -249,14 +242,12 @@ export async function startRoomExperimentRun(
 		return { ok: false, status: 400, message: "作品IDが不正です" };
 	}
 
-	const { error } = await asAny(supabase)
-		.from("room_experiment_runs")
-		.insert({
-			anime_id: Number(options.animeId),
-			created_by: adminId,
-			label: options.label || null,
-			notes: options.notes || null,
-		});
+	const { error } = await supabase.from("room_experiment_runs").insert({
+		anime_id: Number(options.animeId),
+		created_by: adminId,
+		label: options.label || null,
+		notes: options.notes || null,
+	});
 
 	if (!error) return { ok: true };
 	if (error.code === "23505") return { ok: false, status: 409, message: "この作品はすでに検証対象です" };
@@ -269,13 +260,29 @@ export async function stopRoomExperimentRun(
 	adminId: string,
 	runId: string,
 ): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
-	const { error } = await asAny(supabase)
+	const { data: existingRun, error: lookupError } = await supabase
+		.from("room_experiment_runs")
+		.select("id, ended_at")
+		.eq("id", runId)
+		.maybeSingle();
+
+	if (lookupError) {
+		console.error("room experiment run stop lookup error:", lookupError);
+		return { ok: false, status: 500, message: "検証runの確認に失敗しました" };
+	}
+	if (!existingRun) return { ok: false, status: 404, message: "検証runが見つかりません" };
+	if (existingRun.ended_at) return { ok: false, status: 409, message: "この検証runはすでに停止されています" };
+
+	const { data, error } = await supabase
 		.from("room_experiment_runs")
 		.update({ ended_at: new Date().toISOString(), ended_by: adminId })
 		.eq("id", runId)
-		.is("ended_at", null);
+		.is("ended_at", null)
+		.select("id")
+		.maybeSingle();
 
-	if (!error) return { ok: true };
+	if (!error && data) return { ok: true };
+	if (!error && !data) return { ok: false, status: 409, message: "この検証runはすでに停止されています" };
 	console.error("room experiment run stop error:", error);
 	return { ok: false, status: 500, message: "検証runの停止に失敗しました" };
 }
@@ -295,14 +302,14 @@ export async function createRoomExperimentVisit(
 		return { error: true, status: 400, message: "client_visit_keyが不正です" };
 	}
 
-	const { data: session } = await asAny(supabase)
+	const { data: session } = await supabase
 		.from("broadcast_room_sessions")
 		.select("id, anime_id, room_kind")
 		.eq("id", sessionId)
 		.maybeSingle();
 	if (!session || session.room_kind !== "episode") return { tracked: false };
 
-	const { data: run } = await asAny(supabase)
+	const { data: run } = await supabase
 		.from("room_experiment_runs")
 		.select("id, anime_id")
 		.eq("anime_id", session.anime_id)
@@ -311,7 +318,7 @@ export async function createRoomExperimentVisit(
 	if (!run) return { tracked: false };
 
 	const now = new Date().toISOString();
-	const { data, error } = await asAny(supabase)
+	const { data, error } = await supabase
 		.from("room_experiment_visits")
 		.upsert(
 			{
@@ -346,19 +353,23 @@ export async function heartbeatRoomExperimentVisit(
 	supabase: SupabaseClient<Database>,
 	userId: string,
 	visitId: string,
-): Promise<void> {
-	const { data: visit } = await asAny(supabase)
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+	const { data: visit, error } = await supabase
 		.from("room_experiment_visits")
 		.select("id, heartbeat_count, run:room_experiment_runs!room_experiment_visits_run_id_fkey ( ended_at )")
 		.eq("id", visitId)
 		.eq("user_id", userId)
 		.maybeSingle();
-	if (!visit) return;
+	if (error) {
+		console.error("room experiment heartbeat lookup error:", { visitId, userId, error });
+		return { ok: false, status: 500, message: "heartbeatの更新に失敗しました" };
+	}
+	if (!visit) return { ok: true };
 
 	const run = firstMaybeArray(visit.run as { ended_at: string | null } | { ended_at: string | null }[] | null);
-	if (run?.ended_at) return;
+	if (run?.ended_at) return { ok: true };
 
-	await asAny(supabase)
+	const { error: updateError } = await supabase
 		.from("room_experiment_visits")
 		.update({
 			last_seen_at: new Date().toISOString(),
@@ -366,23 +377,32 @@ export async function heartbeatRoomExperimentVisit(
 		})
 		.eq("id", visitId)
 		.eq("user_id", userId);
+	if (updateError) {
+		console.error("room experiment heartbeat update error:", { visitId, userId, error: updateError });
+		return { ok: false, status: 500, message: "heartbeatの更新に失敗しました" };
+	}
+	return { ok: true };
 }
 
 export async function exitRoomExperimentVisit(
 	supabase: SupabaseClient<Database>,
 	userId: string,
 	visitId: string,
-): Promise<void> {
-	const { data: visit } = await asAny(supabase)
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+	const { data: visit, error } = await supabase
 		.from("room_experiment_visits")
 		.select("id, exited_at")
 		.eq("id", visitId)
 		.eq("user_id", userId)
 		.maybeSingle();
-	if (!visit) return;
+	if (error) {
+		console.error("room experiment exit lookup error:", { visitId, userId, error });
+		return { ok: false, status: 500, message: "exitの更新に失敗しました" };
+	}
+	if (!visit) return { ok: true };
 
 	const now = new Date().toISOString();
-	await asAny(supabase)
+	const { error: updateError } = await supabase
 		.from("room_experiment_visits")
 		.update({
 			last_seen_at: now,
@@ -390,6 +410,11 @@ export async function exitRoomExperimentVisit(
 		})
 		.eq("id", visitId)
 		.eq("user_id", userId);
+	if (updateError) {
+		console.error("room experiment exit update error:", { visitId, userId, error: updateError });
+		return { ok: false, status: 500, message: "exitの更新に失敗しました" };
+	}
+	return { ok: true };
 }
 
 export async function getRoomExperimentDashboardData(
@@ -398,7 +423,7 @@ export async function getRoomExperimentDashboardData(
 ): Promise<{ runs: RoomExperimentDashboardRun[]; searchResults: RoomExperimentAnimeSearchResult[] }> {
 	const [searchResults, { data: runRows }] = await Promise.all([
 		searchRoomExperimentAnime(supabase, searchQuery),
-		asAny(supabase)
+		supabase
 			.from("room_experiment_runs")
 			.select(
 				"id, anime_id, started_at, ended_at, label, notes, anime:anime!room_experiment_runs_anime_id_fkey ( title, cover_url )",
@@ -415,13 +440,13 @@ export async function getRoomExperimentDashboardData(
 	const earliestStartedAt = runs.map((run) => run.started_at).sort()[0];
 
 	const [{ data: visitRows }, { data: postRows }, { data: sessionRows }] = await Promise.all([
-		asAny(supabase)
+		supabase
 			.from("room_experiment_visits")
 			.select(
 				"id, run_id, anime_id, broadcast_room_session_id, user_id, entered_at, last_seen_at, exited_at, session:broadcast_room_sessions!room_experiment_visits_broadcast_room_session_id_fkey ( id, room_date, room_kind, room_key, scheduled_at, posting_closes_at )",
 			)
 			.in("run_id", runIds),
-		asAny(supabase)
+		supabase
 			.from("posts")
 			.select(
 				"id, user_id, broadcast_room_session_id, created_at, parent_id, hidden_by_admin, session:broadcast_room_sessions!posts_broadcast_room_session_id_fkey ( id, anime_id, room_date, room_kind, room_key, scheduled_at, posting_closes_at )",
@@ -429,7 +454,7 @@ export async function getRoomExperimentDashboardData(
 			.in("anime_id", animeIds)
 			.not("broadcast_room_session_id", "is", null)
 			.gte("created_at", earliestStartedAt),
-		asAny(supabase)
+		supabase
 			.from("broadcast_room_sessions")
 			.select("id, anime_id, room_date, room_kind, room_key, scheduled_at, posting_closes_at")
 			.in("anime_id", animeIds)

--- a/src/lib/server/room-experiments.ts
+++ b/src/lib/server/room-experiments.ts
@@ -1,0 +1,499 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildTitleSearchFilter } from "$lib/server/queries";
+import { createServiceRoleClient } from "$lib/server/supabase-admin";
+import type { Database } from "$lib/supabase/database.types";
+import type { RoomExperimentAnimeSearchResult, RoomExperimentDashboardRun, RoomExperimentRun } from "$lib/types";
+import {
+	calculateRoomExperimentMetrics,
+	type ExperimentPostCandidate,
+	type ExperimentRoomInput,
+	type ExperimentVisitInput,
+	filterRoomExperimentPosts,
+	ROOM_EXPERIMENT_HEARTBEAT_INTERVAL_MS,
+	ROOM_EXPERIMENT_STALE_AFTER_MS,
+} from "./room-experiment-metrics";
+
+// biome-ignore lint/suspicious/noExplicitAny: new room experiment tables may lag behind linked Supabase type generation
+type AnySupabase = SupabaseClient<any>;
+
+type RunRow = {
+	id: string;
+	anime_id: number;
+	started_at: string;
+	ended_at: string | null;
+	label: string | null;
+	notes: string | null;
+	anime: { title: string; cover_url: string | null } | { title: string; cover_url: string | null }[] | null;
+};
+
+type VisitRow = {
+	id: string;
+	run_id: string;
+	anime_id: number;
+	broadcast_room_session_id: string;
+	user_id: string;
+	entered_at: string;
+	last_seen_at: string;
+	exited_at: string | null;
+	session:
+		| {
+				id: string;
+				room_date: string;
+				room_kind: string;
+				room_key: string;
+				scheduled_at: string;
+				posting_closes_at: string | null;
+		  }
+		| {
+				id: string;
+				room_date: string;
+				room_kind: string;
+				room_key: string;
+				scheduled_at: string;
+				posting_closes_at: string | null;
+		  }[]
+		| null;
+};
+
+type PostRow = ExperimentPostCandidate & {
+	session:
+		| {
+				id: string;
+				anime_id: number;
+				room_date: string;
+				room_kind: string;
+				room_key: string;
+				scheduled_at: string;
+				posting_closes_at: string | null;
+		  }
+		| {
+				id: string;
+				anime_id: number;
+				room_date: string;
+				room_kind: string;
+				room_key: string;
+				scheduled_at: string;
+				posting_closes_at: string | null;
+		  }[]
+		| null;
+};
+
+type SessionInfo = {
+	id: string;
+	anime_id?: number;
+	room_date: string;
+	room_kind: string;
+	room_key: string;
+	scheduled_at: string;
+	posting_closes_at: string | null;
+};
+
+function asAny(supabase: SupabaseClient<Database>): AnySupabase {
+	return supabase as unknown as AnySupabase;
+}
+
+export function createRoomExperimentServiceClient(): SupabaseClient<Database> | null {
+	try {
+		return createServiceRoleClient();
+	} catch (error) {
+		console.error("room experiment service client unavailable:", error);
+		return null;
+	}
+}
+
+function firstMaybeArray<T>(value: T | T[] | null): T | null {
+	if (Array.isArray(value)) return value[0] ?? null;
+	return value;
+}
+
+function toDashboardRun(row: RunRow, rooms: ExperimentRoomInput[]): RoomExperimentDashboardRun {
+	const anime = firstMaybeArray(row.anime);
+	const metrics = calculateRoomExperimentMetrics({
+		id: row.id,
+		started_at: row.started_at,
+		ended_at: row.ended_at,
+		rooms,
+	});
+	return {
+		id: row.id,
+		anime_id: String(row.anime_id),
+		anime_title: anime?.title ?? `#${row.anime_id}`,
+		anime_cover_url: anime?.cover_url ?? null,
+		started_at: row.started_at,
+		ended_at: row.ended_at,
+		label: row.label,
+		notes: row.notes,
+		summary: metrics.summary,
+		rooms: metrics.rooms.sort((a, b) => (a.scheduled_at ?? "").localeCompare(b.scheduled_at ?? "")),
+	};
+}
+
+function roomTitle(session: SessionInfo): string {
+	if (session.room_key && session.room_key !== session.room_date) return session.room_key;
+	return session.room_date;
+}
+
+function shouldIncludeSessionForRun(session: SessionInfo, run: RunRow): boolean {
+	if (session.anime_id !== run.anime_id) return false;
+	if (!session.posting_closes_at) return true;
+
+	const roomClosesMs = new Date(session.posting_closes_at).getTime();
+	const runStartsMs = new Date(run.started_at).getTime();
+	if (!Number.isFinite(roomClosesMs) || !Number.isFinite(runStartsMs)) return true;
+	return roomClosesMs >= runStartsMs;
+}
+
+function getSessionFromVisit(row: VisitRow): SessionInfo | null {
+	const session = firstMaybeArray(row.session);
+	return session
+		? {
+				id: session.id,
+				room_date: session.room_date,
+				room_kind: session.room_kind,
+				room_key: session.room_key,
+				scheduled_at: session.scheduled_at,
+				posting_closes_at: session.posting_closes_at,
+			}
+		: null;
+}
+
+function getSessionFromPost(row: PostRow): SessionInfo | null {
+	const session = firstMaybeArray(row.session);
+	return session
+		? {
+				id: session.id,
+				anime_id: session.anime_id,
+				room_date: session.room_date,
+				room_kind: session.room_kind,
+				room_key: session.room_key,
+				scheduled_at: session.scheduled_at,
+				posting_closes_at: session.posting_closes_at,
+			}
+		: null;
+}
+
+export async function getActiveRoomExperimentRunForAnime(
+	supabase: SupabaseClient<Database>,
+	animeId: string | number,
+): Promise<RoomExperimentRun | null> {
+	const { data, error } = await asAny(supabase)
+		.from("room_experiment_runs")
+		.select(
+			"id, anime_id, started_at, ended_at, label, notes, anime:anime!room_experiment_runs_anime_id_fkey ( title, cover_url )",
+		)
+		.eq("anime_id", Number(animeId))
+		.is("ended_at", null)
+		.maybeSingle();
+
+	if (error || !data) return null;
+	const row = data as unknown as RunRow;
+	const anime = firstMaybeArray(row.anime);
+	return {
+		id: row.id,
+		anime_id: String(row.anime_id),
+		anime_title: anime?.title ?? `#${row.anime_id}`,
+		anime_cover_url: anime?.cover_url ?? null,
+		started_at: row.started_at,
+		ended_at: row.ended_at,
+		label: row.label,
+		notes: row.notes,
+	};
+}
+
+export async function searchRoomExperimentAnime(
+	supabase: SupabaseClient<Database>,
+	query: string,
+): Promise<RoomExperimentAnimeSearchResult[]> {
+	const trimmed = query.trim().replace(/[%,]/g, "");
+	if (!trimmed) return [];
+
+	const [{ data: animeRows }, { data: activeRuns }] = await Promise.all([
+		asAny(supabase)
+			.from("anime")
+			.select("id, title, cover_url, room_type")
+			.or(buildTitleSearchFilter(trimmed))
+			.order("title", { ascending: true })
+			.limit(10),
+		asAny(supabase).from("room_experiment_runs").select("id, anime_id").is("ended_at", null),
+	]);
+
+	const activeRunByAnime = new Map(
+		((activeRuns ?? []) as unknown as Array<{ id: string; anime_id: number }>).map((run) => [
+			String(run.anime_id),
+			run.id,
+		]),
+	);
+
+	return (
+		(animeRows ?? []) as unknown as Array<{
+			id: number;
+			title: string;
+			cover_url: string | null;
+			room_type: string;
+		}>
+	).map((row) => ({
+		id: String(row.id),
+		title: row.title,
+		cover_url: row.cover_url,
+		room_type: row.room_type,
+		active_run_id: activeRunByAnime.get(String(row.id)) ?? null,
+	}));
+}
+
+export async function startRoomExperimentRun(
+	supabase: SupabaseClient<Database>,
+	adminId: string,
+	options: { animeId: string; label: string | null; notes: string | null },
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+	if (!/^\d+$/.test(options.animeId)) {
+		return { ok: false, status: 400, message: "作品IDが不正です" };
+	}
+
+	const { error } = await asAny(supabase)
+		.from("room_experiment_runs")
+		.insert({
+			anime_id: Number(options.animeId),
+			created_by: adminId,
+			label: options.label || null,
+			notes: options.notes || null,
+		});
+
+	if (!error) return { ok: true };
+	if (error.code === "23505") return { ok: false, status: 409, message: "この作品はすでに検証対象です" };
+	console.error("room experiment run start error:", error);
+	return { ok: false, status: 500, message: "検証runの開始に失敗しました" };
+}
+
+export async function stopRoomExperimentRun(
+	supabase: SupabaseClient<Database>,
+	adminId: string,
+	runId: string,
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+	const { error } = await asAny(supabase)
+		.from("room_experiment_runs")
+		.update({ ended_at: new Date().toISOString(), ended_by: adminId })
+		.eq("id", runId)
+		.is("ended_at", null);
+
+	if (!error) return { ok: true };
+	console.error("room experiment run stop error:", error);
+	return { ok: false, status: 500, message: "検証runの停止に失敗しました" };
+}
+
+export async function createRoomExperimentVisit(
+	supabase: SupabaseClient<Database>,
+	userId: string,
+	options: { sessionId: string; clientVisitKey: string; userAgent: string | null },
+): Promise<
+	| { tracked: true; visitId: string; heartbeatIntervalMs: number; staleAfterMs: number }
+	| { tracked: false }
+	| { error: true; status: number; message: string }
+> {
+	const sessionId = options.sessionId.trim();
+	const clientVisitKey = options.clientVisitKey.trim();
+	if (!clientVisitKey || clientVisitKey.length > 120) {
+		return { error: true, status: 400, message: "client_visit_keyが不正です" };
+	}
+
+	const { data: session } = await asAny(supabase)
+		.from("broadcast_room_sessions")
+		.select("id, anime_id, room_kind")
+		.eq("id", sessionId)
+		.maybeSingle();
+	if (!session || session.room_kind !== "episode") return { tracked: false };
+
+	const { data: run } = await asAny(supabase)
+		.from("room_experiment_runs")
+		.select("id, anime_id")
+		.eq("anime_id", session.anime_id)
+		.is("ended_at", null)
+		.maybeSingle();
+	if (!run) return { tracked: false };
+
+	const now = new Date().toISOString();
+	const { data, error } = await asAny(supabase)
+		.from("room_experiment_visits")
+		.upsert(
+			{
+				run_id: run.id,
+				anime_id: run.anime_id,
+				broadcast_room_session_id: session.id,
+				user_id: userId,
+				client_visit_key: clientVisitKey,
+				last_seen_at: now,
+				exited_at: null,
+				user_agent: options.userAgent?.slice(0, 500) ?? null,
+			},
+			{ onConflict: "run_id,user_id,broadcast_room_session_id,client_visit_key" },
+		)
+		.select("id")
+		.single();
+
+	if (error || !data) {
+		console.error("room experiment visit create error:", error);
+		return { error: true, status: 500, message: "visitの作成に失敗しました" };
+	}
+
+	return {
+		tracked: true,
+		visitId: data.id,
+		heartbeatIntervalMs: ROOM_EXPERIMENT_HEARTBEAT_INTERVAL_MS,
+		staleAfterMs: ROOM_EXPERIMENT_STALE_AFTER_MS,
+	};
+}
+
+export async function heartbeatRoomExperimentVisit(
+	supabase: SupabaseClient<Database>,
+	userId: string,
+	visitId: string,
+): Promise<void> {
+	const { data: visit } = await asAny(supabase)
+		.from("room_experiment_visits")
+		.select("id, heartbeat_count, run:room_experiment_runs!room_experiment_visits_run_id_fkey ( ended_at )")
+		.eq("id", visitId)
+		.eq("user_id", userId)
+		.maybeSingle();
+	if (!visit) return;
+
+	const run = firstMaybeArray(visit.run as { ended_at: string | null } | { ended_at: string | null }[] | null);
+	if (run?.ended_at) return;
+
+	await asAny(supabase)
+		.from("room_experiment_visits")
+		.update({
+			last_seen_at: new Date().toISOString(),
+			heartbeat_count: Number(visit.heartbeat_count ?? 0) + 1,
+		})
+		.eq("id", visitId)
+		.eq("user_id", userId);
+}
+
+export async function exitRoomExperimentVisit(
+	supabase: SupabaseClient<Database>,
+	userId: string,
+	visitId: string,
+): Promise<void> {
+	const { data: visit } = await asAny(supabase)
+		.from("room_experiment_visits")
+		.select("id, exited_at")
+		.eq("id", visitId)
+		.eq("user_id", userId)
+		.maybeSingle();
+	if (!visit) return;
+
+	const now = new Date().toISOString();
+	await asAny(supabase)
+		.from("room_experiment_visits")
+		.update({
+			last_seen_at: now,
+			...(visit.exited_at ? {} : { exited_at: now }),
+		})
+		.eq("id", visitId)
+		.eq("user_id", userId);
+}
+
+export async function getRoomExperimentDashboardData(
+	supabase: SupabaseClient<Database>,
+	searchQuery: string,
+): Promise<{ runs: RoomExperimentDashboardRun[]; searchResults: RoomExperimentAnimeSearchResult[] }> {
+	const [searchResults, { data: runRows }] = await Promise.all([
+		searchRoomExperimentAnime(supabase, searchQuery),
+		asAny(supabase)
+			.from("room_experiment_runs")
+			.select(
+				"id, anime_id, started_at, ended_at, label, notes, anime:anime!room_experiment_runs_anime_id_fkey ( title, cover_url )",
+			)
+			.is("ended_at", null)
+			.order("started_at", { ascending: false }),
+	]);
+
+	const runs = ((runRows ?? []) as unknown as RunRow[]) ?? [];
+	if (runs.length === 0) return { runs: [], searchResults };
+
+	const runIds = runs.map((run) => run.id);
+	const animeIds = [...new Set(runs.map((run) => run.anime_id))];
+	const earliestStartedAt = runs.map((run) => run.started_at).sort()[0];
+
+	const [{ data: visitRows }, { data: postRows }, { data: sessionRows }] = await Promise.all([
+		asAny(supabase)
+			.from("room_experiment_visits")
+			.select(
+				"id, run_id, anime_id, broadcast_room_session_id, user_id, entered_at, last_seen_at, exited_at, session:broadcast_room_sessions!room_experiment_visits_broadcast_room_session_id_fkey ( id, room_date, room_kind, room_key, scheduled_at, posting_closes_at )",
+			)
+			.in("run_id", runIds),
+		asAny(supabase)
+			.from("posts")
+			.select(
+				"id, user_id, broadcast_room_session_id, created_at, parent_id, hidden_by_admin, session:broadcast_room_sessions!posts_broadcast_room_session_id_fkey ( id, anime_id, room_date, room_kind, room_key, scheduled_at, posting_closes_at )",
+			)
+			.in("anime_id", animeIds)
+			.not("broadcast_room_session_id", "is", null)
+			.gte("created_at", earliestStartedAt),
+		asAny(supabase)
+			.from("broadcast_room_sessions")
+			.select("id, anime_id, room_date, room_kind, room_key, scheduled_at, posting_closes_at")
+			.in("anime_id", animeIds)
+			.eq("room_kind", "episode"),
+	]);
+
+	const visits = ((visitRows ?? []) as unknown as VisitRow[]).filter((row) => {
+		const session = getSessionFromVisit(row);
+		return session?.room_kind === "episode";
+	});
+	const posts = ((postRows ?? []) as unknown as PostRow[]).filter((row) => {
+		const session = getSessionFromPost(row);
+		return session?.room_kind === "episode";
+	});
+	const sessions = ((sessionRows ?? []) as unknown as SessionInfo[]).filter((row) => row.room_kind === "episode");
+
+	return {
+		searchResults,
+		runs: runs.map((run) => {
+			const sessionById = new Map<string, SessionInfo>();
+			const visitsBySession = new Map<string, ExperimentVisitInput[]>();
+			const postsBySession = new Map<string, ExperimentPostCandidate[]>();
+
+			for (const session of sessions) {
+				if (shouldIncludeSessionForRun(session, run)) sessionById.set(session.id, session);
+			}
+
+			for (const visit of visits.filter((row) => row.run_id === run.id)) {
+				const session = getSessionFromVisit(visit);
+				if (!session) continue;
+				sessionById.set(session.id, session);
+				const group = visitsBySession.get(session.id) ?? [];
+				group.push({
+					user_id: visit.user_id,
+					entered_at: visit.entered_at,
+					last_seen_at: visit.last_seen_at,
+					exited_at: visit.exited_at,
+				});
+				visitsBySession.set(session.id, group);
+			}
+
+			for (const post of posts) {
+				const session = getSessionFromPost(post);
+				if (!session || session.anime_id !== run.anime_id) continue;
+				sessionById.set(session.id, session);
+				const group = postsBySession.get(session.id) ?? [];
+				group.push(post);
+				postsBySession.set(session.id, group);
+			}
+
+			const rooms = [...sessionById.values()].map((session) => ({
+				broadcast_room_session_id: session.id,
+				room_title: roomTitle(session),
+				scheduled_at: session.scheduled_at,
+				posting_closes_at: session.posting_closes_at,
+				visits: visitsBySession.get(session.id) ?? [],
+				posts: filterRoomExperimentPosts(postsBySession.get(session.id) ?? [], {
+					sessionId: session.id,
+					runStartedAt: run.started_at,
+					runEndedAt: run.ended_at,
+				}),
+			}));
+
+			return toDashboardRun(run, rooms);
+		}),
+	};
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -870,6 +870,133 @@ export type Database = {
 					},
 				];
 			};
+			room_experiment_runs: {
+				Row: {
+					id: string;
+					anime_id: number;
+					started_at: string;
+					ended_at: string | null;
+					created_by: string;
+					ended_by: string | null;
+					label: string | null;
+					notes: string | null;
+					created_at: string;
+					updated_at: string;
+				};
+				Insert: {
+					id?: string;
+					anime_id: number;
+					started_at?: string;
+					ended_at?: string | null;
+					created_by: string;
+					ended_by?: string | null;
+					label?: string | null;
+					notes?: string | null;
+					created_at?: string;
+					updated_at?: string;
+				};
+				Update: {
+					anime_id?: number;
+					started_at?: string;
+					ended_at?: string | null;
+					ended_by?: string | null;
+					label?: string | null;
+					notes?: string | null;
+					updated_at?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "room_experiment_runs_anime_id_fkey";
+						columns: ["anime_id"];
+						isOneToOne: false;
+						referencedRelation: "anime";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_experiment_runs_created_by_fkey";
+						columns: ["created_by"];
+						isOneToOne: false;
+						referencedRelation: "profiles";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_experiment_runs_ended_by_fkey";
+						columns: ["ended_by"];
+						isOneToOne: false;
+						referencedRelation: "profiles";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+			room_experiment_visits: {
+				Row: {
+					id: string;
+					run_id: string;
+					anime_id: number;
+					broadcast_room_session_id: string;
+					user_id: string;
+					client_visit_key: string;
+					entered_at: string;
+					last_seen_at: string;
+					exited_at: string | null;
+					heartbeat_count: number;
+					user_agent: string | null;
+					created_at: string;
+					updated_at: string;
+				};
+				Insert: {
+					id?: string;
+					run_id: string;
+					anime_id: number;
+					broadcast_room_session_id: string;
+					user_id: string;
+					client_visit_key: string;
+					entered_at?: string;
+					last_seen_at?: string;
+					exited_at?: string | null;
+					heartbeat_count?: number;
+					user_agent?: string | null;
+					created_at?: string;
+					updated_at?: string;
+				};
+				Update: {
+					last_seen_at?: string;
+					exited_at?: string | null;
+					heartbeat_count?: number;
+					user_agent?: string | null;
+					updated_at?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "room_experiment_visits_run_id_fkey";
+						columns: ["run_id"];
+						isOneToOne: false;
+						referencedRelation: "room_experiment_runs";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_experiment_visits_anime_id_fkey";
+						columns: ["anime_id"];
+						isOneToOne: false;
+						referencedRelation: "anime";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_experiment_visits_broadcast_room_session_id_fkey";
+						columns: ["broadcast_room_session_id"];
+						isOneToOne: false;
+						referencedRelation: "broadcast_room_sessions";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_experiment_visits_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "profiles";
+						referencedColumns: ["id"];
+					},
+				];
+			};
 			broadcast_notification_subscriptions: {
 				Row: {
 					user_id: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -532,6 +532,54 @@ export interface BroadcastRoomOverride {
 	created_at: string;
 }
 
+export interface RoomExperimentRun {
+	id: string;
+	anime_id: string;
+	anime_title: string;
+	anime_cover_url: string | null;
+	started_at: string;
+	ended_at: string | null;
+	label: string | null;
+	notes: string | null;
+}
+
+export interface RoomExperimentRoomMetric {
+	broadcast_room_session_id: string;
+	room_title: string | null;
+	episode_number: number | null;
+	scheduled_at: string | null;
+	posting_closes_at: string | null;
+	visit_count: number;
+	unique_visitor_count: number;
+	active_visit_count: number;
+	post_count: number;
+	poster_count: number;
+	posting_rate: number;
+	posts_per_poster: number;
+	posts_per_unique_visitor: number;
+	average_stay_seconds: number | null;
+	bounce_rate_under_60s: number | null;
+	early_exit_rate: number | null;
+}
+
+export type RoomExperimentSummaryMetric = Omit<
+	RoomExperimentRoomMetric,
+	"broadcast_room_session_id" | "room_title" | "episode_number" | "scheduled_at" | "posting_closes_at"
+>;
+
+export interface RoomExperimentDashboardRun extends RoomExperimentRun {
+	summary: RoomExperimentSummaryMetric;
+	rooms: RoomExperimentRoomMetric[];
+}
+
+export interface RoomExperimentAnimeSearchResult {
+	id: string;
+	title: string;
+	cover_url: string | null;
+	room_type: string;
+	active_run_id: string | null;
+}
+
 export interface StoredAccount {
 	userId: string;
 	refreshToken: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,7 @@ export interface Post {
 	reposted_by_me: boolean;
 	bookmarked_by_me: boolean;
 	anime_id: string | null;
+	broadcast_room_session_id: string | null;
 	anime_quote: AnimeQuote | null;
 	exchange_share: AnimeExchangeShare | null;
 	cw_anime_id: string | null;
@@ -380,6 +381,7 @@ export function toPost(
 		reposted_by_me: counts?.reposted_by_me ?? false,
 		bookmarked_by_me: counts?.bookmarked_by_me ?? false,
 		anime_id: raw.anime_id != null ? String(raw.anime_id) : null,
+		broadcast_room_session_id: raw.broadcast_room_session_id ?? null,
 		anime_quote: raw.anime
 			? {
 					id: String(raw.anime.id),

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -103,6 +103,13 @@ const dashboard = $derived(data.dashboard);
 			</div>
 			<span class="nav-link-arrow">→</span>
 		</a>
+		<a href="/admin/room-experiments" class="nav-link">
+			<div class="nav-link-body">
+				<span class="nav-link-label">放送回ルーム検証</span>
+				<span class="nav-link-sub">対象作品の入室・滞在・投稿KPIを確認</span>
+			</div>
+			<span class="nav-link-arrow">→</span>
+		</a>
 	</div>
 </main>
 

--- a/src/routes/admin/room-experiments/+page.server.ts
+++ b/src/routes/admin/room-experiments/+page.server.ts
@@ -7,6 +7,13 @@ import {
 } from "$lib/server/room-experiments";
 import type { Actions, PageServerLoad } from "./$types";
 
+function getTextField(form: FormData, name: string): { ok: true; value: string } | { ok: false } {
+	const value = form.get(name);
+	if (value == null) return { ok: true, value: "" };
+	if (typeof value !== "string") return { ok: false };
+	return { ok: true, value: value.trim() };
+}
+
 export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSession } }) => {
 	const { user } = await safeGetSession();
 	if (!user) redirect(302, "/");
@@ -26,9 +33,15 @@ export const actions: Actions = {
 		if (!(await isAdminUser(supabase, user.id))) return fail(403, { message: "管理者権限が必要です" });
 
 		const form = await request.formData();
-		const animeId = (form.get("anime_id") as string | null)?.trim() ?? "";
-		const label = (form.get("label") as string | null)?.trim() || null;
-		const notes = (form.get("notes") as string | null)?.trim() || null;
+		const animeIdField = getTextField(form, "anime_id");
+		const labelField = getTextField(form, "label");
+		const notesField = getTextField(form, "notes");
+		if (!animeIdField.ok || !labelField.ok || !notesField.ok) {
+			return fail(400, { message: "フォーム値が不正です" });
+		}
+		const animeId = animeIdField.value;
+		const label = labelField.value || null;
+		const notes = notesField.value || null;
 		const result = await startRoomExperimentRun(supabase, user.id, { animeId, label, notes });
 		if (!result.ok) return fail(result.status, { message: result.message });
 		return { success: true, message: "検証runを開始しました" };
@@ -40,7 +53,9 @@ export const actions: Actions = {
 		if (!(await isAdminUser(supabase, user.id))) return fail(403, { message: "管理者権限が必要です" });
 
 		const form = await request.formData();
-		const runId = (form.get("run_id") as string | null)?.trim() ?? "";
+		const runIdField = getTextField(form, "run_id");
+		if (!runIdField.ok) return fail(400, { message: "フォーム値が不正です" });
+		const runId = runIdField.value;
 		if (!runId) return fail(400, { message: "run IDが不正です" });
 
 		const result = await stopRoomExperimentRun(supabase, user.id, runId);

--- a/src/routes/admin/room-experiments/+page.server.ts
+++ b/src/routes/admin/room-experiments/+page.server.ts
@@ -1,0 +1,50 @@
+import { fail, redirect } from "@sveltejs/kit";
+import { isAdminUser } from "$lib/server/queries";
+import {
+	getRoomExperimentDashboardData,
+	startRoomExperimentRun,
+	stopRoomExperimentRun,
+} from "$lib/server/room-experiments";
+import type { Actions, PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) redirect(302, "/");
+
+	const isAdmin = await isAdminUser(supabase, user.id);
+	if (!isAdmin) redirect(302, "/");
+
+	const query = url.searchParams.get("q")?.trim() ?? "";
+	const dashboard = await getRoomExperimentDashboardData(supabase, query);
+	return { dashboard, query };
+};
+
+export const actions: Actions = {
+	startRun: async ({ request, locals: { supabase, safeGetSession } }) => {
+		const { user } = await safeGetSession();
+		if (!user) return fail(401, { message: "ログインが必要です" });
+		if (!(await isAdminUser(supabase, user.id))) return fail(403, { message: "管理者権限が必要です" });
+
+		const form = await request.formData();
+		const animeId = (form.get("anime_id") as string | null)?.trim() ?? "";
+		const label = (form.get("label") as string | null)?.trim() || null;
+		const notes = (form.get("notes") as string | null)?.trim() || null;
+		const result = await startRoomExperimentRun(supabase, user.id, { animeId, label, notes });
+		if (!result.ok) return fail(result.status, { message: result.message });
+		return { success: true, message: "検証runを開始しました" };
+	},
+
+	stopRun: async ({ request, locals: { supabase, safeGetSession } }) => {
+		const { user } = await safeGetSession();
+		if (!user) return fail(401, { message: "ログインが必要です" });
+		if (!(await isAdminUser(supabase, user.id))) return fail(403, { message: "管理者権限が必要です" });
+
+		const form = await request.formData();
+		const runId = (form.get("run_id") as string | null)?.trim() ?? "";
+		if (!runId) return fail(400, { message: "run IDが不正です" });
+
+		const result = await stopRoomExperimentRun(supabase, user.id, runId);
+		if (!result.ok) return fail(result.status, { message: result.message });
+		return { success: true, message: "検証runを停止しました" };
+	},
+};

--- a/src/routes/admin/room-experiments/+page.svelte
+++ b/src/routes/admin/room-experiments/+page.svelte
@@ -1,0 +1,567 @@
+<script lang="ts">
+import type { SubmitFunction } from "@sveltejs/kit";
+import { onMount } from "svelte";
+import { enhance } from "$app/forms";
+import { invalidateAll } from "$app/navigation";
+import type { PageProps } from "./$types";
+
+let { data, form }: PageProps = $props();
+
+let stopTarget: { id: string; title: string } | null = $state(null);
+
+onMount(() => {
+	const refreshId = setInterval(() => void invalidateAll(), 30_000);
+	return () => clearInterval(refreshId);
+});
+
+function formatDate(iso: string | null) {
+	if (!iso) return "-";
+	return new Intl.DateTimeFormat("ja-JP", {
+		month: "numeric",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	}).format(new Date(iso));
+}
+
+function formatElapsed(iso: string) {
+	const minutes = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 60_000));
+	if (minutes < 60) return `${minutes}分`;
+	const hours = Math.floor(minutes / 60);
+	const rest = minutes % 60;
+	return rest ? `${hours}時間${rest}分` : `${hours}時間`;
+}
+
+function formatPercent(value: number | null) {
+	if (value == null) return "-";
+	return `${Math.round(value * 1000) / 10}%`;
+}
+
+function formatDecimal(value: number) {
+	return value.toFixed(value >= 10 ? 1 : 2);
+}
+
+function formatDuration(seconds: number | null) {
+	if (seconds == null) return "-";
+	const rounded = Math.round(seconds);
+	const minutes = Math.floor(rounded / 60);
+	const rest = rounded % 60;
+	if (minutes <= 0) return `${rest}秒`;
+	return rest ? `${minutes}分${rest}秒` : `${minutes}分`;
+}
+
+const closeStopModalAfterSubmit: SubmitFunction = () => {
+	return async ({ update }) => {
+		await update();
+		stopTarget = null;
+	};
+};
+</script>
+
+<svelte:head> <title>Room Experiments - Anipolis</title> </svelte:head>
+
+<main class="room-experiments-page">
+	<header class="admin-header">
+		<div>
+			<a class="back-link" href="/admin">← Admin</a>
+			<p class="admin-kicker">KPI Experiment</p>
+			<h1>放送回ルーム検証</h1>
+		</div>
+	</header>
+
+	{#if form?.message}
+		<p class="form-message" class:form-message--error={!form.success}>{form.message}</p>
+	{/if}
+
+	<section class="admin-section">
+		<div class="admin-section-header">
+			<h2>作品検索</h2>
+		</div>
+		<form method="GET" class="search-form">
+			<input class="input" name="q" value={data.query} placeholder="作品名で検索">
+			<button class="btn" type="submit">検索</button>
+		</form>
+
+		{#if data.dashboard.searchResults.length > 0}
+			<div class="search-results">
+				{#each data.dashboard.searchResults as anime}
+					<div class="search-row">
+						<div class="anime-summary">
+							{#if anime.cover_url}
+								<img src={anime.cover_url} alt="" class="anime-cover">
+							{:else}
+								<div class="anime-cover anime-cover--empty"></div>
+							{/if}
+							<div>
+								<strong>{anime.title}</strong>
+								<span
+									>{anime.room_type === "global" ? "グローバルロビー作品" : "放送回ルーム作品"}</span
+								>
+							</div>
+						</div>
+						{#if anime.active_run_id}
+							<button
+								class="btn btn-danger"
+								type="button"
+								onclick={() => (stopTarget = { id: anime.active_run_id ?? "", title: anime.title })}
+							>
+								停止
+							</button>
+						{:else}
+							<form method="POST" action="?/startRun" use:enhance class="inline-form">
+								<input type="hidden" name="anime_id" value={anime.id}>
+								<button class="btn" type="submit">対象化</button>
+							</form>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{:else if data.query}
+			<p class="empty-state">該当する作品がありません。</p>
+		{/if}
+	</section>
+
+	<section class="admin-section">
+		<div class="admin-section-header">
+			<h2>active run</h2>
+			<span>{data.dashboard.runs.length}件</span>
+		</div>
+		{#if data.dashboard.runs.length === 0}
+			<p class="empty-state">現在進行中の検証runはありません。</p>
+		{:else}
+			<div class="run-grid">
+				{#each data.dashboard.runs as run}
+					<article class="run-panel">
+						<div class="run-panel-header">
+							<div class="anime-summary">
+								{#if run.anime_cover_url}
+									<img src={run.anime_cover_url} alt="" class="anime-cover">
+								{:else}
+									<div class="anime-cover anime-cover--empty"></div>
+								{/if}
+								<div>
+									<strong>{run.anime_title}</strong>
+									<span>{formatDate(run.started_at)}開始 · {formatElapsed(run.started_at)}</span>
+								</div>
+							</div>
+							<button
+								class="btn btn-danger"
+								type="button"
+								onclick={() => (stopTarget = { id: run.id, title: run.anime_title })}
+							>
+								停止
+							</button>
+						</div>
+
+						<div class="metric-strip">
+							<div><span>入室</span><strong>{run.summary.visit_count}</strong></div>
+							<div><span>UU</span><strong>{run.summary.unique_visitor_count}</strong></div>
+							<div><span>active</span><strong>{run.summary.active_visit_count}</strong></div>
+							<div><span>投稿者</span><strong>{run.summary.poster_count}</strong></div>
+							<div><span>投稿数</span><strong>{run.summary.post_count}</strong></div>
+							<div><span>投稿率</span><strong>{formatPercent(run.summary.posting_rate)}</strong></div>
+							<div>
+								<span>平均滞在</span><strong>{formatDuration(run.summary.average_stay_seconds)}</strong>
+							</div>
+						</div>
+
+						<div class="room-table-wrap">
+							<table>
+								<thead>
+									<tr>
+										<th>ルーム</th>
+										<th>開始</th>
+										<th>入室</th>
+										<th>UU</th>
+										<th>active</th>
+										<th>投稿者</th>
+										<th>投稿率</th>
+										<th>投稿数</th>
+										<th>投稿/UU</th>
+										<th>平均滞在</th>
+										<th>即離脱</th>
+										<th>終了前離脱</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#if run.rooms.length === 0}
+										<tr>
+											<td colspan="12" class="empty-cell">
+												まだ放送回ルーム内の計測データはありません。
+											</td>
+										</tr>
+									{:else}
+										{#each run.rooms as room}
+											<tr>
+												<td>{room.room_title ?? "-"}</td>
+												<td>{formatDate(room.scheduled_at)}</td>
+												<td>{room.visit_count}</td>
+												<td>{room.unique_visitor_count}</td>
+												<td>{room.active_visit_count}</td>
+												<td>{room.poster_count}</td>
+												<td>{formatPercent(room.posting_rate)}</td>
+												<td>{room.post_count}</td>
+												<td>{formatDecimal(room.posts_per_unique_visitor)}</td>
+												<td>{formatDuration(room.average_stay_seconds)}</td>
+												<td>{formatPercent(room.bounce_rate_under_60s)}</td>
+												<td>{formatPercent(room.early_exit_rate)}</td>
+											</tr>
+										{/each}
+									{/if}
+								</tbody>
+							</table>
+						</div>
+					</article>
+				{/each}
+			</div>
+		{/if}
+	</section>
+
+	<section class="note-box">
+		<p>※この画面では、検証対象化後のログインユーザーによる放送回ルーム内の行動のみ集計しています。</p>
+		<p>※グローバルロビー、未ログイン閲覧、対象化前の入室・投稿は含まれません。</p>
+		<p>※滞在時間は exit が送信されなかった場合、最後の heartbeat 時刻で補完されます。</p>
+	</section>
+</main>
+
+{#if stopTarget}
+	<div
+		class="modal-backdrop"
+		role="presentation"
+		onclick={(event) => { if (event.target === event.currentTarget) stopTarget = null; }}
+	>
+		<div class="modal" role="dialog" aria-modal="true" aria-labelledby="stop-run-title">
+			<h2 id="stop-run-title">検証runを停止</h2>
+			<p>「{stopTarget.title}」の検証runを停止します。以後、このrunには新規入室・投稿が集計されません。</p>
+			<div class="modal-actions">
+				<button class="btn btn-ghost" type="button" onclick={() => (stopTarget = null)}>キャンセル</button>
+				<form method="POST" action="?/stopRun" use:enhance={closeStopModalAfterSubmit}>
+					<input type="hidden" name="run_id" value={stopTarget.id}>
+					<button class="btn btn-danger" type="submit">停止する</button>
+				</form>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+.room-experiments-page {
+	width: min(1180px, calc(100% - 32px));
+	margin: 0 auto;
+	padding: calc(var(--nav-height) + 24px) 0 56px;
+}
+
+.admin-header {
+	display: flex;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 18px;
+}
+
+.back-link {
+	display: inline-flex;
+	margin-bottom: 8px;
+	color: var(--color-text-muted);
+	font-size: 13px;
+	text-decoration: none;
+}
+
+.admin-kicker {
+	margin: 0 0 2px;
+	color: var(--color-accent);
+	font-size: 12px;
+	font-weight: 800;
+	text-transform: uppercase;
+}
+
+.admin-header h1 {
+	margin: 0;
+	font-size: 24px;
+	line-height: 1.2;
+}
+
+.admin-section,
+.note-box {
+	margin-top: 16px;
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	background: var(--color-surface);
+	overflow: hidden;
+}
+
+.admin-section-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 14px 16px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.admin-section-header h2 {
+	margin: 0;
+	font-size: 16px;
+}
+
+.search-form {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 10px;
+	padding: 16px;
+}
+
+.input {
+	width: 100%;
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	background: var(--color-bg);
+	color: var(--color-text);
+	padding: 10px 12px;
+	font: inherit;
+}
+
+.btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	border: 1px solid var(--color-accent);
+	border-radius: 8px;
+	background: var(--color-accent);
+	color: white;
+	padding: 0 14px;
+	font-weight: 800;
+	cursor: pointer;
+	text-decoration: none;
+}
+
+.btn-danger {
+	border-color: var(--color-danger);
+	background: var(--color-danger);
+}
+
+.btn-ghost {
+	border-color: var(--color-border);
+	background: var(--color-surface);
+	color: var(--color-text);
+}
+
+.inline-form {
+	margin: 0;
+}
+
+.search-results {
+	border-top: 1px solid var(--color-border);
+}
+
+.search-row,
+.run-panel-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 14px;
+	padding: 12px 16px;
+	border-top: 1px solid var(--color-border);
+}
+
+.search-row:first-child {
+	border-top: 0;
+}
+
+.anime-summary {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+	gap: 10px;
+}
+
+.anime-summary strong,
+.anime-summary span {
+	display: block;
+}
+
+.anime-summary strong {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.anime-summary span {
+	color: var(--color-text-muted);
+	font-size: 12px;
+}
+
+.anime-cover {
+	width: 36px;
+	height: 50px;
+	flex: 0 0 auto;
+	border-radius: 6px;
+	object-fit: cover;
+	background: var(--color-border);
+}
+
+.anime-cover--empty {
+	border: 1px solid var(--color-border);
+}
+
+.empty-state,
+.empty-cell {
+	padding: 18px 16px;
+	color: var(--color-text-muted);
+	text-align: center;
+}
+
+.run-grid {
+	display: grid;
+	gap: 14px;
+	padding: 16px;
+}
+
+.run-panel {
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.metric-strip {
+	display: grid;
+	grid-template-columns: repeat(7, minmax(0, 1fr));
+	gap: 1px;
+	background: var(--color-border);
+	border-top: 1px solid var(--color-border);
+}
+
+.metric-strip div {
+	min-width: 0;
+	background: var(--color-surface);
+	padding: 12px;
+}
+
+.metric-strip span {
+	display: block;
+	color: var(--color-text-muted);
+	font-size: 12px;
+	font-weight: 700;
+}
+
+.metric-strip strong {
+	display: block;
+	margin-top: 4px;
+	font-size: 22px;
+	line-height: 1;
+}
+
+.room-table-wrap {
+	overflow-x: auto;
+	border-top: 1px solid var(--color-border);
+}
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	min-width: 980px;
+}
+
+th,
+td {
+	padding: 10px 12px;
+	border-bottom: 1px solid var(--color-border);
+	text-align: right;
+	white-space: nowrap;
+}
+
+th:first-child,
+td:first-child {
+	text-align: left;
+}
+
+th {
+	color: var(--color-text-muted);
+	font-size: 12px;
+	font-weight: 800;
+}
+
+.note-box {
+	padding: 14px 16px;
+	color: var(--color-text-muted);
+	font-size: 13px;
+}
+
+.note-box p {
+	margin: 4px 0;
+}
+
+.form-message {
+	border: 1px solid var(--color-accent);
+	border-radius: 8px;
+	background: color-mix(in srgb, var(--color-accent) 10%, var(--color-surface));
+	padding: 12px 14px;
+	font-weight: 700;
+}
+
+.form-message--error {
+	border-color: var(--color-danger);
+	background: color-mix(in srgb, var(--color-danger) 10%, var(--color-surface));
+}
+
+.modal-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 80;
+	display: grid;
+	place-items: center;
+	background: rgb(0 0 0 / 0.5);
+	padding: 18px;
+}
+
+.modal {
+	width: min(420px, 100%);
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	background: var(--color-surface);
+	padding: 20px;
+	box-shadow: 0 24px 60px rgb(0 0 0 / 0.35);
+}
+
+.modal h2 {
+	margin: 0 0 8px;
+	font-size: 18px;
+}
+
+.modal p {
+	margin: 0;
+	color: var(--color-text-muted);
+	line-height: 1.7;
+}
+
+.modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	margin-top: 18px;
+}
+
+@media (max-width: 800px) {
+	.room-experiments-page {
+		width: min(100% - 24px, 1180px);
+		padding-top: calc(var(--nav-height) + 12px);
+	}
+
+	.search-form,
+	.metric-strip {
+		grid-template-columns: 1fr;
+	}
+
+	.search-row,
+	.run-panel-header {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.search-row .btn,
+	.search-row form,
+	.run-panel-header .btn {
+		width: 100%;
+	}
+}
+</style>

--- a/src/routes/api/room-experiment-visits/+server.ts
+++ b/src/routes/api/room-experiment-visits/+server.ts
@@ -1,0 +1,45 @@
+import { error, json } from "@sveltejs/kit";
+import { createRoomExperimentServiceClient, createRoomExperimentVisit } from "$lib/server/room-experiments";
+import type { RequestHandler } from "./$types";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function noContent() {
+	return new Response(null, { status: 204 });
+}
+
+async function readBody(request: Request): Promise<{ session_id?: unknown; client_visit_key?: unknown }> {
+	try {
+		return (await request.json()) as { session_id?: unknown; client_visit_key?: unknown };
+	} catch {
+		return {};
+	}
+}
+
+export const POST: RequestHandler = async ({ request, locals: { safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) error(401, "ログインが必要です");
+
+	const body = await readBody(request);
+	const sessionId = typeof body.session_id === "string" ? body.session_id.trim() : "";
+	const clientVisitKey = typeof body.client_visit_key === "string" ? body.client_visit_key.trim() : "";
+	if (!UUID_RE.test(sessionId)) return noContent();
+
+	const supabase = createRoomExperimentServiceClient();
+	if (!supabase) return noContent();
+
+	const result = await createRoomExperimentVisit(supabase, user.id, {
+		sessionId,
+		clientVisitKey,
+		userAgent: request.headers.get("user-agent"),
+	});
+
+	if ("error" in result) error(result.status, result.message);
+	if (!result.tracked) return noContent();
+
+	return json({
+		visit_id: result.visitId,
+		heartbeat_interval_ms: result.heartbeatIntervalMs,
+		stale_after_ms: result.staleAfterMs,
+	});
+};

--- a/src/routes/api/room-experiment-visits/[id]/exit/+server.ts
+++ b/src/routes/api/room-experiment-visits/[id]/exit/+server.ts
@@ -16,6 +16,7 @@ export const POST: RequestHandler = async ({ params, locals: { safeGetSession } 
 	const supabase = createRoomExperimentServiceClient();
 	if (!supabase) return noContent();
 
-	await exitRoomExperimentVisit(supabase, user.id, params.id);
+	const result = await exitRoomExperimentVisit(supabase, user.id, params.id);
+	if (!result.ok) error(result.status, result.message);
 	return noContent();
 };

--- a/src/routes/api/room-experiment-visits/[id]/exit/+server.ts
+++ b/src/routes/api/room-experiment-visits/[id]/exit/+server.ts
@@ -1,0 +1,21 @@
+import { error } from "@sveltejs/kit";
+import { createRoomExperimentServiceClient, exitRoomExperimentVisit } from "$lib/server/room-experiments";
+import type { RequestHandler } from "./$types";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function noContent() {
+	return new Response(null, { status: 204 });
+}
+
+export const POST: RequestHandler = async ({ params, locals: { safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) error(401, "ログインが必要です");
+	if (!UUID_RE.test(params.id)) return noContent();
+
+	const supabase = createRoomExperimentServiceClient();
+	if (!supabase) return noContent();
+
+	await exitRoomExperimentVisit(supabase, user.id, params.id);
+	return noContent();
+};

--- a/src/routes/api/room-experiment-visits/[id]/heartbeat/+server.ts
+++ b/src/routes/api/room-experiment-visits/[id]/heartbeat/+server.ts
@@ -1,0 +1,21 @@
+import { error } from "@sveltejs/kit";
+import { createRoomExperimentServiceClient, heartbeatRoomExperimentVisit } from "$lib/server/room-experiments";
+import type { RequestHandler } from "./$types";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function noContent() {
+	return new Response(null, { status: 204 });
+}
+
+export const POST: RequestHandler = async ({ params, locals: { safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) error(401, "ログインが必要です");
+	if (!UUID_RE.test(params.id)) return noContent();
+
+	const supabase = createRoomExperimentServiceClient();
+	if (!supabase) return noContent();
+
+	await heartbeatRoomExperimentVisit(supabase, user.id, params.id);
+	return noContent();
+};

--- a/src/routes/api/room-experiment-visits/[id]/heartbeat/+server.ts
+++ b/src/routes/api/room-experiment-visits/[id]/heartbeat/+server.ts
@@ -16,6 +16,7 @@ export const POST: RequestHandler = async ({ params, locals: { safeGetSession } 
 	const supabase = createRoomExperimentServiceClient();
 	if (!supabase) return noContent();
 
-	await heartbeatRoomExperimentVisit(supabase, user.id, params.id);
+	const result = await heartbeatRoomExperimentVisit(supabase, user.id, params.id);
+	if (!result.ok) error(result.status, result.message);
 	return noContent();
 };

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -130,11 +130,12 @@ export const actions: Actions = {
 
 		const form = await request.formData();
 		const content = (form.get("content") as string | null)?.trim() ?? "";
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 		const hashtag = roomHashtag(anime);
-		const hasTag = content.toLowerCase().includes(`#${hashtag.toLowerCase()}`);
-		const finalContent = hasTag ? content : `${content} #${hashtag}`;
 
-		return insertPostWithHashtags(supabase, user.id, finalContent, null, [], anime.id, null, null, session.id);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
+			hashtag,
+		]);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -55,6 +55,18 @@ function roomHashtag(anime: Anime) {
 	return officialHashtag ?? fallbackRoomHashtag(anime.title);
 }
 
+function stripTrailingRoomHashtag(content: string, hashtag: string) {
+	const tag = normalizeHashtag(hashtag);
+	if (!tag) return content.trim();
+	const trimmed = content.trim();
+	const normalized = trimmed.toLowerCase();
+	const suffix = `#${tag}`;
+	if (!normalized.endsWith(suffix)) return trimmed;
+	const before = trimmed.slice(0, trimmed.length - suffix.length);
+	if (before.length > 0 && !/\s$/.test(before)) return trimmed;
+	return before.trimEnd();
+}
+
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
 	const { user } = await safeGetSession();
 	const anime = await getAnime(supabase, params.id, user?.id ?? null);
@@ -129,9 +141,10 @@ export const actions: Actions = {
 		}
 
 		const form = await request.formData();
-		const content = (form.get("content") as string | null)?.trim() ?? "";
-		if (!content) return fail(400, { message: "投稿内容を入力してください" });
+		const rawContent = (form.get("content") as string | null) ?? "";
 		const hashtag = roomHashtag(anime);
+		const content = stripTrailingRoomHashtag(rawContent, hashtag);
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
 		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
 			hashtag,

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -13,6 +13,10 @@ import {
 	getBroadcastRoomPosts,
 	getBroadcastRoomSession,
 } from "$lib/server/queries";
+import {
+	createRoomExperimentServiceClient,
+	getActiveRoomExperimentRunForAnime as getActiveExperimentRun,
+} from "$lib/server/room-experiments";
 import type { Anime } from "$lib/types";
 import type { Actions, PageServerLoad } from "./$types";
 
@@ -68,10 +72,12 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	if (!session) throw error(404, "放送ルームが見つかりません");
 
 	const hashtag = roomHashtag(anime);
-	const [posts, trending, animeTrending] = await Promise.all([
+	const roomExperimentSupabase = user ? createRoomExperimentServiceClient() : null;
+	const [posts, trending, animeTrending, roomExperimentRun] = await Promise.all([
 		getBroadcastRoomPosts(supabase, session.id, user?.id ?? null, { limit: 100, ascending: true }),
 		supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
 		getAnimeRankingTrending(supabase, 5),
+		roomExperimentSupabase ? getActiveExperimentRun(roomExperimentSupabase, anime.id) : Promise.resolve(null),
 	]);
 
 	return {
@@ -91,6 +97,10 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		trending: trending.data ?? [],
 		animeTrending,
 		user,
+		roomExperiment: {
+			enabled: Boolean(user && roomExperimentRun),
+			sessionId: roomExperimentRun ? session.id : undefined,
+		},
 	};
 };
 

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -30,11 +30,7 @@ const closeMs = $derived(new Date(data.room.posting_closes_at).getTime());
 const openLeadMinutes = $derived(Math.round((scheduledMs - openMs) / (60 * 1000)));
 const roomHref = $derived(`/rooms/anime/${data.anime.id}/${data.room.date}`);
 const isGlobalLobby = $derived(data.room.kind === "global");
-const hashtagSuffix = $derived(` #${data.room.hashtag}`);
-const contentWithTag = $derived(
-	postContent.includes(`#${data.room.hashtag}`) ? postContent : postContent + hashtagSuffix,
-);
-const charCount = $derived(contentWithTag.length);
+const charCount = $derived(postContent.length);
 const overLimit = $derived(charCount > maxLen);
 // ライブ更新で受信した投稿（load 由来の data.posts とは別に保持し、ID でマージする）
 let extraPosts = $state<Post[]>([]);
@@ -335,7 +331,7 @@ function formatCompactDate(iso: string) {
 							bind:this={textareaEl}
 							class="composer-textarea"
 							name="content"
-							placeholder="#{data.room.hashtag} で実況しよう... (Shift+Enterで改行)"
+							placeholder="いまの感想を投稿... (Shift+Enterで改行)"
 							rows="3"
 							bind:value={postContent}
 							maxlength={maxLen}
@@ -359,7 +355,6 @@ function formatCompactDate(iso: string) {
 							</button>
 						</div>
 					</div>
-					<p class="composer-hint">投稿には <strong>#{data.room.hashtag}</strong> が自動で付きます。</p>
 				</form>
 			</div>
 		{:else if !data.user && status === "open"}
@@ -398,11 +393,7 @@ function formatCompactDate(iso: string) {
 		</div>
 
 		{#if allPosts.length === 0}
-			<div class="card anime-room-empty">
-				まだ実況投稿はありません。<br>
-				#{data.room.hashtag}
-				で最初の感想を残しましょう。
-			</div>
+			<div class="card anime-room-empty">まだ投稿はありません。最初の感想を残しましょう。</div>
 		{:else}
 			{#each displayedPosts as post (post.id)}
 				<div class="anime-room-post">
@@ -451,10 +442,7 @@ function formatCompactDate(iso: string) {
 						</div>
 						<div class="room-summary-muted mt-1 truncate text-xs">{broadcastMetaLine}</div>
 					</div>
-					<div class="mt-2 flex items-center justify-between gap-2">
-						<a href="/hashtag/{data.room.hashtag}" class="room-summary-link truncate text-xs">
-							#{data.room.hashtag}
-						</a>
+					<div class="mt-2 flex items-center justify-end gap-2">
 						<a href="/schedule" class="room-summary-back shrink-0 text-xs transition-colors">
 							← 週間スケジュールへ戻る
 						</a>
@@ -496,11 +484,6 @@ function formatCompactDate(iso: string) {
 	color: var(--color-text-muted);
 }
 
-.room-summary-link {
-	color: var(--color-accent);
-}
-
-.room-summary-link:hover,
 .room-summary-back:hover {
 	color: var(--color-accent-hover);
 }

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -38,6 +38,9 @@ const charCount = $derived(contentWithTag.length);
 const overLimit = $derived(charCount > maxLen);
 // ライブ更新で受信した投稿（load 由来の data.posts とは別に保持し、ID でマージする）
 let extraPosts = $state<Post[]>([]);
+let roomExperimentVisitId: string | null = null;
+let roomExperimentHeartbeatTimer: ReturnType<typeof setInterval> | undefined;
+let roomExperimentExitSent = false;
 
 const allPosts = $derived.by(() => {
 	if (extraPosts.length === 0) return data.posts;
@@ -56,6 +59,64 @@ const displayedPosts = $derived(
 );
 
 let fetchingLive = false;
+
+function getRoomExperimentClientVisitKey(sessionId: string) {
+	const storageKey = `room-experiment-visit:${sessionId}`;
+	const existingKey = sessionStorage.getItem(storageKey);
+	if (existingKey) return existingKey;
+	const generatedKey = crypto.randomUUID();
+	sessionStorage.setItem(storageKey, generatedKey);
+	return generatedKey;
+}
+
+async function startRoomExperimentTracking() {
+	const sessionId = data.roomExperiment?.sessionId;
+	if (!data.user || !data.roomExperiment?.enabled || !sessionId) return;
+	try {
+		const res = await fetch("/api/room-experiment-visits", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				session_id: sessionId,
+				client_visit_key: getRoomExperimentClientVisitKey(sessionId),
+			}),
+		});
+		if (res.status === 204 || !res.ok) return;
+		const body = (await res.json()) as {
+			visit_id?: string;
+			heartbeat_interval_ms?: number;
+		};
+		if (!body.visit_id) return;
+		roomExperimentVisitId = body.visit_id;
+		roomExperimentExitSent = false;
+		const intervalMs = body.heartbeat_interval_ms ?? 30_000;
+		roomExperimentHeartbeatTimer = setInterval(() => void sendRoomExperimentHeartbeat(), intervalMs);
+	} catch {
+		// Tracking is best-effort and must not affect room viewing.
+	}
+}
+
+async function sendRoomExperimentHeartbeat() {
+	if (!roomExperimentVisitId || roomExperimentExitSent) return;
+	try {
+		await fetch(`/api/room-experiment-visits/${roomExperimentVisitId}/heartbeat`, { method: "POST" });
+	} catch {
+		// Best-effort.
+	}
+}
+
+function sendRoomExperimentExit() {
+	if (!roomExperimentVisitId || roomExperimentExitSent) return;
+	roomExperimentExitSent = true;
+	if (roomExperimentHeartbeatTimer) {
+		clearInterval(roomExperimentHeartbeatTimer);
+		roomExperimentHeartbeatTimer = undefined;
+	}
+	const url = `/api/room-experiment-visits/${roomExperimentVisitId}/exit`;
+	if (typeof navigator === "undefined") return;
+	if (navigator.sendBeacon?.(url)) return;
+	void fetch(url, { method: "POST", keepalive: true }).catch(() => undefined);
+}
 
 /** 最後に受信した投稿以降の差分を取得して extraPosts に追加する */
 async function fetchNewPosts() {
@@ -98,12 +159,19 @@ onMount(() => {
 		void focusLatestPost();
 	}
 	window.addEventListener("scroll", handleWindowScroll, { passive: true });
+	window.addEventListener("pagehide", sendRoomExperimentExit);
+	void startRoomExperimentTracking();
 });
 
 onDestroy(() => {
 	clearInterval(intervalId);
 	if (programmaticScrollTimer) clearTimeout(programmaticScrollTimer);
-	if (typeof window !== "undefined") window.removeEventListener("scroll", handleWindowScroll);
+	if (roomExperimentHeartbeatTimer) clearInterval(roomExperimentHeartbeatTimer);
+	if (typeof window !== "undefined") {
+		window.removeEventListener("scroll", handleWindowScroll);
+		window.removeEventListener("pagehide", sendRoomExperimentExit);
+	}
+	sendRoomExperimentExit();
 });
 
 $effect(() => {

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -69,6 +69,12 @@ function getRoomExperimentClientVisitKey(sessionId: string) {
 	return generatedKey;
 }
 
+function clearRoomExperimentHeartbeatTimer() {
+	if (!roomExperimentHeartbeatTimer) return;
+	clearInterval(roomExperimentHeartbeatTimer);
+	roomExperimentHeartbeatTimer = undefined;
+}
+
 async function startRoomExperimentTracking() {
 	const sessionId = data.roomExperiment?.sessionId;
 	if (!data.user || !data.roomExperiment?.enabled || !sessionId) return;
@@ -90,6 +96,7 @@ async function startRoomExperimentTracking() {
 		roomExperimentVisitId = body.visit_id;
 		roomExperimentExitSent = false;
 		const intervalMs = body.heartbeat_interval_ms ?? 30_000;
+		clearRoomExperimentHeartbeatTimer();
 		roomExperimentHeartbeatTimer = setInterval(() => void sendRoomExperimentHeartbeat(), intervalMs);
 	} catch {
 		// Tracking is best-effort and must not affect room viewing.
@@ -108,14 +115,23 @@ async function sendRoomExperimentHeartbeat() {
 function sendRoomExperimentExit() {
 	if (!roomExperimentVisitId || roomExperimentExitSent) return;
 	roomExperimentExitSent = true;
-	if (roomExperimentHeartbeatTimer) {
-		clearInterval(roomExperimentHeartbeatTimer);
-		roomExperimentHeartbeatTimer = undefined;
-	}
+	clearRoomExperimentHeartbeatTimer();
 	const url = `/api/room-experiment-visits/${roomExperimentVisitId}/exit`;
 	if (typeof navigator === "undefined") return;
 	if (navigator.sendBeacon?.(url)) return;
 	void fetch(url, { method: "POST", keepalive: true }).catch(() => undefined);
+}
+
+function handleRoomExperimentPageHide(event: PageTransitionEvent) {
+	if (event.persisted) {
+		clearRoomExperimentHeartbeatTimer();
+		return;
+	}
+	sendRoomExperimentExit();
+}
+
+function handleRoomExperimentPageShow(event: PageTransitionEvent) {
+	if (event.persisted) void startRoomExperimentTracking();
 }
 
 /** 最後に受信した投稿以降の差分を取得して extraPosts に追加する */
@@ -159,17 +175,19 @@ onMount(() => {
 		void focusLatestPost();
 	}
 	window.addEventListener("scroll", handleWindowScroll, { passive: true });
-	window.addEventListener("pagehide", sendRoomExperimentExit);
+	window.addEventListener("pagehide", handleRoomExperimentPageHide);
+	window.addEventListener("pageshow", handleRoomExperimentPageShow);
 	void startRoomExperimentTracking();
 });
 
 onDestroy(() => {
 	clearInterval(intervalId);
 	if (programmaticScrollTimer) clearTimeout(programmaticScrollTimer);
-	if (roomExperimentHeartbeatTimer) clearInterval(roomExperimentHeartbeatTimer);
+	clearRoomExperimentHeartbeatTimer();
 	if (typeof window !== "undefined") {
 		window.removeEventListener("scroll", handleWindowScroll);
-		window.removeEventListener("pagehide", sendRoomExperimentExit);
+		window.removeEventListener("pagehide", handleRoomExperimentPageHide);
+		window.removeEventListener("pageshow", handleRoomExperimentPageShow);
 	}
 	sendRoomExperimentExit();
 });

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -60,6 +60,10 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		trending: trending.data ?? [],
 		animeTrending,
 		user,
+		roomExperiment: {
+			enabled: false,
+			sessionId: undefined,
+		},
 	};
 };
 

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -80,11 +80,12 @@ export const actions: Actions = {
 
 		const form = await request.formData();
 		const content = (form.get("content") as string | null)?.trim() ?? "";
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 		const hashtag = roomHashtag(anime);
-		const hasTag = content.toLowerCase().includes(`#${hashtag.toLowerCase()}`);
-		const finalContent = hasTag ? content : `${content} #${hashtag}`;
 
-		return insertPostWithHashtags(supabase, user.id, finalContent, null, [], anime.id, null, null, session.id);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
+			hashtag,
+		]);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -28,6 +28,18 @@ function roomHashtag(anime: Anime) {
 	return officialHashtag ?? fallbackRoomHashtag(anime.title);
 }
 
+function stripTrailingRoomHashtag(content: string, hashtag: string) {
+	const tag = normalizeHashtag(hashtag);
+	if (!tag) return content.trim();
+	const trimmed = content.trim();
+	const normalized = trimmed.toLowerCase();
+	const suffix = `#${tag}`;
+	if (!normalized.endsWith(suffix)) return trimmed;
+	const before = trimmed.slice(0, trimmed.length - suffix.length);
+	if (before.length > 0 && !/\s$/.test(before)) return trimmed;
+	return before.trimEnd();
+}
+
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
 	const { user } = await safeGetSession();
 	const anime = await getAnime(supabase, params.id, user?.id ?? null);
@@ -79,9 +91,10 @@ export const actions: Actions = {
 		if (!session) return fail(404, { message: "総合ロビーが見つかりません" });
 
 		const form = await request.formData();
-		const content = (form.get("content") as string | null)?.trim() ?? "";
-		if (!content) return fail(400, { message: "投稿内容を入力してください" });
+		const rawContent = (form.get("content") as string | null) ?? "";
 		const hashtag = roomHashtag(anime);
+		const content = stripTrailingRoomHashtag(rawContent, hashtag);
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
 		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
 			hashtag,

--- a/supabase/migrations/085_room_experiment_analytics.sql
+++ b/supabase/migrations/085_room_experiment_analytics.sql
@@ -1,0 +1,195 @@
+-- KPI experiment tracking for episode broadcast rooms.
+
+CREATE TABLE IF NOT EXISTS public.room_experiment_runs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    anime_id bigint NOT NULL REFERENCES public.anime(id) ON DELETE CASCADE,
+    started_at timestamptz NOT NULL DEFAULT now(),
+    ended_at timestamptz,
+    created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+    ended_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+    label text CHECK (label IS NULL OR char_length(label) <= 100),
+    notes text CHECK (notes IS NULL OR char_length(notes) <= 1000),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT room_experiment_runs_time_check CHECK (ended_at IS NULL OR ended_at >= started_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS room_experiment_runs_one_active_per_anime
+    ON public.room_experiment_runs (anime_id)
+    WHERE ended_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS room_experiment_runs_started_idx
+    ON public.room_experiment_runs (started_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.room_experiment_visits (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id uuid NOT NULL REFERENCES public.room_experiment_runs(id) ON DELETE CASCADE,
+    anime_id bigint NOT NULL REFERENCES public.anime(id) ON DELETE CASCADE,
+    broadcast_room_session_id uuid NOT NULL REFERENCES public.broadcast_room_sessions(id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    client_visit_key text NOT NULL CHECK (char_length(client_visit_key) BETWEEN 1 AND 120),
+    entered_at timestamptz NOT NULL DEFAULT now(),
+    last_seen_at timestamptz NOT NULL DEFAULT now(),
+    exited_at timestamptz,
+    heartbeat_count integer NOT NULL DEFAULT 0 CHECK (heartbeat_count >= 0),
+    user_agent text CHECK (user_agent IS NULL OR char_length(user_agent) <= 500),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT room_experiment_visits_seen_check CHECK (last_seen_at >= entered_at),
+    CONSTRAINT room_experiment_visits_exit_check CHECK (exited_at IS NULL OR exited_at >= entered_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS room_experiment_visits_unique_client_visit
+    ON public.room_experiment_visits (
+        run_id,
+        user_id,
+        broadcast_room_session_id,
+        client_visit_key
+    );
+
+CREATE INDEX IF NOT EXISTS room_experiment_visits_run_session_idx
+    ON public.room_experiment_visits (run_id, broadcast_room_session_id);
+
+CREATE INDEX IF NOT EXISTS room_experiment_visits_active_idx
+    ON public.room_experiment_visits (run_id, last_seen_at DESC)
+    WHERE exited_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.touch_room_experiment_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS room_experiment_runs_touch_updated_at ON public.room_experiment_runs;
+CREATE TRIGGER room_experiment_runs_touch_updated_at
+    BEFORE UPDATE ON public.room_experiment_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_room_experiment_updated_at();
+
+DROP TRIGGER IF EXISTS room_experiment_visits_touch_updated_at ON public.room_experiment_visits;
+CREATE TRIGGER room_experiment_visits_touch_updated_at
+    BEFORE UPDATE ON public.room_experiment_visits
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_room_experiment_updated_at();
+
+CREATE OR REPLACE FUNCTION public.validate_room_experiment_visit()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+    target_run public.room_experiment_runs%ROWTYPE;
+    target_session public.broadcast_room_sessions%ROWTYPE;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        IF NEW.run_id IS DISTINCT FROM OLD.run_id
+           OR NEW.anime_id IS DISTINCT FROM OLD.anime_id
+           OR NEW.broadcast_room_session_id IS DISTINCT FROM OLD.broadcast_room_session_id
+           OR NEW.user_id IS DISTINCT FROM OLD.user_id
+           OR NEW.client_visit_key IS DISTINCT FROM OLD.client_visit_key
+           OR NEW.entered_at IS DISTINCT FROM OLD.entered_at THEN
+            RAISE EXCEPTION 'room experiment visit identity fields cannot be changed'
+                USING ERRCODE = 'check_violation';
+        END IF;
+    END IF;
+
+    SELECT * INTO target_run
+    FROM public.room_experiment_runs
+    WHERE id = NEW.run_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'room experiment run does not exist'
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    IF TG_OP = 'INSERT' AND target_run.ended_at IS NOT NULL THEN
+        RAISE EXCEPTION 'room experiment run is not active'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT * INTO target_session
+    FROM public.broadcast_room_sessions
+    WHERE id = NEW.broadcast_room_session_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'broadcast room session does not exist'
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    IF target_session.room_kind <> 'episode' THEN
+        RAISE EXCEPTION 'room experiment visits are only allowed for episode rooms'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF NEW.anime_id IS DISTINCT FROM target_run.anime_id
+       OR NEW.anime_id IS DISTINCT FROM target_session.anime_id THEN
+        RAISE EXCEPTION 'room experiment anime mismatch'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS room_experiment_visits_validate ON public.room_experiment_visits;
+CREATE TRIGGER room_experiment_visits_validate
+    BEFORE INSERT OR UPDATE ON public.room_experiment_visits
+    FOR EACH ROW
+    EXECUTE FUNCTION public.validate_room_experiment_visit();
+
+ALTER TABLE public.room_experiment_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_experiment_visits ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "room_experiment_runs_select_admin" ON public.room_experiment_runs;
+CREATE POLICY "room_experiment_runs_select_admin"
+    ON public.room_experiment_runs
+    FOR SELECT
+    TO authenticated
+    USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "room_experiment_runs_insert_admin" ON public.room_experiment_runs;
+CREATE POLICY "room_experiment_runs_insert_admin"
+    ON public.room_experiment_runs
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        created_by = auth.uid()
+        AND public.is_current_user_admin()
+    );
+
+DROP POLICY IF EXISTS "room_experiment_runs_update_admin" ON public.room_experiment_runs;
+CREATE POLICY "room_experiment_runs_update_admin"
+    ON public.room_experiment_runs
+    FOR UPDATE
+    TO authenticated
+    USING (public.is_current_user_admin())
+    WITH CHECK (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "room_experiment_visits_select_own_or_admin" ON public.room_experiment_visits;
+CREATE POLICY "room_experiment_visits_select_own_or_admin"
+    ON public.room_experiment_visits
+    FOR SELECT
+    TO authenticated
+    USING (
+        user_id = auth.uid()
+        OR public.is_current_user_admin()
+    );
+
+DROP POLICY IF EXISTS "room_experiment_visits_insert_own" ON public.room_experiment_visits;
+CREATE POLICY "room_experiment_visits_insert_own"
+    ON public.room_experiment_visits
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "room_experiment_visits_update_own" ON public.room_experiment_visits;
+CREATE POLICY "room_experiment_visits_update_own"
+    ON public.room_experiment_visits
+    FOR UPDATE
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/085_room_experiment_analytics.sql
+++ b/supabase/migrations/085_room_experiment_analytics.sql
@@ -99,7 +99,8 @@ BEGIN
 
     SELECT * INTO target_run
     FROM public.room_experiment_runs
-    WHERE id = NEW.run_id;
+    WHERE id = NEW.run_id
+    FOR UPDATE;
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'room experiment run does not exist'
@@ -187,9 +188,4 @@ CREATE POLICY "room_experiment_visits_insert_own"
     WITH CHECK (user_id = auth.uid());
 
 DROP POLICY IF EXISTS "room_experiment_visits_update_own" ON public.room_experiment_visits;
-CREATE POLICY "room_experiment_visits_update_own"
-    ON public.room_experiment_visits
-    FOR UPDATE
-    TO authenticated
-    USING (user_id = auth.uid())
-    WITH CHECK (user_id = auth.uid());
+-- Visit updates are performed only through trusted server-side API helpers.


### PR DESCRIPTION
## Summary
- 作品単位の room experiment run / visit テーブル、RLS、episode room 限定のDB制約を追加
- 放送回ルーム限定の visit / heartbeat / exit API とクライアント計測を追加
- 管理画面 `/admin/room-experiments` で対象化、停止、active run、全体/放送回別KPIを確認できるように追加
- 集計ヘルパー、型、rate limit、単体テストを追加

## Notes
- グローバルロビー、未ログイン閲覧、非対象作品、対象化前データはv1集計対象外
- 全体サマリーのUU/投稿者数はrun全体でdistinct集計
- Supabase linked schema未適用のため、`database.types.ts` はmigrationに合わせて手動補完

## Validation
- `pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json`
- `pnpm.cmd exec tsc --noEmit`
- `pnpm.cmd exec vitest run src/lib/server/room-experiment-metrics.test.ts src/lib/server/rate-limit.test.ts`
- `pnpm.cmd exec biome lint ...` targeted files