### PR TITLE
[codex] Separate room hashtags from post text

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -37,16 +37,18 @@ function fallbackRoomTag(title: string) {
 	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
 }
 
-function getRoomTagCandidates(anime: Post["anime_quote"]) {
-	if (!anime?.room_href) return [];
+function getRoomTagCandidates(post: Post) {
+	const anime = post.anime_quote;
+	if (!post.broadcast_room_session_id || !anime?.room_href) return [];
 	return [
 		...(anime.official_hashtag ?? []).map(normalizeRoomTag),
 		normalizeRoomTag(fallbackRoomTag(anime.title)),
 	].filter((tag) => tag.length > 0);
 }
 
-function hideTrailingRoomTag(content: string, anime: Post["anime_quote"]) {
-	const roomTags = getRoomTagCandidates(anime);
+function hideTrailingRoomTag(post: Post) {
+	const content = post.content;
+	const roomTags = getRoomTagCandidates(post);
 	if (roomTags.length === 0) return content;
 	const trimmed = content.trimEnd();
 	const normalized = trimmed.toLowerCase();
@@ -60,7 +62,7 @@ function hideTrailingRoomTag(content: string, anime: Post["anime_quote"]) {
 	return content;
 }
 
-const displayContent = $derived(hideTrailingRoomTag(post.content, post.anime_quote));
+const displayContent = $derived(hideTrailingRoomTag(post));
 const parts = $derived(parseContentParts(displayContent));
 const relativeTime = $derived(formatRelativeTime(post.created_at));
 const broadcastRelativeTime = $derived(

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -29,7 +29,39 @@ let {
 	broadcastStartAt = null,
 }: Props = $props();
 
-const parts = $derived(parseContentParts(post.content));
+function normalizeRoomTag(value: string) {
+	return value.trim().replace(/^#+/, "").toLowerCase();
+}
+
+function fallbackRoomTag(title: string) {
+	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
+}
+
+function getRoomTagCandidates(anime: Post["anime_quote"]) {
+	if (!anime?.room_href) return [];
+	return [
+		...(anime.official_hashtag ?? []).map(normalizeRoomTag),
+		normalizeRoomTag(fallbackRoomTag(anime.title)),
+	].filter((tag) => tag.length > 0);
+}
+
+function hideTrailingRoomTag(content: string, anime: Post["anime_quote"]) {
+	const roomTags = getRoomTagCandidates(anime);
+	if (roomTags.length === 0) return content;
+	const trimmed = content.trimEnd();
+	const normalized = trimmed.toLowerCase();
+	for (const tag of roomTags) {
+		const suffix = `#${tag}`;
+		if (!normalized.endsWith(suffix)) continue;
+		const before = trimmed.slice(0, trimmed.length - suffix.length);
+		if (before.length > 0 && !/\s$/.test(before)) continue;
+		return before.trimEnd();
+	}
+	return content;
+}
+
+const displayContent = $derived(hideTrailingRoomTag(post.content, post.anime_quote));
+const parts = $derived(parseContentParts(displayContent));
 const relativeTime = $derived(formatRelativeTime(post.created_at));
 const broadcastRelativeTime = $derived(
 	broadcastStartAt ? formatBroadcastRelativeTime(post.created_at, broadcastStartAt) : null,
@@ -50,7 +82,7 @@ const effectiveRoomContext = $derived(
 const showsContextStack = $derived(!isDetailView && (!!post.repost_context || (!!effectiveRoomContext && !insideRoom)));
 const cwContentId = $derived(`post-cw-content-${post.id}`);
 
-const isLong = $derived(post.content.length > 300 || (post.content.match(/\n/g)?.length ?? 0) >= 5);
+const isLong = $derived(displayContent.length > 300 || (displayContent.match(/\n/g)?.length ?? 0) >= 5);
 let collapsed = $state(true);
 let cwRevealed = $state(false);
 
@@ -579,7 +611,7 @@ async function submitReport() {
 								<span class="quote-preview-name">{post.display_name || post.username}</span>
 								<span class="quote-preview-at">@{post.username}</span>
 							</div>
-							<p class="quote-preview-content">{post.content}</p>
+							<p class="quote-preview-content">{displayContent}</p>
 						</div>
 						{#if quoteError}
 							<p class="flash-error" role="alert" style="margin-top:8px;">{quoteError}</p>

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -67,6 +67,7 @@ export async function insertPostWithHashtags(
 	exchangeShare: AnimeExchangeShare | null = null,
 	broadcastRoomSessionId: string | null = null,
 	cwAnimeId: string | null = null,
+	additionalHashtags: string[] = [],
 ) {
 	const moderationFailure = await ensureAccountCanWrite(supabase, userId);
 	if (moderationFailure) return moderationFailure;
@@ -109,7 +110,10 @@ export async function insertPostWithHashtags(
 	// ハッシュタグを一括登録（既存タグは ON CONFLICT DO NOTHING）。
 	// タグごとの insert+select ループは実況時の余分な往復になるため一括化している。
 	// メンション通知は DB トリガー notify_on_mention（migration 026）が生成する。
-	const tags = extractHashtags(postContent);
+	const additionalTags = additionalHashtags
+		.map((tag) => tag.trim().replace(/^#+/, "").toLowerCase())
+		.filter((tag) => tag.length > 0);
+	const tags = [...new Set([...extractHashtags(postContent), ...additionalTags])];
 	if (tags.length > 0) {
 		await supabase.from("hashtags").upsert(
 			tags.map((name) => ({ name })),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,7 @@ export interface Post {
 	reposted_by_me: boolean;
 	bookmarked_by_me: boolean;
 	anime_id: string | null;
+	broadcast_room_session_id: string | null;
 	anime_quote: AnimeQuote | null;
 	exchange_share: AnimeExchangeShare | null;
 	cw_anime_id: string | null;
@@ -380,6 +381,7 @@ export function toPost(
 		reposted_by_me: counts?.reposted_by_me ?? false,
 		bookmarked_by_me: counts?.bookmarked_by_me ?? false,
 		anime_id: raw.anime_id != null ? String(raw.anime_id) : null,
+		broadcast_room_session_id: raw.broadcast_room_session_id ?? null,
 		anime_quote: raw.anime
 			? {
 					id: String(raw.anime.id),

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -130,11 +130,12 @@ export const actions: Actions = {
 
 		const form = await request.formData();
 		const content = (form.get("content") as string | null)?.trim() ?? "";
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 		const hashtag = roomHashtag(anime);
-		const hasTag = content.toLowerCase().includes(`#${hashtag.toLowerCase()}`);
-		const finalContent = hasTag ? content : `${content} #${hashtag}`;
 
-		return insertPostWithHashtags(supabase, user.id, finalContent, null, [], anime.id, null, null, session.id);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
+			hashtag,
+		]);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -55,6 +55,18 @@ function roomHashtag(anime: Anime) {
 	return officialHashtag ?? fallbackRoomHashtag(anime.title);
 }
 
+function stripTrailingRoomHashtag(content: string, hashtag: string) {
+	const tag = normalizeHashtag(hashtag);
+	if (!tag) return content.trim();
+	const trimmed = content.trim();
+	const normalized = trimmed.toLowerCase();
+	const suffix = `#${tag}`;
+	if (!normalized.endsWith(suffix)) return trimmed;
+	const before = trimmed.slice(0, trimmed.length - suffix.length);
+	if (before.length > 0 && !/\s$/.test(before)) return trimmed;
+	return before.trimEnd();
+}
+
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
 	const { user } = await safeGetSession();
 	const anime = await getAnime(supabase, params.id, user?.id ?? null);
@@ -129,9 +141,10 @@ export const actions: Actions = {
 		}
 
 		const form = await request.formData();
-		const content = (form.get("content") as string | null)?.trim() ?? "";
-		if (!content) return fail(400, { message: "投稿内容を入力してください" });
+		const rawContent = (form.get("content") as string | null) ?? "";
 		const hashtag = roomHashtag(anime);
+		const content = stripTrailingRoomHashtag(rawContent, hashtag);
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
 		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
 			hashtag,

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -30,11 +30,7 @@ const closeMs = $derived(new Date(data.room.posting_closes_at).getTime());
 const openLeadMinutes = $derived(Math.round((scheduledMs - openMs) / (60 * 1000)));
 const roomHref = $derived(`/rooms/anime/${data.anime.id}/${data.room.date}`);
 const isGlobalLobby = $derived(data.room.kind === "global");
-const hashtagSuffix = $derived(` #${data.room.hashtag}`);
-const contentWithTag = $derived(
-	postContent.includes(`#${data.room.hashtag}`) ? postContent : postContent + hashtagSuffix,
-);
-const charCount = $derived(contentWithTag.length);
+const charCount = $derived(postContent.length);
 const overLimit = $derived(charCount > maxLen);
 // ライブ更新で受信した投稿（load 由来の data.posts とは別に保持し、ID でマージする）
 let extraPosts = $state<Post[]>([]);
@@ -335,7 +331,7 @@ function formatCompactDate(iso: string) {
 							bind:this={textareaEl}
 							class="composer-textarea"
 							name="content"
-							placeholder="#{data.room.hashtag} で実況しよう... (Shift+Enterで改行)"
+							placeholder="いまの感想を投稿... (Shift+Enterで改行)"
 							rows="3"
 							bind:value={postContent}
 							maxlength={maxLen}
@@ -359,7 +355,6 @@ function formatCompactDate(iso: string) {
 							</button>
 						</div>
 					</div>
-					<p class="composer-hint">投稿には <strong>#{data.room.hashtag}</strong> が自動で付きます。</p>
 				</form>
 			</div>
 		{:else if !data.user && status === "open"}
@@ -398,11 +393,7 @@ function formatCompactDate(iso: string) {
 		</div>
 
 		{#if allPosts.length === 0}
-			<div class="card anime-room-empty">
-				まだ実況投稿はありません。<br>
-				#{data.room.hashtag}
-				で最初の感想を残しましょう。
-			</div>
+			<div class="card anime-room-empty">まだ投稿はありません。最初の感想を残しましょう。</div>
 		{:else}
 			{#each displayedPosts as post (post.id)}
 				<div class="anime-room-post">
@@ -451,10 +442,7 @@ function formatCompactDate(iso: string) {
 						</div>
 						<div class="room-summary-muted mt-1 truncate text-xs">{broadcastMetaLine}</div>
 					</div>
-					<div class="mt-2 flex items-center justify-between gap-2">
-						<a href="/hashtag/{data.room.hashtag}" class="room-summary-link truncate text-xs">
-							#{data.room.hashtag}
-						</a>
+					<div class="mt-2 flex items-center justify-end gap-2">
 						<a href="/schedule" class="room-summary-back shrink-0 text-xs transition-colors">
 							← 週間スケジュールへ戻る
 						</a>
@@ -496,11 +484,6 @@ function formatCompactDate(iso: string) {
 	color: var(--color-text-muted);
 }
 
-.room-summary-link {
-	color: var(--color-accent);
-}
-
-.room-summary-link:hover,
 .room-summary-back:hover {
 	color: var(--color-accent-hover);
 }

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -80,11 +80,12 @@ export const actions: Actions = {
 
 		const form = await request.formData();
 		const content = (form.get("content") as string | null)?.trim() ?? "";
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 		const hashtag = roomHashtag(anime);
-		const hasTag = content.toLowerCase().includes(`#${hashtag.toLowerCase()}`);
-		const finalContent = hasTag ? content : `${content} #${hashtag}`;
 
-		return insertPostWithHashtags(supabase, user.id, finalContent, null, [], anime.id, null, null, session.id);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
+			hashtag,
+		]);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -28,6 +28,18 @@ function roomHashtag(anime: Anime) {
 	return officialHashtag ?? fallbackRoomHashtag(anime.title);
 }
 
+function stripTrailingRoomHashtag(content: string, hashtag: string) {
+	const tag = normalizeHashtag(hashtag);
+	if (!tag) return content.trim();
+	const trimmed = content.trim();
+	const normalized = trimmed.toLowerCase();
+	const suffix = `#${tag}`;
+	if (!normalized.endsWith(suffix)) return trimmed;
+	const before = trimmed.slice(0, trimmed.length - suffix.length);
+	if (before.length > 0 && !/\s$/.test(before)) return trimmed;
+	return before.trimEnd();
+}
+
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
 	const { user } = await safeGetSession();
 	const anime = await getAnime(supabase, params.id, user?.id ?? null);
@@ -79,9 +91,10 @@ export const actions: Actions = {
 		if (!session) return fail(404, { message: "総合ロビーが見つかりません" });
 
 		const form = await request.formData();
-		const content = (form.get("content") as string | null)?.trim() ?? "";
-		if (!content) return fail(400, { message: "投稿内容を入力してください" });
+		const rawContent = (form.get("content") as string | null) ?? "";
 		const hashtag = roomHashtag(anime);
+		const content = stripTrailingRoomHashtag(rawContent, hashtag);
+		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
 		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
 			hashtag,


### PR DESCRIPTION
﻿## Summary
- stop appending the room hashtag to room post text
- store the room hashtag as post hashtag metadata for search and trending
- hide legacy trailing room hashtags in PostCard while leaving room links as the timeline context
- remove room hashtag chrome from the room composer and room summary

## Why
Room posts were showing duplicated context: the room link already identified the anime room, while the auto-appended hashtag appeared as another visible tag. Inside the room, the anime context is already obvious, so the hashtag should remain metadata rather than visible text.

## Validation
- pnpm.cmd exec biome check src\lib\components\PostCard.svelte src\lib\server\actions.ts src\routes\rooms\anime\[id]\[date]\+page.server.ts src\routes\rooms\anime\[id]\[date]\+page.svelte src\routes\rooms\anime\[id]\lobby\+page.server.ts
- pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json
- git diff --check
