### PR TITLE
[codex] Refine room hashtag and live room UI

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1884,6 +1884,11 @@ textarea {
 	padding-right: 0;
 }
 
+.post-bookmark-btn:not(:disabled):hover {
+	color: var(--color-text);
+	background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+}
+
 /* --- Post action buttons (reply / repost / like) --- */
 
 .post-action-btn {
@@ -1972,11 +1977,17 @@ textarea {
 .reaction-count-button {
 	cursor: pointer;
 	border-radius: var(--radius-sm);
+	margin-left: 0;
 }
 
 .reaction-count-static {
 	height: 28px;
 	margin-left: 2px;
+}
+
+.reaction-count-static.has-count {
+	margin-left: 0;
+	min-width: 28px;
 }
 
 .reaction-icon-hitbox {
@@ -2013,9 +2024,15 @@ textarea {
 	left: 0;
 }
 
+.post-reply-btn.reaction-icon-hitbox:hover,
 .post-repost-btn.reaction-icon-hitbox:not(:disabled):hover,
-.post-like-btn.reaction-icon-hitbox:not(:disabled):hover {
+.post-like-btn.reaction-icon-hitbox:not(:disabled):hover,
+.post-bookmark-btn.reaction-icon-hitbox:not(:disabled):hover {
 	background: none;
+}
+
+.post-reply-btn.reaction-icon-hitbox:hover::before {
+	background: color-mix(in srgb, var(--color-accent) 10%, transparent);
 }
 
 .post-repost-count.reaction-count-hitbox:hover {
@@ -2034,6 +2051,10 @@ textarea {
 
 .post-like-btn.reaction-icon-hitbox:not(:disabled):hover::before {
 	background: rgba(244, 63, 94, 0.1);
+}
+
+.post-bookmark-btn.reaction-icon-hitbox:not(:disabled):hover::before {
+	background: color-mix(in srgb, var(--color-accent) 10%, transparent);
 }
 
 .reaction-popover-backdrop {

--- a/src/lib/components/LiveRoomPostCard.svelte
+++ b/src/lib/components/LiveRoomPostCard.svelte
@@ -61,14 +61,25 @@ function stop(event: Event) {
 	event.stopPropagation();
 }
 
+function isInteractiveEventTarget(event: Event) {
+	const target = event.target;
+	return target instanceof Element && !!target.closest("a, button, input, textarea, select, label, form");
+}
+
 async function toggleExpanded() {
 	expanded = !expanded;
 	showKebabMenu = false;
 	if (expanded) await loadRecentReplies();
 }
 
+function handleRowClick(event: MouseEvent) {
+	if (isInteractiveEventTarget(event)) return;
+	void toggleExpanded();
+}
+
 function handleRowKeydown(event: KeyboardEvent) {
 	if (event.key !== "Enter" && event.key !== " ") return;
+	if (isInteractiveEventTarget(event)) return;
 	event.preventDefault();
 	void toggleExpanded();
 }
@@ -213,7 +224,7 @@ async function submitReport(event: MouseEvent) {
 		role="button"
 		tabindex="0"
 		aria-expanded={expanded}
-		onclick={() => void toggleExpanded()}
+		onclick={handleRowClick}
 		onkeydown={handleRowKeydown}
 	>
 		<a href="/profile/{post.username}" class="live-avatar" aria-label={displayName} onclick={stop}>
@@ -236,7 +247,7 @@ async function submitReport(event: MouseEvent) {
 		</p>
 		<span class="live-time">
 			{#if timelineTimeMode}
-				<time datetime={post.created_at} title={post.created_at}>{relativeTime}</time>
+				<time datetime={post.created_at} title={absoluteTimeStr}>{relativeTime}</time>
 			{:else if broadcastRelativeTime}
 				<BroadcastTimestamp relativeTime={broadcastRelativeTime} absoluteTime={absoluteTimeStr} />
 			{:else}

--- a/src/lib/components/LiveRoomPostCard.svelte
+++ b/src/lib/components/LiveRoomPostCard.svelte
@@ -12,9 +12,10 @@ interface Props {
 	post: Post;
 	currentUserId?: string | null;
 	broadcastStartAt?: string | null;
+	timelineTimeMode?: boolean;
 }
 
-let { post, currentUserId = null, broadcastStartAt = null }: Props = $props();
+let { post, currentUserId = null, broadcastStartAt = null, timelineTimeMode = false }: Props = $props();
 
 let expanded = $state(false);
 let likeCountLocal = $state<number | null>(null);
@@ -64,6 +65,12 @@ async function toggleExpanded() {
 	expanded = !expanded;
 	showKebabMenu = false;
 	if (expanded) await loadRecentReplies();
+}
+
+function handleRowKeydown(event: KeyboardEvent) {
+	if (event.key !== "Enter" && event.key !== " ") return;
+	event.preventDefault();
+	void toggleExpanded();
 }
 
 async function loadRecentReplies() {
@@ -201,7 +208,14 @@ async function submitReport(event: MouseEvent) {
 		</form>
 	{/if}
 
-	<div class="live-post-row">
+	<div
+		class="live-post-row"
+		role="button"
+		tabindex="0"
+		aria-expanded={expanded}
+		onclick={() => void toggleExpanded()}
+		onkeydown={handleRowKeydown}
+	>
 		<a href="/profile/{post.username}" class="live-avatar" aria-label={displayName} onclick={stop}>
 			<UserAvatar src={post.avatar_url} username={post.username} size="xs" />
 		</a>
@@ -221,58 +235,86 @@ async function submitReport(event: MouseEvent) {
 			{/each}
 		</p>
 		<span class="live-time">
-			{#if broadcastRelativeTime}
+			{#if timelineTimeMode}
+				<time datetime={post.created_at} title={post.created_at}>{relativeTime}</time>
+			{:else if broadcastRelativeTime}
 				<BroadcastTimestamp relativeTime={broadcastRelativeTime} absoluteTime={absoluteTimeStr} />
 			{:else}
 				<time datetime={post.created_at} title={absoluteTimeStr}>{relativeTime}</time>
 				<span class="live-time-abs">({absoluteTimeStr})</span>
 			{/if}
 		</span>
-		<div class="live-row-actions">
-			{#if expanded}
-				<button
-					type="button"
-					class="live-collapse"
-					aria-expanded={expanded}
-					aria-label="閉じる"
-					onclick={(event) => { event.stopPropagation(); void toggleExpanded(); }}
+		{#if expanded}
+			<button
+				type="button"
+				class="live-collapse"
+				aria-label="閉じる"
+				onclick={(event) => { event.stopPropagation(); void toggleExpanded(); }}
+			>
+				<svg
+					width="15"
+					height="15"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
 				>
-					▲
-				</button>
-			{:else}
-				<form method="POST" action="?/like" use:enhance={handleLike} class="live-like-form">
-					<input type="hidden" name="post_id" value={post.id}>
-					<button
-						type="submit"
-						class="live-like"
-						class:active={likedByMe}
-						disabled={!isLoggedIn}
-						aria-pressed={likedByMe}
-						aria-label={likedByMe ? 'いいねを取り消す' : 'いいね'}
-						onclick={stop}
+					<path d="m18 15-6-6-6 6" />
+				</svg>
+			</button>
+		{:else}
+			<form method="POST" action="?/like" use:enhance={handleLike} class="live-like-form">
+				<input type="hidden" name="post_id" value={post.id}>
+				<button
+					type="submit"
+					class="live-like"
+					class:active={likedByMe}
+					disabled={!isLoggedIn}
+					aria-pressed={likedByMe}
+					aria-label={likedByMe ? 'いいねを取り消す' : 'いいね'}
+					onclick={stop}
+				>
+					<svg
+						width="15"
+						height="15"
+						viewBox="0 0 24 24"
+						fill={likedByMe ? 'currentColor' : 'none'}
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
 					>
-						<span class="i-lucide-heart" aria-hidden="true"></span>
-						<span>{likeCount}</span>
-					</button>
-				</form>
-				<button
-					type="button"
-					class="live-expand-toggle"
-					aria-expanded={expanded}
-					aria-label="詳細を開く"
-					onclick={(event) => { event.stopPropagation(); void toggleExpanded(); }}
-				>
-					▼
+						<path
+							d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+						/>
+					</svg>
+					<span>{likeCount}</span>
 				</button>
-			{/if}
-		</div>
+			</form>
+		{/if}
 	</div>
 
 	{#if expanded}
 		<div class="live-detail">
 			<div class="live-actions" aria-label="投稿アクション">
-				<a href="/posts/{post.id}" class="live-action" aria-label="返信">
-					<span class="i-lucide-message-circle" aria-hidden="true"></span>
+				<a href="/posts/{post.id}" class="live-action live-action-reply" aria-label="返信">
+					<svg
+						width="15"
+						height="15"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+					</svg>
 					{#if post.reply_count > 0}
 						<span>{post.reply_count}</span>
 					{/if}
@@ -281,13 +323,28 @@ async function submitReport(event: MouseEvent) {
 					<input type="hidden" name="post_id" value={post.id}>
 					<button
 						type="submit"
-						class="live-action"
+						class="live-action live-action-repost"
 						class:active={repostedByMe}
 						disabled={!isLoggedIn}
 						aria-pressed={repostedByMe}
 						aria-label={repostedByMe ? "リポストを取り消す" : "リポスト"}
 					>
-						<span class="i-lucide-repeat-2" aria-hidden="true"></span>
+						<svg
+							width="15"
+							height="15"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="M17 1l4 4-4 4" />
+							<path d="M3 11V9a4 4 0 0 1 4-4h14" />
+							<path d="M7 23l-4-4 4-4" />
+							<path d="M21 13v2a4 4 0 0 1-4 4H3" />
+						</svg>
 						{#if repostCount > 0}
 							<span>{repostCount}</span>
 						{/if}
@@ -303,7 +360,21 @@ async function submitReport(event: MouseEvent) {
 						aria-pressed={likedByMe}
 						aria-label={likedByMe ? "いいねを取り消す" : "いいね"}
 					>
-						<span class="i-lucide-heart" aria-hidden="true"></span>
+						<svg
+							width="15"
+							height="15"
+							viewBox="0 0 24 24"
+							fill={likedByMe ? 'currentColor' : 'none'}
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path
+								d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+							/>
+						</svg>
 						{#if likeCount > 0}
 							<span>{likeCount}</span>
 						{/if}
@@ -313,13 +384,25 @@ async function submitReport(event: MouseEvent) {
 					<input type="hidden" name="post_id" value={post.id}>
 					<button
 						type="submit"
-						class="live-action"
+						class="live-action live-action-bookmark"
 						class:active={bookmarkedByMe}
 						disabled={!isLoggedIn}
 						aria-pressed={bookmarkedByMe}
 						aria-label={bookmarkedByMe ? "ブックマークを解除" : "ブックマーク"}
 					>
-						<span class="i-lucide-bookmark" aria-hidden="true"></span>
+						<svg
+							width="15"
+							height="15"
+							viewBox="0 0 24 24"
+							fill={bookmarkedByMe ? 'currentColor' : 'none'}
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+						</svg>
 					</button>
 				</form>
 				{#if isLoggedIn}
@@ -518,6 +601,7 @@ async function submitReport(event: MouseEvent) {
 	row-gap: 3px;
 	min-height: 52px;
 	padding: 6px var(--live-row-pad-x);
+	cursor: pointer;
 }
 
 .live-post-row:focus-visible {
@@ -622,22 +706,15 @@ async function submitReport(event: MouseEvent) {
 	font-size: 10px;
 }
 
-.live-row-actions {
+.live-like-form {
 	grid-area: action;
 	display: inline-flex;
 	align-self: center;
-	align-items: center;
 	justify-content: flex-end;
-	min-width: 52px;
-}
-
-.live-like-form {
-	display: inline-flex;
 }
 
 .live-like,
-.live-collapse,
-.live-expand-toggle {
+.live-collapse {
 	grid-area: action;
 	align-self: center;
 	display: inline-flex;
@@ -656,15 +733,6 @@ async function submitReport(event: MouseEvent) {
 	cursor: pointer;
 }
 
-.live-row-actions .live-like {
-	width: 34px;
-}
-
-.live-expand-toggle {
-	width: 18px;
-	color: var(--color-text-secondary);
-}
-
 .live-like:hover,
 .live-like.active,
 .live-action-like:hover,
@@ -672,12 +740,17 @@ async function submitReport(event: MouseEvent) {
 	color: #f43f5e;
 }
 
-.live-like [class^="i-lucide"] {
+.live-like svg,
+.live-collapse svg {
 	flex-shrink: 0;
 }
 
 .live-collapse {
 	color: var(--color-text-secondary);
+}
+
+.live-collapse svg {
+	transform: translateX(-5px);
 }
 
 .live-detail {
@@ -693,8 +766,7 @@ async function submitReport(event: MouseEvent) {
 }
 
 .live-actions > .live-action:first-child {
-	min-width: 23px;
-	padding-left: 0;
+	margin-left: -7px;
 }
 
 .live-actions form {
@@ -719,10 +791,42 @@ async function submitReport(event: MouseEvent) {
 	cursor: pointer;
 }
 
-.live-action:hover,
-.live-action.active {
+.live-action:hover {
 	background: color-mix(in srgb, var(--color-accent) 10%, transparent);
 	color: var(--color-text);
+}
+
+.live-action.active {
+	color: var(--color-text-muted);
+}
+
+.live-action-reply:hover {
+	background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+	color: var(--color-accent);
+	text-decoration: none;
+}
+
+.live-action-repost:not(:disabled):hover {
+	background: rgba(34, 197, 94, 0.1);
+	color: #22c55e;
+}
+
+.live-action-repost.active {
+	color: #22c55e;
+}
+
+.live-action-like:not(:disabled):hover {
+	background: rgba(244, 63, 94, 0.1);
+	color: #f43f5e;
+}
+
+.live-action-like:hover,
+.live-action-like.active {
+	color: #f43f5e;
+}
+
+.live-action-bookmark.active {
+	color: var(--color-text-muted);
 }
 
 .live-action:disabled,
@@ -731,6 +835,7 @@ async function submitReport(event: MouseEvent) {
 	opacity: 0.5;
 }
 
+.live-action svg,
 .live-action [class^="i-lucide"] {
 	width: 15px;
 	height: 15px;

--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -804,24 +804,30 @@ async function submitReport() {
 
 		<div class="post-footer">
 			<div class="post-footer-item">
-				<a href="/posts/{post.id}" class="post-action-btn post-reply-btn" aria-label="返信">
-					<svg
-						width="15"
-						height="15"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						aria-hidden="true"
+				<div class="reaction-action-group">
+					<a
+						href="/posts/{post.id}"
+						class="post-action-btn post-reply-btn reaction-icon-hitbox"
+						aria-label="返信"
 					>
-						<path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
-					</svg>
-					{#if post.reply_count > 0}
-						<span>{post.reply_count}</span>
-					{/if}
-				</a>
+						<svg
+							width="15"
+							height="15"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+						</svg>
+					</a>
+					<span class="reaction-count-static" class:has-count={isDetailView && post.reply_count > 0}
+						>{post.reply_count > 0 ? post.reply_count : ''}</span
+					>
+				</div>
 			</div>
 
 			<div class="post-footer-item">
@@ -865,7 +871,9 @@ async function submitReport() {
 							</button>
 						{/if}
 					{:else}
-						<span class="reaction-count-static">{repostCount > 0 ? repostCount : ''}</span>
+						<span class="reaction-count-static" class:has-count={isDetailView && repostCount > 0}
+							>{repostCount > 0 ? repostCount : ''}</span
+						>
 					{/if}
 
 					{#if showRepostMenu}
@@ -973,7 +981,9 @@ async function submitReport() {
 							{likeCount}
 						</button>
 					{:else}
-						<span class="reaction-count-static">{likeCount > 0 ? likeCount : ''}</span>
+						<span class="reaction-count-static" class:has-count={isDetailView && likeCount > 0}
+							>{likeCount > 0 ? likeCount : ''}</span
+						>
 					{/if}
 					{#if openReactionType === 'like'}
 						<ReactionUsersPopover
@@ -992,7 +1002,7 @@ async function submitReport() {
 					<input type="hidden" name="post_id" value={post.id}>
 					<button
 						type="submit"
-						class="post-action-btn post-bookmark-btn"
+						class="post-action-btn post-bookmark-btn reaction-icon-hitbox"
 						class:active={bookmarkedByMe}
 						disabled={!isLoggedIn}
 						aria-label={bookmarkedByMe ? 'ブックマーク解除' : 'ブックマーク'}

--- a/src/routes/anime/[id]/+page.svelte
+++ b/src/routes/anime/[id]/+page.svelte
@@ -1115,7 +1115,6 @@ $effect(() => {
 						<span class="i-lucide-messages-square" aria-hidden="true"></span>
 						<span>
 							<strong>この作品の総合実況・雑談ロビーへ入る</strong>
-							<small>話数別ではなく、作品全体の常設ルームです</small>
 						</span>
 					</a>
 				</section>
@@ -1995,18 +1994,11 @@ $effect(() => {
 	font-size: 1.35rem;
 	color: #0f766e;
 }
-.global-lobby-link strong,
-.global-lobby-link small {
+.global-lobby-link strong {
 	display: block;
 }
 .global-lobby-link strong {
 	font-size: 0.95rem;
-	line-height: 1.35;
-}
-.global-lobby-link small {
-	margin-top: 2px;
-	color: var(--text-muted);
-	font-size: 0.78rem;
 	line-height: 1.35;
 }
 

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -146,9 +146,7 @@ export const actions: Actions = {
 		const content = stripTrailingRoomHashtag(rawContent, hashtag);
 		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
-		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
-			hashtag,
-		]);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, []);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { SubmitFunction } from "@sveltejs/kit";
 import { onDestroy, onMount, tick } from "svelte";
 import { enhance } from "$app/forms";
 import LiveRoomPostCard from "$lib/components/LiveRoomPostCard.svelte";
@@ -15,6 +16,8 @@ let now = $state(Date.now());
 let intervalId: ReturnType<typeof setInterval>;
 let postContent = $state("");
 let textareaEl: HTMLTextAreaElement | null = $state(null);
+let composerEl: HTMLDivElement | null = $state(null);
+let keepComposerFocused = $state(true);
 let mounted = $state(false);
 let postOrder = $state<PostOrder>("oldest");
 let lastPostCount = $state(0);
@@ -135,6 +138,39 @@ function handleRoomExperimentPageShow(event: PageTransitionEvent) {
 	if (event.persisted) void startRoomExperimentTracking();
 }
 
+function shouldAutoFocusComposer() {
+	return !("ontouchstart" in window) && navigator.maxTouchPoints === 0;
+}
+
+async function focusComposerTextarea(options: FocusOptions = {}) {
+	if (!shouldAutoFocusComposer() || !keepComposerFocused) return;
+	await tick();
+	await new Promise<void>((resolve) => {
+		requestAnimationFrame(() => resolve());
+	});
+	textareaEl?.focus(options);
+}
+
+function handleWindowPointerDown(event: PointerEvent) {
+	const target = event.target;
+	if (!(target instanceof Node)) return;
+	if (target === textareaEl) {
+		keepComposerFocused = true;
+		return;
+	}
+	const targetElement = target instanceof Element ? target : target.parentElement;
+	if (composerEl?.contains(target) && targetElement?.closest('button[type="submit"]')) return;
+	keepComposerFocused = false;
+}
+
+const handleCreatePost: SubmitFunction = () => {
+	keepComposerFocused = true;
+	return async ({ update }) => {
+		await update({ reset: false });
+		await focusComposerTextarea({ preventScroll: true });
+	};
+};
+
 /** 最後に受信した投稿以降の差分を取得して extraPosts に追加する */
 async function fetchNewPosts() {
 	if (fetchingLive) return;
@@ -169,13 +205,12 @@ onMount(() => {
 	intervalId = setInterval(() => {
 		now = Date.now();
 	}, 1000);
-	if (!("ontouchstart" in window) && textareaEl) {
-		textareaEl.focus();
-	}
 	if (status === "open" && data.posts.length > 0) {
 		void focusLatestPost();
 	}
+	void focusComposerTextarea();
 	window.addEventListener("scroll", handleWindowScroll, { passive: true });
+	window.addEventListener("pointerdown", handleWindowPointerDown, true);
 	window.addEventListener("pagehide", handleRoomExperimentPageHide);
 	window.addEventListener("pageshow", handleRoomExperimentPageShow);
 	void startRoomExperimentTracking();
@@ -187,6 +222,7 @@ onDestroy(() => {
 	clearRoomExperimentHeartbeatTimer();
 	if (typeof window !== "undefined") {
 		window.removeEventListener("scroll", handleWindowScroll);
+		window.removeEventListener("pointerdown", handleWindowPointerDown, true);
 		window.removeEventListener("pagehide", handleRoomExperimentPageHide);
 		window.removeEventListener("pageshow", handleRoomExperimentPageShow);
 	}
@@ -194,7 +230,10 @@ onDestroy(() => {
 });
 
 $effect(() => {
-	if (form && "success" in form && form.success) postContent = "";
+	if (form && "success" in form && form.success) {
+		postContent = "";
+		void focusComposerTextarea();
+	}
 });
 
 $effect(() => {
@@ -207,9 +246,10 @@ $effect(() => {
 	if (shouldFollow) {
 		isFollowingLatest = true;
 		unreadNewPostCount = 0;
-		void focusLatestPost(postOrder, "smooth");
+		void focusLatestPost(postOrder, "smooth").then(() => focusComposerTextarea({ preventScroll: true }));
 	} else {
 		unreadNewPostCount += Math.max(1, newPostCount);
+		void focusComposerTextarea({ preventScroll: true });
 	}
 });
 
@@ -296,7 +336,7 @@ const timerLabel = $derived.by(() => {
 });
 
 const broadcastMetaLine = $derived.by(() => {
-	if (isGlobalLobby) return "総合実況・雑談ロビー";
+	if (isGlobalLobby) return "";
 	const station = data.anime.broadcast_station?.filter(Boolean).join(" / ");
 	const frame = `${data.room.duration_minutes}分枠`;
 	return station ? `${station} · ${frame}` : frame;
@@ -326,20 +366,23 @@ function formatCompactDate(iso: string) {
 		</div>
 
 		{#if data.user && status === "open"}
-			<div class="card composer">
+			<div class="card composer" bind:this={composerEl}>
 				{#if form && "message" in form}
 					<p class="form-error">{form.message}</p>
 				{/if}
-				<form method="POST" action="?/createPost" use:enhance>
+				<form method="POST" action="?/createPost" use:enhance={handleCreatePost}>
 					<div class="composer-body">
 						<textarea
 							bind:this={textareaEl}
-							class="composer-textarea"
+							class="composer-textarea room-composer-textarea"
 							name="content"
 							placeholder="いまの感想を投稿... (Shift+Enterで改行)"
 							rows="3"
 							bind:value={postContent}
 							maxlength={maxLen}
+							onfocus={() => {
+								keepComposerFocused = true;
+							}}
 							onkeydown={(e) => {
 								if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
 									e.preventDefault();
@@ -406,6 +449,7 @@ function formatCompactDate(iso: string) {
 						{post}
 						currentUserId={data.user?.id ?? null}
 						broadcastStartAt={data.room.scheduled_at}
+						timelineTimeMode={isGlobalLobby}
 					/>
 				</div>
 			{/each}
@@ -433,17 +477,21 @@ function formatCompactDate(iso: string) {
 				<div class="flex min-h-20 min-w-0 flex-1 flex-col justify-between pl-3">
 					<div class="min-w-0">
 						<h1 class="room-summary-title line-clamp-1 text-sm font-bold">{data.room.title}</h1>
-						<div class="mt-2 flex min-w-0 items-center gap-2">
-							{#if status === "ended"}
-								<span class="room-summary-status rounded px-1.5 py-0.5 text-[10px] font-bold"
-									>終了</span
+						{#if !isGlobalLobby}
+							<div class="mt-2 flex min-w-0 items-center gap-2">
+								{#if status === "ended"}
+									<span class="room-summary-status rounded px-1.5 py-0.5 text-[10px] font-bold"
+										>終了</span
+									>
+								{/if}
+								<time class="room-summary-secondary truncate text-xs"
+									>{formatCompactDate(data.room.scheduled_at)}</time
 								>
-							{/if}
-							<time class="room-summary-secondary truncate text-xs"
-								>{formatCompactDate(data.room.scheduled_at)}</time
-							>
-						</div>
-						<div class="room-summary-muted mt-1 truncate text-xs">{broadcastMetaLine}</div>
+							</div>
+						{/if}
+						{#if broadcastMetaLine}
+							<div class="room-summary-muted mt-1 truncate text-xs">{broadcastMetaLine}</div>
+						{/if}
 					</div>
 					<div class="mt-2 flex items-center justify-end gap-2">
 						<a href="/schedule" class="room-summary-back shrink-0 text-xs transition-colors">
@@ -584,6 +632,11 @@ function formatCompactDate(iso: string) {
 .room-order-toggle button.active {
 	background: var(--color-accent);
 	color: white;
+}
+
+:global(.room-composer-textarea:focus-visible) {
+	outline: none;
+	outline-offset: 0;
 }
 
 /* ── モバイル用コンパクトバー (サイドバー非表示時のみ表示) ── */

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -206,9 +206,10 @@ onMount(() => {
 		now = Date.now();
 	}, 1000);
 	if (status === "open" && data.posts.length > 0) {
-		void focusLatestPost();
+		void focusLatestPost().then(() => focusComposerTextarea({ preventScroll: true }));
+	} else {
+		void focusComposerTextarea();
 	}
-	void focusComposerTextarea();
 	window.addEventListener("scroll", handleWindowScroll, { passive: true });
 	window.addEventListener("pointerdown", handleWindowPointerDown, true);
 	window.addEventListener("pagehide", handleRoomExperimentPageHide);
@@ -232,7 +233,6 @@ onDestroy(() => {
 $effect(() => {
 	if (form && "success" in form && form.success) {
 		postContent = "";
-		void focusComposerTextarea();
 	}
 });
 

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -96,9 +96,7 @@ export const actions: Actions = {
 		const content = stripTrailingRoomHashtag(rawContent, hashtag);
 		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
-		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
-			hashtag,
-		]);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, []);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {


### PR DESCRIPTION
## Summary
- Stop auto-attaching room hashtags to new room and global lobby posts while still stripping trailing room tags from submitted content.
- Restore and refine compact live room post reactions, expanded action icons, timeline reaction spacing, and bookmark hover behavior.
- Simplify global lobby timestamp/sidebar copy and keep the room composer focused on desktop after submit/update without showing the blue focus ring.

## Validation
- `pnpm.cmd exec biome check src/app.css src/lib/components/LiveRoomPostCard.svelte src/lib/components/PostCard.svelte "src/routes/anime/[id]/+page.svelte" "src/routes/rooms/anime/[id]/[date]/+page.server.ts" "src/routes/rooms/anime/[id]/[date]/+page.svelte" "src/routes/rooms/anime/[id]/lobby/+page.server.ts"`
- `pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json`
- pre-commit `biome check --write`