### PR TITLE
[codex] イレギュラー放送設定を用途別に整理

### DIFF
--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -486,7 +486,9 @@ export async function createEventAction(request: Request, supabase: SupabaseClie
 	const rawHashtag = (form.get("hashtag") as string | null)?.trim() ?? "";
 	const scheduledAtRaw = (form.get("scheduled_at") as string | null)?.trim() ?? "";
 	const durationRaw = (form.get("duration_minutes") as string | null)?.trim() ?? "";
-	const animeId = parsePositiveInt(form.get("anime_id") as string | null);
+	const animeIdRaw = (form.get("anime_id") as string | null)?.trim() ?? "";
+	const animeId = animeIdRaw ? parsePositiveInt(animeIdRaw) : null;
+	if (animeIdRaw && animeId === null) return fail(400, { message: "アニメIDの形式が正しくありません" });
 
 	if (!title) return fail(400, { message: "タイトルを入力してください" });
 	if (title.length > 100) return fail(400, { message: "タイトルは100文字以内で入力してください" });

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -486,6 +486,7 @@ export async function createEventAction(request: Request, supabase: SupabaseClie
 	const rawHashtag = (form.get("hashtag") as string | null)?.trim() ?? "";
 	const scheduledAtRaw = (form.get("scheduled_at") as string | null)?.trim() ?? "";
 	const durationRaw = (form.get("duration_minutes") as string | null)?.trim() ?? "";
+	const animeId = parsePositiveInt(form.get("anime_id") as string | null);
 
 	if (!title) return fail(400, { message: "タイトルを入力してください" });
 	if (title.length > 100) return fail(400, { message: "タイトルは100文字以内で入力してください" });
@@ -506,6 +507,11 @@ export async function createEventAction(request: Request, supabase: SupabaseClie
 		return fail(400, { message: "配信時間は正の整数で入力してください" });
 	}
 
+	if (animeId !== null) {
+		const { data: anime } = await supabase.from("anime").select("id").eq("id", animeId).maybeSingle();
+		if (!anime) return fail(400, { message: "アニメが見つかりません" });
+	}
+
 	const { data: event, error } = await supabase
 		.from("events")
 		.insert({
@@ -513,6 +519,7 @@ export async function createEventAction(request: Request, supabase: SupabaseClie
 			title,
 			description,
 			hashtag,
+			anime_id: animeId,
 			scheduled_at: scheduledAt.toISOString(),
 			duration_minutes: durationMinutes,
 		})

--- a/src/lib/server/anime-admin.ts
+++ b/src/lib/server/anime-admin.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { fail } from "@sveltejs/kit";
 import type { Database } from "$lib/supabase/database.types";
+import type { BroadcastOverrideKind } from "$lib/utils/broadcast-episodes";
 
 type AnimeWriteResult = { success: true; animeId: string } | ReturnType<typeof fail<{ message: string }>>;
 
@@ -61,6 +62,19 @@ function normalizeOptionalEpisodeIncrement(value: string | null | undefined) {
 	const increment = Number(raw);
 	if (!Number.isInteger(increment) || increment < 0 || increment > 99) return undefined;
 	return increment;
+}
+
+function normalizeOverrideKind(value: string | null | undefined): BroadcastOverrideKind {
+	switch (value) {
+		case "cancelled":
+		case "recap":
+		case "time_change":
+		case "marathon":
+		case "custom":
+			return value;
+		default:
+			return "custom";
+	}
 }
 
 function toArr(vals: FormDataEntryValue[]) {
@@ -221,7 +235,8 @@ export async function addBroadcastOverrideAction(
 		return fail(400, { message: "投稿終了の延長時間は0〜1440分の整数で入力してください" });
 	}
 
-	const isCancelled = fd.get("is_cancelled") === "on";
+	const overrideKind = normalizeOverrideKind(fd.get("override_kind") as string | null);
+	const isCancelled = overrideKind === "cancelled" || fd.get("is_cancelled") === "on";
 
 	const episodeStart = normalizeOptionalEpisode(fd.get("episode_start") as string | null);
 	if (episodeStart === undefined) {
@@ -233,7 +248,7 @@ export async function addBroadcastOverrideAction(
 		return fail(400, { message: "対象話数（終了）は1以上の整数で入力してください" });
 	}
 
-	const episodeCountIncrement = normalizeOptionalEpisodeIncrement(fd.get("episode_count_increment") as string | null);
+	let episodeCountIncrement = normalizeOptionalEpisodeIncrement(fd.get("episode_count_increment") as string | null);
 	if (episodeCountIncrement === undefined) {
 		return fail(400, { message: "話数カウントの進み方は0以上の整数で入力してください" });
 	}
@@ -246,22 +261,36 @@ export async function addBroadcastOverrideAction(
 		return fail(400, { message: "対象話数（終了）は開始以上の値を入力してください" });
 	}
 
+	let episodeLabel = nullableText(fd, "episode_label");
+	let announcementLabel = nullableText(fd, "announcement_label");
+	if (overrideKind === "recap") {
+		episodeLabel ??= "総集編";
+		episodeCountIncrement ??= 0;
+	}
+	if (overrideKind === "cancelled") {
+		announcementLabel ??= "今週は放送休止";
+	}
+	if (overrideKind === "marathon" && (episodeStart == null || episodeEnd == null)) {
+		return fail(400, { message: "一挙放送では対象話数の開始と終了を入力してください" });
+	}
+
 	// biome-ignore lint/suspicious/noExplicitAny: broadcast_room_overrides not yet in generated types
 	const writer = supabase as SupabaseClient<any>;
 	const { error } = await writer.from("broadcast_room_overrides").upsert(
 		{
 			anime_id: Number(animeId),
 			room_date: roomDate,
+			override_kind: overrideKind,
 			broadcast_time: broadcastTime,
 			duration_minutes: durationMinutes,
 			pre_open_minutes: preOpenMinutes,
 			post_close_minutes: postCloseMinutes,
 			episode_start: episodeStart,
 			episode_end: episodeEnd,
-			episode_label: nullableText(fd, "episode_label"),
+			episode_label: episodeLabel,
 			episode_count_increment: episodeCountIncrement,
 			is_cancelled: isCancelled,
-			announcement_label: nullableText(fd, "announcement_label"),
+			announcement_label: announcementLabel,
 			note: nullableText(fd, "note"),
 		},
 		{ onConflict: "anime_id,room_date" },

--- a/src/lib/server/anime-admin.ts
+++ b/src/lib/server/anime-admin.ts
@@ -270,8 +270,8 @@ export async function addBroadcastOverrideAction(
 	if (overrideKind === "cancelled") {
 		announcementLabel ??= "今週は放送休止";
 	}
-	if (overrideKind === "marathon" && (episodeStart == null || episodeEnd == null)) {
-		return fail(400, { message: "一挙放送では対象話数の開始と終了を入力してください" });
+	if (overrideKind === "marathon" && (episodeStart == null || episodeEnd == null || episodeEnd <= episodeStart)) {
+		return fail(400, { message: "一挙放送では対象話数の開始より大きい終了話数を入力してください" });
 	}
 
 	// biome-ignore lint/suspicious/noExplicitAny: broadcast_room_overrides not yet in generated types

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -64,6 +64,7 @@ type NotificationRow = {
 type EventRow = Omit<Database["public"]["Tables"]["events"]["Row"], "anime_id"> & {
 	anime_id?: number | null;
 	profiles: { username: string; display_name: string | null; avatar_url: string | null } | null;
+	anime?: { id: number; title: string; title_en: string | null; cover_url: string | null } | null;
 };
 
 type UserAnimeListWithAnimeRow = {
@@ -473,7 +474,8 @@ export async function getEventsByMonth(
 		.select(`
             id, creator_id, title, description, hashtag, anime_id,
             scheduled_at, duration_minutes, is_cancelled, created_at,
-            profiles!events_creator_id_fkey ( username, display_name, avatar_url )
+            profiles!events_creator_id_fkey ( username, display_name, avatar_url ),
+            anime:anime!events_anime_id_fkey ( id, title, title_en, cover_url )
         `)
 		.gte("scheduled_at", startOfMonth)
 		.lte("scheduled_at", endOfMonth)
@@ -493,7 +495,8 @@ export async function getEventsByRange(
 		.select(`
             id, creator_id, title, description, hashtag, anime_id,
             scheduled_at, duration_minutes, is_cancelled, created_at,
-            profiles!events_creator_id_fkey ( username, display_name, avatar_url )
+            profiles!events_creator_id_fkey ( username, display_name, avatar_url ),
+            anime:anime!events_anime_id_fkey ( id, title, title_en, cover_url )
         `)
 		.gte("scheduled_at", startIso)
 		.lte("scheduled_at", endIso)
@@ -514,7 +517,8 @@ export async function getUpcomingEvents(supabase: SupabaseClient<Database>, limi
 		.select(`
             id, creator_id, title, description, hashtag, anime_id,
             scheduled_at, duration_minutes, is_cancelled, created_at,
-            profiles!events_creator_id_fkey ( username, display_name, avatar_url )
+            profiles!events_creator_id_fkey ( username, display_name, avatar_url ),
+            anime:anime!events_anime_id_fkey ( id, title, title_en, cover_url )
         `)
 		.gte("scheduled_at", now)
 		.eq("is_cancelled", false)
@@ -534,7 +538,8 @@ export async function getEvent(supabase: SupabaseClient<Database>, eventId: stri
 		.select(`
             id, creator_id, title, description, hashtag, anime_id,
             scheduled_at, duration_minutes, is_cancelled, created_at,
-            profiles!events_creator_id_fkey ( username, display_name, avatar_url )
+            profiles!events_creator_id_fkey ( username, display_name, avatar_url ),
+            anime:anime!events_anime_id_fkey ( id, title, title_en, cover_url )
         `)
 		.eq("id", eventId)
 		.maybeSingle();
@@ -630,9 +635,11 @@ export async function getPostReplies(
 
 function toEvent(raw: EventRow): Event {
 	const profiles = raw.profiles;
+	const anime = raw.anime;
 	return {
 		id: raw.id,
 		creator_id: raw.creator_id,
+		anime_id: raw.anime_id != null ? String(raw.anime_id) : null,
 		title: raw.title,
 		description: raw.description ?? null,
 		hashtag: raw.hashtag,
@@ -640,6 +647,14 @@ function toEvent(raw: EventRow): Event {
 		duration_minutes: raw.duration_minutes ?? null,
 		is_cancelled: raw.is_cancelled,
 		created_at: raw["created_at"],
+		anime: anime
+			? {
+					id: String(anime.id),
+					title: anime.title,
+					title_en: anime.title_en ?? null,
+					cover_url: anime.cover_url ?? null,
+				}
+			: null,
 		creator_username: profiles?.username ?? "unknown",
 		creator_display_name: profiles?.display_name ?? null,
 		creator_avatar_url: profiles?.avatar_url ?? null,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -160,6 +160,7 @@ export interface Notification {
 export interface Event {
 	id: string;
 	creator_id: string;
+	anime_id: string | null;
 	title: string;
 	description: string | null;
 	hashtag: string; // # なし (例: "AnimeOP2026")
@@ -169,6 +170,12 @@ export interface Event {
 	created_at: string;
 	// JOIN で付加されるフィールド（任意）
 	creator_username?: string;
+	anime?: {
+		id: string;
+		title: string;
+		title_en: string | null;
+		cover_url: string | null;
+	} | null;
 	creator_display_name?: string | null;
 	creator_avatar_url?: string | null;
 }
@@ -538,6 +545,7 @@ export interface BroadcastRoomOverride {
 	id: string;
 	anime_id: number;
 	room_date: string;
+	override_kind: "cancelled" | "recap" | "time_change" | "marathon" | "custom";
 	broadcast_time: string | null;
 	duration_minutes: number | null;
 	pre_open_minutes: number | null;

--- a/src/lib/utils/broadcast-episodes.ts
+++ b/src/lib/utils/broadcast-episodes.ts
@@ -83,7 +83,21 @@ export function formatBroadcastOverrideKindLabel(override: BroadcastRoomOverride
 }
 
 export function formatBroadcastOverrideAnnouncement(override: BroadcastRoomOverride): string {
-	return override.announcement_label?.trim() || "今週は放送休止";
+	const customLabel = override.announcement_label?.trim();
+	if (customLabel) return customLabel;
+
+	switch (inferBroadcastOverrideKind(override)) {
+		case "cancelled":
+			return "今週は放送休止";
+		case "recap":
+			return normalizedBroadcastEpisodeLabel(override) ?? "総集編/特別編";
+		case "time_change":
+			return override.broadcast_time ? `放送時間変更：${override.broadcast_time}〜` : "放送時間変更";
+		case "marathon":
+			return formatBroadcastOverrideEpisodeSummary(override) ?? "一挙放送";
+		default:
+			return override.note?.trim() || "イレギュラー放送";
+	}
 }
 
 export function normalizedBroadcastEpisodeLabel(override: BroadcastRoomOverride | undefined): string | null {

--- a/src/lib/utils/broadcast-episodes.ts
+++ b/src/lib/utils/broadcast-episodes.ts
@@ -1,5 +1,7 @@
 import type { BroadcastRoomOverride } from "$lib/types";
 
+export type BroadcastOverrideKind = BroadcastRoomOverride["override_kind"];
+
 export interface BroadcastEpisodeSlot {
 	date: string;
 	start: number | null;
@@ -43,15 +45,80 @@ function actualBroadcastDate(roomDate: Date, broadcastTime: string | null): Date
 	return actual;
 }
 
-function normalizedLabel(override: BroadcastRoomOverride | undefined): string | null {
+export function inferBroadcastOverrideKind(override: BroadcastRoomOverride): BroadcastOverrideKind {
+	if (override.override_kind) return override.override_kind;
+	if (override.is_cancelled) return "cancelled";
+	if (
+		override.episode_start != null &&
+		override.episode_end != null &&
+		override.episode_end > override.episode_start
+	) {
+		return "marathon";
+	}
+	if (override.episode_label || override.episode_count_increment === 0) return "recap";
+	if (
+		override.broadcast_time ||
+		override.duration_minutes != null ||
+		override.pre_open_minutes != null ||
+		override.post_close_minutes != null
+	) {
+		return "time_change";
+	}
+	return "custom";
+}
+
+export function formatBroadcastOverrideKindLabel(override: BroadcastRoomOverride): string {
+	switch (inferBroadcastOverrideKind(override)) {
+		case "cancelled":
+			return "放送休止";
+		case "recap":
+			return "総集編/特別編";
+		case "time_change":
+			return "放送時間変更";
+		case "marathon":
+			return "一挙放送";
+		default:
+			return "詳細設定";
+	}
+}
+
+export function formatBroadcastOverrideAnnouncement(override: BroadcastRoomOverride): string {
+	return override.announcement_label?.trim() || "今週は放送休止";
+}
+
+export function normalizedBroadcastEpisodeLabel(override: BroadcastRoomOverride | undefined): string | null {
 	const label = override?.episode_label?.trim();
-	return label || null;
+	if (label) return label;
+	if (!override) return null;
+	if (inferBroadcastOverrideKind(override) === "recap" || override.episode_count_increment === 0) return "総集編";
+	return null;
 }
 
 function episodeIncrement(override: BroadcastRoomOverride | undefined): number {
 	if (!override) return 1;
 	if (override.episode_count_increment != null) return override.episode_count_increment;
-	return normalizedLabel(override) ? 0 : 1;
+	return normalizedBroadcastEpisodeLabel(override) ? 0 : 1;
+}
+
+export function formatBroadcastOverrideEpisodeSummary(override: BroadcastRoomOverride): string | null {
+	const label = normalizedBroadcastEpisodeLabel(override);
+	if (override.episode_start != null && override.episode_end != null) {
+		const episode =
+			override.episode_start === override.episode_end
+				? `第${override.episode_start}話`
+				: `第${override.episode_start}話〜第${override.episode_end}話`;
+		const suffix = inferBroadcastOverrideKind(override) === "marathon" ? " 一挙放送" : "";
+		return label ? `${episode}${suffix} ${label}` : `${episode}${suffix}`;
+	}
+	return label;
+}
+
+export function isMarathonEpisodeSlot(slot: BroadcastEpisodeSlot): boolean {
+	return slot.start != null && slot.end != null && slot.end !== slot.start;
+}
+
+export function formatMarathonBadge(_slot: BroadcastEpisodeSlot): string {
+	return "一挙放送";
 }
 
 export function generateBroadcastEpisodeSlots({
@@ -103,7 +170,7 @@ export function generateBroadcastEpisodeSlots({
 		.map((date): BroadcastEpisodeSlot | null => {
 			const override = overrideByDate.get(date);
 			if (override?.is_cancelled) return null;
-			const label = normalizedLabel(override);
+			const label = normalizedBroadcastEpisodeLabel(override);
 
 			if (override?.episode_start != null && override.episode_end != null) {
 				episodeCounter = override.episode_end + 1;

--- a/src/routes/anime/[id]/+page.svelte
+++ b/src/routes/anime/[id]/+page.svelte
@@ -7,7 +7,13 @@ import { page } from "$app/state";
 import AnimeRegisterForm from "$lib/components/AnimeRegisterForm.svelte";
 import MyListModal from "$lib/components/MyListModal.svelte";
 import type { BroadcastRoomOverride } from "$lib/types";
-import { formatBroadcastEpisodeNumber, formatBroadcastEpisodeSlot } from "$lib/utils/broadcast-episodes";
+import {
+	type BroadcastOverrideKind,
+	formatBroadcastEpisodeNumber,
+	formatBroadcastEpisodeSlot,
+	formatBroadcastOverrideEpisodeSummary,
+	formatBroadcastOverrideKindLabel,
+} from "$lib/utils/broadcast-episodes";
 import type { PageProps } from "./$types";
 
 interface UserResult {
@@ -150,9 +156,24 @@ let showUserListModal = $state(false);
 let adminEditOpen = $state(Boolean(form?.success || form?.message));
 let activeAdminTab = $state<"basic" | "overrides">("basic");
 let overrideFormOpen = $state(false);
+let selectedOverrideKind = $state<BroadcastOverrideKind>("cancelled");
+let overrideAdvancedOpen = $state(false);
 $effect(() => {
 	if (form?.success || form?.message) adminEditOpen = true;
 });
+
+const overrideKindOptions: { kind: BroadcastOverrideKind; label: string; description: string }[] = [
+	{ kind: "cancelled", label: "放送休止", description: "休止カードを表示" },
+	{ kind: "recap", label: "総集編/特別編", description: "話数を進めずに表示" },
+	{ kind: "time_change", label: "放送時間変更", description: "開始時刻や枠を変更" },
+	{ kind: "marathon", label: "一挙放送", description: "話数範囲をまとめて表示" },
+	{ kind: "custom", label: "詳細設定", description: "全項目を直接指定" },
+];
+
+function selectOverrideKind(kind: BroadcastOverrideKind) {
+	selectedOverrideKind = kind;
+	overrideAdvancedOpen = kind === "custom";
+}
 
 function handleUserListKeydown(event: KeyboardEvent) {
 	if (event.key === "Escape" && showUserListModal) showUserListModal = false;
@@ -873,6 +894,10 @@ $effect(() => {
 														<td class="broadcast-override-date">{override.room_date}</td>
 														<td>
 															<div class="broadcast-override-table-tags">
+																<span
+																	class="broadcast-override-tag broadcast-override-tag--kind"
+																	>{formatBroadcastOverrideKindLabel(override)}</span
+																>
 																{#if override.is_cancelled}
 																	<span class="broadcast-override-tag">放送休止</span>
 																{/if}
@@ -895,19 +920,9 @@ $effect(() => {
 														</td>
 														<td>
 															<div class="broadcast-override-table-tags">
-																{#if override.episode_start != null && override.episode_end != null}
-																	<span class="broadcast-override-tag">
-																		{#if override.episode_start === override.episode_end}
-																			第{override.episode_start}話
-																		{:else}
-																			第{override.episode_start}話〜第{override.episode_end}話
-																			一挙放送
-																		{/if}
-																	</span>
-																{/if}
-																{#if override.episode_label}
+																{#if formatBroadcastOverrideEpisodeSummary(override)}
 																	<span class="broadcast-override-tag"
-																		>{override.episode_label}</span
+																		>{formatBroadcastOverrideEpisodeSummary(override)}</span
 																	>
 																{/if}
 																{#if override.episode_count_increment != null}
@@ -978,116 +993,299 @@ $effect(() => {
 											}}
 											class="broadcast-override-form"
 										>
+											<input type="hidden" name="override_kind" value={selectedOverrideKind}>
 											<div class="broadcast-override-field">
 												<label for="override-room-date">日付</label>
 												<input id="override-room-date" type="date" name="room_date" required>
 											</div>
-											<label class="broadcast-override-checkbox">
-												<input type="checkbox" name="is_cancelled">
-												<span>放送休止として告知する</span>
-											</label>
-											<div class="broadcast-override-field">
-												<label for="override-announcement-label">告知文（任意）</label>
-												<input
-													id="override-announcement-label"
-													type="text"
-													name="announcement_label"
-													placeholder="今週は放送休止"
-												>
+											<div
+												class="broadcast-override-kind-picker"
+												role="radiogroup"
+												aria-label="シチュエーション"
+											>
+												{#each overrideKindOptions as option}
+													<button
+														type="button"
+														class="broadcast-override-kind-option"
+														class:broadcast-override-kind-option--active={selectedOverrideKind === option.kind}
+														aria-pressed={selectedOverrideKind === option.kind}
+														onclick={() => selectOverrideKind(option.kind)}
+													>
+														<span>{option.label}</span>
+														<small>{option.description}</small>
+													</button>
+												{/each}
 											</div>
-											<div class="broadcast-override-field">
-												<label for="override-broadcast-time"
-													>放送時刻（任意・未指定で通常値）</label
-												>
-												<input
-													id="override-broadcast-time"
-													type="text"
-													name="broadcast_time"
-													placeholder="23:30"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-duration">放送時間・分（任意）</label>
-												<input
-													id="override-duration"
-													type="number"
-													name="duration_minutes"
-													min="1"
-													max="1440"
-													placeholder="60"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-pre-open">投稿開始の前倒し・分（任意）</label>
-												<input
-													id="override-pre-open"
-													type="number"
-													name="pre_open_minutes"
-													min="0"
-													max="1440"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-post-close">投稿終了の延長・分（任意）</label>
-												<input
-													id="override-post-close"
-													type="number"
-													name="post_close_minutes"
-													min="0"
-													max="1440"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-episode-start">対象話数（開始・任意）</label>
-												<input
-													id="override-episode-start"
-													type="number"
-													name="episode_start"
-													min="1"
-													placeholder="1"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-episode-end">対象話数（終了・任意）</label>
-												<input
-													id="override-episode-end"
-													type="number"
-													name="episode_end"
-													min="1"
-													placeholder="2"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-episode-label">表示ラベル（任意）</label>
-												<input
-													id="override-episode-label"
-													type="text"
-													name="episode_label"
-													placeholder="総集編"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-episode-count-increment"
-													>話数カウント進行（任意・総集編は0）</label
-												>
-												<input
-													id="override-episode-count-increment"
-													type="number"
-													name="episode_count_increment"
-													min="0"
-													max="99"
-													placeholder="0"
-												>
-											</div>
-											<div class="broadcast-override-field">
-												<label for="override-note">メモ（任意）</label>
-												<input
-													id="override-note"
-													type="text"
-													name="note"
-													placeholder="1時間拡大SP"
-												>
-											</div>
+
+											{#if selectedOverrideKind === "cancelled"}
+												<div class="broadcast-override-field">
+													<label for="override-announcement-label">休止時の表示文</label>
+													<input
+														id="override-announcement-label"
+														type="text"
+														name="announcement_label"
+														placeholder="今週は放送休止"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-note">管理用メモ（任意）</label>
+													<input
+														id="override-note"
+														type="text"
+														name="note"
+														placeholder="公式X確認済み"
+													>
+												</div>
+											{:else if selectedOverrideKind === "recap"}
+												<div class="broadcast-override-field">
+													<label for="override-episode-label"
+														>話数の代わりに表示するラベル</label
+													>
+													<input
+														id="override-episode-label"
+														type="text"
+														name="episode_label"
+														value="総集編"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-episode-count-increment"
+														>話数カウント進行</label
+													>
+													<input
+														id="override-episode-count-increment"
+														type="number"
+														name="episode_count_increment"
+														min="0"
+														max="99"
+														value="0"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-note">管理用メモ（任意）</label>
+													<input
+														id="override-note"
+														type="text"
+														name="note"
+														placeholder="総集編で通常話数は進めない"
+													>
+												</div>
+											{:else if selectedOverrideKind === "time_change"}
+												<div class="broadcast-override-field">
+													<label for="override-broadcast-time">変更後の放送時刻</label>
+													<input
+														id="override-broadcast-time"
+														type="text"
+														name="broadcast_time"
+														placeholder="23:30"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-duration">放送時間・分（任意）</label>
+													<input
+														id="override-duration"
+														type="number"
+														name="duration_minutes"
+														min="1"
+														max="1440"
+														placeholder="60"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-note">管理用メモ（任意）</label>
+													<input
+														id="override-note"
+														type="text"
+														name="note"
+														placeholder="特番編成で15分押し"
+													>
+												</div>
+											{:else if selectedOverrideKind === "marathon"}
+												<div class="broadcast-override-field">
+													<label for="override-episode-start">対象話数（開始）</label>
+													<input
+														id="override-episode-start"
+														type="number"
+														name="episode_start"
+														min="1"
+														placeholder="1"
+														required
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-episode-end">対象話数（終了）</label>
+													<input
+														id="override-episode-end"
+														type="number"
+														name="episode_end"
+														min="1"
+														placeholder="3"
+														required
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-broadcast-time">放送時刻（任意）</label>
+													<input
+														id="override-broadcast-time"
+														type="text"
+														name="broadcast_time"
+														placeholder="23:30"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-duration">放送時間・分（任意）</label>
+													<input
+														id="override-duration"
+														type="number"
+														name="duration_minutes"
+														min="1"
+														max="1440"
+														placeholder="90"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-note">管理用メモ（任意）</label>
+													<input
+														id="override-note"
+														type="text"
+														name="note"
+														placeholder="第1話〜第3話"
+													>
+												</div>
+											{:else}
+												<label class="broadcast-override-checkbox">
+													<input type="checkbox" name="is_cancelled">
+													<span>放送休止として告知する</span>
+												</label>
+												<div class="broadcast-override-field">
+													<label for="override-announcement-label"
+														>休止時の表示文（任意）</label
+													>
+													<input
+														id="override-announcement-label"
+														type="text"
+														name="announcement_label"
+														placeholder="今週は放送休止"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-broadcast-time"
+														>放送時刻（任意・未指定で通常値）</label
+													>
+													<input
+														id="override-broadcast-time"
+														type="text"
+														name="broadcast_time"
+														placeholder="23:30"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-duration">放送時間・分（任意）</label>
+													<input
+														id="override-duration"
+														type="number"
+														name="duration_minutes"
+														min="1"
+														max="1440"
+														placeholder="60"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-episode-start">対象話数（開始・任意）</label>
+													<input
+														id="override-episode-start"
+														type="number"
+														name="episode_start"
+														min="1"
+														placeholder="1"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-episode-end">対象話数（終了・任意）</label>
+													<input
+														id="override-episode-end"
+														type="number"
+														name="episode_end"
+														min="1"
+														placeholder="2"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-episode-label"
+														>話数の代わりに表示するラベル（任意）</label
+													>
+													<input
+														id="override-episode-label"
+														type="text"
+														name="episode_label"
+														placeholder="総集編"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-episode-count-increment"
+														>話数カウント進行（任意）</label
+													>
+													<input
+														id="override-episode-count-increment"
+														type="number"
+														name="episode_count_increment"
+														min="0"
+														max="99"
+														placeholder="0"
+													>
+												</div>
+												<div class="broadcast-override-field">
+													<label for="override-note">管理用メモ（任意）</label>
+													<input
+														id="override-note"
+														type="text"
+														name="note"
+														placeholder="1時間拡大SP"
+													>
+												</div>
+											{/if}
+
+											{#if selectedOverrideKind !== "custom"}
+												<div class="broadcast-override-advanced-toggle">
+													<button
+														type="button"
+														class="broadcast-override-secondary"
+														onclick={() => (overrideAdvancedOpen = !overrideAdvancedOpen)}
+														aria-expanded={overrideAdvancedOpen}
+													>
+														詳細設定
+													</button>
+												</div>
+											{/if}
+
+											{#if overrideAdvancedOpen}
+												<div class="broadcast-override-advanced-fields">
+													<div class="broadcast-override-field">
+														<label for="override-pre-open"
+															>投稿開始の前倒し・分（任意）</label
+														>
+														<input
+															id="override-pre-open"
+															type="number"
+															name="pre_open_minutes"
+															min="0"
+															max="1440"
+														>
+													</div>
+													<div class="broadcast-override-field">
+														<label for="override-post-close"
+															>投稿終了の延長・分（任意）</label
+														>
+														<input
+															id="override-post-close"
+															type="number"
+															name="post_close_minutes"
+															min="0"
+															max="1440"
+														>
+													</div>
+												</div>
+											{/if}
 											<div class="broadcast-override-form-actions">
 												<button type="submit" class="broadcast-override-submit">登録</button>
 												<button
@@ -1813,6 +2011,10 @@ $effect(() => {
 	color: #d4d4d8;
 	font-size: 0.76rem;
 }
+.broadcast-override-tag--kind {
+	border-color: color-mix(in srgb, var(--accent) 55%, #3f3f46);
+	color: var(--accent);
+}
 .broadcast-override-note {
 	color: #a1a1aa;
 	font-size: 0.8rem;
@@ -1876,6 +2078,45 @@ $effect(() => {
 	grid-template-columns: repeat(1, minmax(0, 1fr));
 	gap: 12px;
 }
+.broadcast-override-kind-picker,
+.broadcast-override-advanced-toggle,
+.broadcast-override-advanced-fields {
+	grid-column: 1 / -1;
+}
+.broadcast-override-kind-picker {
+	display: grid;
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+	gap: 8px;
+}
+.broadcast-override-kind-option {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
+	min-height: 56px;
+	padding: 9px 11px;
+	border: 1px solid #3f3f46;
+	border-radius: 8px;
+	background: #18181b;
+	color: #f4f4f5;
+	text-align: left;
+	cursor: pointer;
+}
+.broadcast-override-kind-option span {
+	font-size: 0.86rem;
+	font-weight: 700;
+}
+.broadcast-override-kind-option small {
+	font-size: 0.72rem;
+	color: #a1a1aa;
+}
+.broadcast-override-kind-option--active {
+	border-color: var(--accent);
+	background: color-mix(in srgb, var(--accent) 14%, #18181b);
+}
+.broadcast-override-kind-option--active small {
+	color: #d4d4d8;
+}
 .broadcast-override-field {
 	display: flex;
 	flex-direction: column;
@@ -1906,6 +2147,34 @@ $effect(() => {
 	width: 16px;
 	height: 16px;
 	accent-color: var(--accent);
+}
+.broadcast-override-advanced-toggle {
+	display: flex;
+	justify-content: flex-start;
+}
+.broadcast-override-secondary {
+	min-height: 34px;
+	padding: 0 12px;
+	border: 1px solid #3f3f46;
+	border-radius: 7px;
+	background: transparent;
+	color: #d4d4d8;
+	font-size: 0.8rem;
+	font-weight: 700;
+	cursor: pointer;
+}
+.broadcast-override-secondary:hover {
+	background: #27272a;
+	color: #f4f4f5;
+}
+.broadcast-override-advanced-fields {
+	display: grid;
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+	gap: 12px;
+	padding: 12px;
+	border: 1px dashed #3f3f46;
+	border-radius: 9px;
+	background: #0c0c0e;
 }
 .broadcast-override-form-actions {
 	grid-column: 1 / -1;
@@ -1954,6 +2223,12 @@ $effect(() => {
 
 @media (min-width: 768px) {
 	.broadcast-override-form {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	.broadcast-override-kind-picker {
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+	}
+	.broadcast-override-advanced-fields {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 }

--- a/src/routes/anime/[id]/+page.svelte
+++ b/src/routes/anime/[id]/+page.svelte
@@ -993,7 +993,6 @@ $effect(() => {
 											}}
 											class="broadcast-override-form"
 										>
-											<input type="hidden" name="override_kind" value={selectedOverrideKind}>
 											<div class="broadcast-override-field">
 												<label for="override-room-date">日付</label>
 												<input id="override-room-date" type="date" name="room_date" required>
@@ -1004,16 +1003,20 @@ $effect(() => {
 												aria-label="シチュエーション"
 											>
 												{#each overrideKindOptions as option}
-													<button
-														type="button"
+													<label
 														class="broadcast-override-kind-option"
 														class:broadcast-override-kind-option--active={selectedOverrideKind === option.kind}
-														aria-pressed={selectedOverrideKind === option.kind}
-														onclick={() => selectOverrideKind(option.kind)}
 													>
+														<input
+															type="radio"
+															name="override_kind"
+															value={option.kind}
+															checked={selectedOverrideKind === option.kind}
+															onchange={() => selectOverrideKind(option.kind)}
+														>
 														<span>{option.label}</span>
 														<small>{option.description}</small>
-													</button>
+													</label>
 												{/each}
 											</div>
 
@@ -1976,16 +1979,16 @@ $effect(() => {
 .broadcast-override-table th,
 .broadcast-override-table td {
 	padding: 10px 12px;
-	border-bottom: 1px solid #27272a;
+	border-bottom: 1px solid var(--border);
 	text-align: left;
 	vertical-align: middle;
 }
 .broadcast-override-table th {
-	color: #a1a1aa;
+	color: var(--text-muted);
 	font-size: 0.72rem;
 	font-weight: 700;
 	letter-spacing: 0.04em;
-	background: #18181b;
+	background: var(--hover-bg);
 }
 .broadcast-override-table tr:last-child td {
 	border-bottom: 0;
@@ -1998,31 +2001,31 @@ $effect(() => {
 }
 .broadcast-override-date {
 	font-weight: 600;
-	color: #f4f4f5;
+	color: var(--text);
 }
 .broadcast-override-tag {
 	display: inline-flex;
 	align-items: center;
 	min-height: 22px;
 	padding: 2px 8px;
-	border: 1px solid #3f3f46;
+	border: 1px solid var(--border);
 	border-radius: 999px;
-	background: #18181b;
-	color: #d4d4d8;
+	background: var(--card-bg);
+	color: var(--text-muted);
 	font-size: 0.76rem;
 }
 .broadcast-override-tag--kind {
-	border-color: color-mix(in srgb, var(--accent) 55%, #3f3f46);
+	border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
 	color: var(--accent);
 }
 .broadcast-override-note {
-	color: #a1a1aa;
+	color: var(--text-muted);
 	font-size: 0.8rem;
 	font-style: italic;
 }
 .broadcast-override-empty,
 .broadcast-override-empty-row {
-	color: #71717a;
+	color: var(--text-muted);
 }
 .broadcast-override-empty-row {
 	padding: 18px 12px;
@@ -2033,9 +2036,9 @@ $effect(() => {
 	white-space: nowrap;
 }
 .broadcast-override-delete {
-	border: 1px solid #3f3f46;
-	background: #18181b;
-	color: #f4f4f5;
+	border: 1px solid var(--border);
+	background: var(--card-bg);
+	color: var(--text);
 	border-radius: 6px;
 	padding: 4px 10px;
 	font-size: 0.78rem;
@@ -2049,10 +2052,10 @@ $effect(() => {
 	align-self: flex-start;
 	min-height: 40px;
 	padding: 0 16px;
-	border: 1px solid #3f3f46;
+	border: 1px solid var(--border);
 	border-radius: 9px;
-	background: #18181b;
-	color: #f4f4f5;
+	background: var(--card-bg);
+	color: var(--text);
 	font-size: 0.86rem;
 	font-weight: 700;
 	cursor: pointer;
@@ -2064,14 +2067,14 @@ $effect(() => {
 .broadcast-override-add-toggle:hover {
 	border-color: var(--accent);
 	color: var(--accent);
-	background: #27272a;
+	background: var(--hover-bg);
 }
 .broadcast-override-accordion {
 	animation: override-form-enter 0.18s ease-out;
 	padding: 14px;
-	border: 1px solid #27272a;
+	border: 1px solid var(--border);
 	border-radius: 12px;
-	background: #111113;
+	background: var(--card-bg);
 }
 .broadcast-override-form {
 	display: grid;
@@ -2089,18 +2092,29 @@ $effect(() => {
 	gap: 8px;
 }
 .broadcast-override-kind-option {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
 	gap: 2px;
 	min-height: 56px;
 	padding: 9px 11px;
-	border: 1px solid #3f3f46;
+	border: 1px solid var(--border);
 	border-radius: 8px;
-	background: #18181b;
-	color: #f4f4f5;
+	background: var(--card-bg);
+	color: var(--text);
 	text-align: left;
 	cursor: pointer;
+}
+.broadcast-override-kind-option input {
+	position: absolute;
+	inset: 0;
+	opacity: 0;
+	cursor: pointer;
+}
+.broadcast-override-kind-option:focus-within {
+	outline: 2px solid color-mix(in srgb, var(--accent) 70%, transparent);
+	outline-offset: 2px;
 }
 .broadcast-override-kind-option span {
 	font-size: 0.86rem;
@@ -2108,14 +2122,14 @@ $effect(() => {
 }
 .broadcast-override-kind-option small {
 	font-size: 0.72rem;
-	color: #a1a1aa;
+	color: var(--text-muted);
 }
 .broadcast-override-kind-option--active {
 	border-color: var(--accent);
-	background: color-mix(in srgb, var(--accent) 14%, #18181b);
+	background: color-mix(in srgb, var(--accent) 14%, var(--card-bg));
 }
 .broadcast-override-kind-option--active small {
-	color: #d4d4d8;
+	color: var(--text);
 }
 .broadcast-override-field {
 	display: flex;
@@ -2124,15 +2138,15 @@ $effect(() => {
 }
 .broadcast-override-field label {
 	font-size: 0.75rem;
-	color: #a1a1aa;
+	color: var(--text-muted);
 }
 .broadcast-override-field input {
 	height: 36px;
 	padding: 0 10px;
 	border-radius: 6px;
-	border: 1px solid #3f3f46;
-	background: #09090b;
-	color: #f4f4f5;
+	border: 1px solid var(--border);
+	background: var(--card-bg);
+	color: var(--text);
 	font-size: 0.85rem;
 }
 .broadcast-override-checkbox {
@@ -2141,7 +2155,7 @@ $effect(() => {
 	gap: 8px;
 	min-height: 36px;
 	font-size: 0.82rem;
-	color: #f4f4f5;
+	color: var(--text);
 }
 .broadcast-override-checkbox input {
 	width: 16px;
@@ -2155,26 +2169,26 @@ $effect(() => {
 .broadcast-override-secondary {
 	min-height: 34px;
 	padding: 0 12px;
-	border: 1px solid #3f3f46;
+	border: 1px solid var(--border);
 	border-radius: 7px;
 	background: transparent;
-	color: #d4d4d8;
+	color: var(--text-muted);
 	font-size: 0.8rem;
 	font-weight: 700;
 	cursor: pointer;
 }
 .broadcast-override-secondary:hover {
-	background: #27272a;
-	color: #f4f4f5;
+	background: var(--hover-bg);
+	color: var(--text);
 }
 .broadcast-override-advanced-fields {
 	display: grid;
 	grid-template-columns: repeat(1, minmax(0, 1fr));
 	gap: 12px;
 	padding: 12px;
-	border: 1px dashed #3f3f46;
+	border: 1px dashed var(--border);
 	border-radius: 9px;
-	background: #0c0c0e;
+	background: var(--hover-bg);
 }
 .broadcast-override-form-actions {
 	grid-column: 1 / -1;
@@ -2201,13 +2215,13 @@ $effect(() => {
 	opacity: 0.9;
 }
 .broadcast-override-cancel {
-	border: 1px solid #3f3f46;
+	border: 1px solid var(--border);
 	background: transparent;
-	color: #d4d4d8;
+	color: var(--text-muted);
 }
 .broadcast-override-cancel:hover {
-	background: #27272a;
-	color: #f4f4f5;
+	background: var(--hover-bg);
+	color: var(--text);
 }
 
 @keyframes override-form-enter {

--- a/src/routes/events/[id]/+page.server.ts
+++ b/src/routes/events/[id]/+page.server.ts
@@ -31,19 +31,22 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 
 export const actions: Actions = {
 	// イベントルームへの投稿（ハッシュタグを自動付与）
-	createPost: async ({ request, locals: { supabase, safeGetSession } }) => {
+	createPost: async ({ request, params, locals: { supabase, safeGetSession } }) => {
 		const { user } = await safeGetSession();
 		if (!user) return fail(401, { message: "ログインが必要です" });
 
 		const form = await request.formData();
 		const content = (form.get("content") as string | null)?.trim() ?? "";
-		const hashtag = (form.get("hashtag") as string | null)?.trim() ?? "";
+		const event = await getEvent(supabase, params.id);
+		if (!event) return fail(404, { message: "イベントが見つかりません" });
+		const hashtag = event.hashtag;
+		const animeId = event.anime_id;
 
 		// ハッシュタグが含まれていなければ自動付与
 		const hasTag = content.toLowerCase().includes(`#${hashtag.toLowerCase()}`);
 		const finalContent = hasTag ? content : `${content} #${hashtag}`;
 
-		return insertPostWithHashtags(supabase, user.id, finalContent);
+		return insertPostWithHashtags(supabase, user.id, finalContent, null, [], animeId);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/events/[id]/+page.server.ts
+++ b/src/routes/events/[id]/+page.server.ts
@@ -8,6 +8,7 @@ import {
 } from "$lib/server/actions";
 import { getAnimeRankingTrending, getEvent, getEventPosts } from "$lib/server/queries";
 import type { Post } from "$lib/types";
+import { extractHashtags } from "$lib/utils/hashtag";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
@@ -43,10 +44,12 @@ export const actions: Actions = {
 		const animeId = event.anime_id;
 
 		// ハッシュタグが含まれていなければ自動付与
-		const hasTag = content.toLowerCase().includes(`#${hashtag.toLowerCase()}`);
+		const hasTag = extractHashtags(content).includes(hashtag.toLowerCase());
 		const finalContent = hasTag ? content : `${content} #${hashtag}`;
 
-		return insertPostWithHashtags(supabase, user.id, finalContent, null, [], animeId);
+		return insertPostWithHashtags(supabase, user.id, finalContent, null, [], animeId, null, null, null, null, [
+			hashtag,
+		]);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/events/[id]/+page.svelte
+++ b/src/routes/events/[id]/+page.svelte
@@ -104,7 +104,6 @@ function formatDate(iso: string): string {
 						{#if data.event.duration_minutes}
 							<span>・{data.event.duration_minutes}分</span>
 						{/if}
-						<span>・主催: @{data.event.creator_username}</span>
 					</div>
 				</div>
 			</div>

--- a/src/routes/schedule/+page.server.ts
+++ b/src/routes/schedule/+page.server.ts
@@ -11,6 +11,7 @@ import {
 	isAdminUser,
 } from "$lib/server/queries";
 import type { Anime, BroadcastNotificationSettings, BroadcastRoomOverride, Event } from "$lib/types";
+import { formatBroadcastOverrideAnnouncement } from "$lib/utils/broadcast-episodes";
 import {
 	broadcastTimeSortValue,
 	effectiveBroadcastTime,
@@ -72,7 +73,7 @@ function isAnimeOnAirDate(anime: Anime, date: string) {
 }
 
 function announcementMessage(override: BroadcastRoomOverride): string {
-	return override.announcement_label?.trim() || "今週は放送休止";
+	return formatBroadcastOverrideAnnouncement(override);
 }
 
 function pushAnnouncement(

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -3,7 +3,12 @@ import type { SubmitFunction } from "@sveltejs/kit";
 import { untrack } from "svelte";
 import { enhance } from "$app/forms";
 import type { Anime, BroadcastRoomOverride } from "$lib/types";
-import { type BroadcastEpisodeSlot, resolveBroadcastEpisodeSlot } from "$lib/utils/broadcast-episodes";
+import {
+	type BroadcastEpisodeSlot,
+	formatMarathonBadge,
+	isMarathonEpisodeSlot,
+	resolveBroadcastEpisodeSlot,
+} from "$lib/utils/broadcast-episodes";
 import {
 	broadcastTimeMinutes,
 	effectiveBroadcastTime as resolveEffectiveBroadcastTime,
@@ -15,8 +20,20 @@ import type { ActionData, PageProps } from "./$types";
 
 let { data, form }: PageProps & { form: ActionData } = $props();
 
+interface AnimeSearchResult {
+	id: string;
+	title: string;
+	title_en: string | null;
+	cover_url: string | null;
+}
+
 let showEventDialog = $state(false);
 let openAlertMenu = $state<string | null>(null);
+let eventAnimeQuery = $state("");
+let eventAnimeResults = $state<AnimeSearchResult[]>([]);
+let eventAnimeSearching = $state(false);
+let selectedEventAnime = $state<AnimeSearchResult | null>(null);
+let eventAnimeSearchDebounce: ReturnType<typeof setTimeout> | null = null;
 
 // Notification subscription state — optimistic, keyed by anime.id
 let subscribedIds = $state(new Set<string>(untrack(() => data.subscriptions)));
@@ -33,8 +50,7 @@ function getDefaultDayIndex(): number {
 	return getCurrentBroadcastDate().getDay();
 }
 function getDisplayDayOrder(): number[] {
-	const today = getCurrentBroadcastDate().getDay();
-	return Array.from({ length: 7 }, (_, i) => (today - 3 + i + 7) % 7);
+	return data.days.map((_, index) => index);
 }
 
 function getCurrentBroadcastDate(now = new Date()): Date {
@@ -42,35 +58,6 @@ function getCurrentBroadcastDate(now = new Date()): Date {
 	// Late-night broadcasts through 28:00 (04:00 next day) belong to the previous broadcast date.
 	if (date.getHours() < 4) date.setDate(date.getDate() - 1);
 	return date;
-}
-
-function toDateInputValue(date: Date): string {
-	const y = date.getFullYear();
-	const m = String(date.getMonth() + 1).padStart(2, "0");
-	const d = String(date.getDate()).padStart(2, "0");
-	return `${y}-${m}-${d}`;
-}
-
-function addDays(date: Date, days: number): Date {
-	const next = new Date(date);
-	next.setDate(next.getDate() + days);
-	return next;
-}
-
-function getWeekCenterDate(): Date {
-	// Anchor the rolling 7-day window to the displayed week instead of the
-	// real-world today, so week navigation updates the dates. The center is the
-	// day in the displayed week that matches today's weekday (the default
-	// selected day), keeping the current week's dates identical to before.
-	const weekStart = new Date(`${data.weekStart}T00:00:00`);
-	return addDays(weekStart, getCurrentBroadcastDate().getDay());
-}
-
-function getDisplayDateForDay(dayIdx: number, fallbackDate: string): string {
-	const displayPos = getDisplayDayOrder().indexOf(dayIdx);
-	if (displayPos === -1) return fallbackDate;
-
-	return toDateInputValue(addDays(getWeekCenterDate(), displayPos - 3));
 }
 
 function getDisplayDayItems() {
@@ -81,7 +68,7 @@ function getDisplayDayItems() {
 			return {
 				dayIdx,
 				day,
-				date: getDisplayDateForDay(dayIdx, day.date),
+				date: day.date,
 			};
 		})
 		.filter((item): item is NonNullable<typeof item> => item !== null);
@@ -128,6 +115,45 @@ function formatShortDate(value: string): string {
 
 function formatTime(iso: string) {
 	return new Date(iso).toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
+}
+
+function openEventDialog() {
+	showEventDialog = true;
+	eventAnimeQuery = "";
+	eventAnimeResults = [];
+	eventAnimeSearching = false;
+	selectedEventAnime = null;
+}
+
+function selectEventAnime(anime: AnimeSearchResult) {
+	selectedEventAnime = anime;
+	eventAnimeQuery = "";
+	eventAnimeResults = [];
+}
+
+function clearEventAnime() {
+	selectedEventAnime = null;
+	eventAnimeQuery = "";
+	eventAnimeResults = [];
+}
+
+function handleEventAnimeQueryInput() {
+	if (eventAnimeSearchDebounce) clearTimeout(eventAnimeSearchDebounce);
+	if (eventAnimeQuery.trim().length === 0) {
+		eventAnimeResults = [];
+		eventAnimeSearching = false;
+		return;
+	}
+	eventAnimeSearchDebounce = setTimeout(async () => {
+		eventAnimeSearching = true;
+		try {
+			const res = await fetch(`/api/anime/search?q=${encodeURIComponent(eventAnimeQuery.trim())}`);
+			eventAnimeResults = res.ok ? await res.json() : [];
+		} catch {
+			eventAnimeResults = [];
+		}
+		eventAnimeSearching = false;
+	}, 300);
 }
 
 function effectiveBroadcastTime(anime: Anime, dateStr: string): string | null {
@@ -386,7 +412,7 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 				<button
 					type="button"
 					class="btn btn-primary create-event-btn"
-					onclick={() => (showEventDialog = true)}
+					onclick={openEventDialog}
 					aria-label="イベント作成"
 				>
 					<span class="i-lucide-calendar-plus" aria-hidden="true"></span>
@@ -417,7 +443,7 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 
 	<div class="schedule-grid">
 		{#each data.days as day, d}
-			{@const displayDate = d === selectedDayIndex ? getDisplayDateForDay(d, day.date) : day.date}
+			{@const displayDate = day.date}
 			<div class="day-col" class:day-col--selected={d === selectedDayIndex}>
 				<div class="day-heading" style="color: {DAY_COLOR[d]}; background: {DAY_BG[d]}">
 					<span>{day.label}曜日</span>
@@ -433,10 +459,25 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 								class="event-slot"
 								class:event-slot--cancelled={event.is_cancelled}
 							>
-								<span class="slot-kind">EVENT</span>
-								<span class="slot-time">{formatTime(event.scheduled_at)}</span>
-								<span class="slot-title">{event.title}</span>
-								<span class="slot-station">#{event.hashtag}</span>
+								<div class="slot-cover-wrap">
+									{#if event.anime?.cover_url}
+										<img src={event.anime.cover_url} alt={event.anime.title} class="slot-cover">
+									{:else}
+										<div class="slot-cover slot-cover--event-placeholder">
+											<span class="i-lucide-calendar-days" aria-hidden="true"></span>
+										</div>
+									{/if}
+								</div>
+								<div class="slot-info">
+									<div class="slot-meta-row">
+										<span class="slot-time slot-time--event">{formatTime(event.scheduled_at)}</span>
+										<span class="slot-kind slot-kind--event">EVENT</span>
+									</div>
+									<span class="slot-title">{event.title}</span>
+									<span class="slot-bottom"
+										>{[event.anime?.title, `#${event.hashtag}`].filter(Boolean).join(" ・ ")}</span
+									>
+								</div>
 							</a>
 						{/each}
 
@@ -476,9 +517,11 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 										{@const roomMute = roomMuteSettings[anime.id]}
 										{@const subscribable = canSubscribe(anime)}
 										{@const ep = currentEpisodeForSlot(anime, displayDate, data.broadcastOverrides[anime.id])}
-										{@const isMarathon = ep !== null && ep.start != null && ep.end != null && ep.end !== ep.start}
+										{@const isMarathon = ep !== null && isMarathonEpisodeSlot(ep)}
 										{@const epBadge = ep !== null ? formatEpisodeBadge(ep, anime.episode_count) : null}
-										{@const episodeLabel = epBadge !== null ? (anime.episode_count ? epBadge : `#${epBadge}`) : null}
+										{@const specialEpisodeLabel = ep !== null && ep.start == null && ep.end == null ? ep.label : null}
+										{@const episodeLabel =
+											epBadge !== null && specialEpisodeLabel === null ? (anime.episode_count ? epBadge : `#${epBadge}`) : null}
 										{@const stationLabel = anime.broadcast_station?.length ? anime.broadcast_station.join(" / ") : null}
 										<div
 											class="anime-slot-wrap"
@@ -503,9 +546,14 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 														{/if}
 													</div>
 													<span class="slot-title">{anime.title}</span>
-													{#if isMarathon}
+													{#if isMarathon && ep}
 														<span class="slot-marathon-badge"
-															>第{ep?.start}話〜第{ep?.end}話 一挙放送</span
+															>{formatMarathonBadge(ep)}</span
+														>
+													{/if}
+													{#if specialEpisodeLabel}
+														<span class="slot-special-label-badge"
+															>{specialEpisodeLabel}</span
 														>
 													{/if}
 													{#if episodeLabel || stationLabel}
@@ -775,6 +823,68 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 					<span>ハッシュタグ</span>
 					<input class="input" type="text" name="hashtag" required maxlength="50" placeholder="Anipolis視聴">
 				</label>
+				<div class="event-anime-field">
+					<span class="event-form-label">対象アニメ</span>
+					{#if selectedEventAnime}
+						<input type="hidden" name="anime_id" value={selectedEventAnime.id}>
+						<div class="event-anime-selected">
+							{#if selectedEventAnime.cover_url}
+								<img src={selectedEventAnime.cover_url} alt={selectedEventAnime.title}>
+							{:else}
+								<div class="event-anime-thumb-empty"></div>
+							{/if}
+							<div>
+								<strong>{selectedEventAnime.title}</strong>
+								{#if selectedEventAnime.title_en}
+									<span>{selectedEventAnime.title_en}</span>
+								{/if}
+							</div>
+							<button
+								type="button"
+								class="event-anime-clear"
+								onclick={clearEventAnime}
+								aria-label="対象アニメを解除"
+							>
+								<span class="i-lucide-x" aria-hidden="true"></span>
+							</button>
+						</div>
+					{:else}
+						<input
+							class="input"
+							type="search"
+							placeholder="アニメタイトルで検索"
+							bind:value={eventAnimeQuery}
+							oninput={handleEventAnimeQueryInput}
+						>
+						{#if eventAnimeSearching || eventAnimeResults.length > 0}
+							<div class="event-anime-results" aria-live="polite" aria-busy={eventAnimeSearching}>
+								{#if eventAnimeSearching}
+									<p>検索中...</p>
+								{:else}
+									{#each eventAnimeResults as anime}
+										<button
+											type="button"
+											class="event-anime-result"
+											onclick={() => selectEventAnime(anime)}
+										>
+											{#if anime.cover_url}
+												<img src={anime.cover_url} alt={anime.title}>
+											{:else}
+												<div class="event-anime-thumb-empty"></div>
+											{/if}
+											<span>
+												<strong>{anime.title}</strong>
+												{#if anime.title_en}
+													<small>{anime.title_en}</small>
+												{/if}
+											</span>
+										</button>
+									{/each}
+								{/if}
+							</div>
+						{/if}
+					{/if}
+				</div>
 				<label>
 					<span>説明</span>
 					<textarea class="input" name="description" rows="3" placeholder="放映時間や対象話数など"></textarea>
@@ -941,8 +1051,10 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	align-items: stretch;
 }
 .event-slot {
-	gap: 7px;
-	height: 76px;
+	height: 86px;
+	padding: 4px 4px 4px 0;
+	gap: 0;
+	align-items: stretch;
 }
 .anime-slot-wrap .anime-slot {
 	border: none;
@@ -952,8 +1064,6 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	background: var(--color-surface-hover);
 }
 .event-slot {
-	flex-direction: column;
-	gap: 2px;
 	border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border));
 }
 
@@ -976,6 +1086,15 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 }
 .slot-cover--placeholder {
 	background: var(--color-border);
+}
+.slot-cover--event-placeholder {
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: color-mix(in srgb, #f97316 16%, var(--color-surface));
+	color: #f97316;
+	font-size: 1rem;
 }
 .anime-slot-wrap--suspension {
 	opacity: 0.5;
@@ -1076,6 +1195,9 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	color: var(--color-text-muted);
 	letter-spacing: 0;
 }
+.slot-kind--event {
+	color: #f97316;
+}
 @keyframes live-pulse {
 	0%,
 	100% {
@@ -1089,6 +1211,9 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	font-size: 0.72rem;
 	font-weight: 700;
 	color: var(--color-accent);
+}
+.slot-time--event {
+	color: #f97316;
 }
 .slot-title {
 	font-size: 0.73rem;
@@ -1104,25 +1229,17 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	text-overflow: ellipsis;
 	word-break: break-word;
 }
-.slot-station {
-	font-size: 0.7rem;
-	color: var(--color-text-muted);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	max-width: 100%;
-}
-.slot-marathon-badge {
+.slot-marathon-badge,
+.slot-special-label-badge {
 	display: inline-block;
 	font-size: 0.62rem;
 	font-weight: 700;
 	color: var(--accent);
-	background: color-mix(in srgb, var(--accent) 14%, transparent);
-	border-radius: 3px;
-	padding: 1px 4px;
+	line-height: 1.15;
+	margin-top: 3px;
+	padding: 0;
 	width: fit-content;
 }
-
 /* Notification and spoiler mute menu */
 .room-alert-control {
 	position: absolute;
@@ -1383,6 +1500,96 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	font-weight: 700;
 	color: var(--color-text-muted);
 }
+.event-anime-field {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+.event-form-label {
+	font-size: 0.75rem;
+	font-weight: 700;
+	color: var(--color-text-muted);
+}
+.event-anime-selected,
+.event-anime-result {
+	display: grid;
+	grid-template-columns: 40px minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	border: 1px solid var(--color-border);
+	border-radius: 6px;
+	background: var(--color-surface);
+	color: var(--color-text);
+}
+.event-anime-selected {
+	padding: 6px;
+}
+.event-anime-selected img,
+.event-anime-result img,
+.event-anime-thumb-empty {
+	width: 40px;
+	height: 54px;
+	border-radius: 4px;
+	object-fit: cover;
+	background: var(--color-border);
+}
+.event-anime-selected div,
+.event-anime-result span {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+.event-anime-selected strong,
+.event-anime-result strong {
+	font-size: 0.78rem;
+	line-height: 1.3;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.event-anime-selected span,
+.event-anime-result small {
+	font-size: 0.68rem;
+	font-weight: 500;
+	color: var(--color-text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.event-anime-clear {
+	width: 28px;
+	height: 28px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 5px;
+	color: var(--color-text-muted);
+}
+.event-anime-clear:hover,
+.event-anime-result:hover {
+	background: var(--color-surface-hover);
+	color: var(--color-text);
+}
+.event-anime-results {
+	max-height: 220px;
+	overflow: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+.event-anime-results p {
+	margin: 0;
+	font-size: 0.75rem;
+	color: var(--color-text-muted);
+}
+.event-anime-result {
+	grid-template-columns: 40px minmax(0, 1fr);
+	padding: 6px;
+	text-align: left;
+	cursor: pointer;
+}
 .event-form textarea {
 	resize: vertical;
 }
@@ -1504,6 +1711,9 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	.anime-slot {
 		height: 98px;
 		padding: 4px 4px 4px 0;
+	}
+	.event-slot {
+		height: 98px;
 	}
 	.slot-cover-wrap {
 		width: 68px;

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -145,14 +145,16 @@ function handleEventAnimeQueryInput() {
 		return;
 	}
 	eventAnimeSearchDebounce = setTimeout(async () => {
+		const query = eventAnimeQuery.trim();
 		eventAnimeSearching = true;
 		try {
-			const res = await fetch(`/api/anime/search?q=${encodeURIComponent(eventAnimeQuery.trim())}`);
-			eventAnimeResults = res.ok ? await res.json() : [];
+			const res = await fetch(`/api/anime/search?q=${encodeURIComponent(query)}`);
+			const results = res.ok ? await res.json() : [];
+			if (eventAnimeQuery.trim() === query) eventAnimeResults = results;
 		} catch {
-			eventAnimeResults = [];
+			if (eventAnimeQuery.trim() === query) eventAnimeResults = [];
 		}
-		eventAnimeSearching = false;
+		if (eventAnimeQuery.trim() === query) eventAnimeSearching = false;
 	}, 300);
 }
 

--- a/supabase/migrations/089_broadcast_room_override_kind.sql
+++ b/supabase/migrations/089_broadcast_room_override_kind.sql
@@ -1,0 +1,29 @@
+ALTER TABLE public.broadcast_room_overrides
+	ADD COLUMN IF NOT EXISTS override_kind text;
+
+UPDATE public.broadcast_room_overrides
+SET override_kind = CASE
+	WHEN is_cancelled THEN 'cancelled'
+	WHEN episode_start IS NOT NULL
+		AND episode_end IS NOT NULL
+		AND episode_end > episode_start THEN 'marathon'
+	WHEN episode_label IS NOT NULL
+		OR episode_count_increment = 0 THEN 'recap'
+	WHEN broadcast_time IS NOT NULL
+		OR duration_minutes IS NOT NULL
+		OR pre_open_minutes IS NOT NULL
+		OR post_close_minutes IS NOT NULL THEN 'time_change'
+	ELSE 'custom'
+END
+WHERE override_kind IS NULL;
+
+ALTER TABLE public.broadcast_room_overrides
+	ALTER COLUMN override_kind SET DEFAULT 'custom',
+	ALTER COLUMN override_kind SET NOT NULL;
+
+ALTER TABLE public.broadcast_room_overrides
+	DROP CONSTRAINT IF EXISTS broadcast_room_overrides_kind_check;
+
+ALTER TABLE public.broadcast_room_overrides
+	ADD CONSTRAINT broadcast_room_overrides_kind_check
+	CHECK (override_kind IN ('cancelled', 'recap', 'time_change', 'marathon', 'custom'));


### PR DESCRIPTION
## Summary
- イレギュラー放送設定に override_kind を追加し、放送休止・総集編/特別編・放送時間変更・一挙放送・詳細設定の用途別フォームに整理
- カレンダー、アニメ詳細のルームログ、管理一覧で共通 helper を使って話数/ラベル/休止文/一挙放送表示を解決
- モバイルカレンダーの日付ズレを修正し、イベントカードも通常実況ルームに近いカード構成へ調整
- イベント作成時に対象アニメを検索指定できるようにし、イベント投稿にも対象アニメを紐付け

## Why
管理画面のイレギュラー放送設定が1つのフォームに集約されすぎており、総集編・休止・時間変更・一挙放送の扱いが分かりづらくなっていました。あわせて表示側でもPC/スマホやカレンダー/ルームログ間で解釈がずれやすい状態だったため、入力と表示の整理を同じPRで行います。

## Validation
- pnpm.cmd run check:svelte
- git diff --check HEAD