### PR TITLE
[codex] Fix live room fixed layout

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -95,7 +95,6 @@ html {
 html.room-scroll-lock {
 	height: 100%;
 	overflow: hidden;
-	scrollbar-gutter: stable;
 }
 
 body {
@@ -247,11 +246,9 @@ textarea {
 	width: 100%;
 	max-width: calc(var(--content-max) + 48px);
 	margin: 0 auto;
-	padding: 0 32px 0 16px;
+	padding: calc(var(--nav-height) + 24px) 32px 48px 16px;
 	display: flex;
 	gap: 20px;
-	padding-top: calc(var(--nav-height) + 24px);
-	padding-bottom: 48px;
 	align-items: flex-start;
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -92,6 +92,12 @@ html {
 	scrollbar-gutter: stable;
 }
 
+html.room-scroll-lock {
+	height: 100%;
+	overflow: hidden;
+	scrollbar-gutter: stable;
+}
+
 body {
 	background: var(--color-bg);
 	color: var(--color-text);
@@ -103,6 +109,41 @@ body {
 	width: 100%;
 	overflow-x: clip;
 	overscroll-behavior-x: none;
+}
+
+:where(html.room-scroll-lock) body {
+	height: 100%;
+	overflow: hidden;
+}
+
+:where(html.room-scroll-lock) .app-layout,
+:where(html.room-scroll-lock) .app-main {
+	height: 100dvh;
+	min-height: 100dvh;
+	overflow: hidden;
+}
+
+.scrollbar-thin-muted {
+	scrollbar-width: thin;
+	scrollbar-color: color-mix(in srgb, var(--color-text-muted) 28%, transparent) transparent;
+}
+
+.scrollbar-thin-muted::-webkit-scrollbar {
+	width: 6px;
+	height: 6px;
+}
+
+.scrollbar-thin-muted::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.scrollbar-thin-muted::-webkit-scrollbar-thumb {
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--color-text-muted) 24%, transparent);
+}
+
+.scrollbar-thin-muted::-webkit-scrollbar-thumb:hover {
+	background: color-mix(in srgb, var(--color-text-muted) 42%, transparent);
 }
 
 html[data-swipe-direction="next"]::view-transition-old(root) {
@@ -204,14 +245,21 @@ textarea {
 
 .page-container {
 	width: 100%;
-	max-width: var(--content-max);
+	max-width: calc(var(--content-max) + 48px);
 	margin: 0 auto;
-	padding: 0;
+	padding: 0 32px 0 16px;
 	display: flex;
 	gap: 20px;
 	padding-top: calc(var(--nav-height) + 24px);
 	padding-bottom: 48px;
 	align-items: flex-start;
+}
+
+.page-container:not(.room-page-container):has(> .sidebar-column) {
+	max-width: none;
+	margin: 0;
+	padding-right: max(24px, env(safe-area-inset-right));
+	padding-left: max(16px, calc((100% - (var(--content-max) + 48px)) / 2 + 16px));
 }
 
 .feed-column {
@@ -221,8 +269,13 @@ textarea {
 
 .sidebar-column {
 	flex: 0 0 var(--sidebar-width);
+	min-width: 0;
 	position: sticky;
 	top: calc(var(--nav-height) + 24px);
+}
+
+.page-container:not(.room-page-container):has(> .sidebar-column) > .sidebar-column {
+	flex: 1 1 var(--sidebar-width);
 }
 
 @media (max-width: 960px) {
@@ -1015,6 +1068,7 @@ textarea {
 /* --- Trending Panel --- */
 
 .trending-panel {
+	min-width: 0;
 	background: var(--color-surface);
 	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
@@ -1072,13 +1126,18 @@ textarea {
 
 .trending-name {
 	flex: 1;
+	min-width: 0;
 	font-weight: 600;
 	font-size: 14px;
 	color: var(--color-accent);
 	margin-left: 8px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .trending-count {
+	flex-shrink: 0;
 	font-size: 12px;
 	color: var(--color-text-muted);
 }
@@ -1861,8 +1920,8 @@ textarea {
 	grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
 	align-items: center;
 	gap: 0;
-	margin-top: 10px;
-	padding-top: 8px;
+	margin-top: 2px;
+	padding-top: 0;
 }
 
 .post-footer-item {

--- a/src/app.html
+++ b/src/app.html
@@ -15,6 +15,9 @@
 			} else if (window.matchMedia("(prefers-color-scheme: light)").matches) {
 				document.documentElement.setAttribute("data-theme", "light");
 			}
+			if (window.location.pathname.indexOf("/rooms/anime/") === 0) {
+				document.documentElement.classList.add("room-scroll-lock");
+			}
 		})();
 		</script>
 		%sveltekit.head%

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@ let { data, children }: LayoutProps = $props();
 let unreadNotificationCount = $state(0);
 let unreadBroadcastNotificationCount = $state(0);
 let pendingReportsCount = $state(0);
+const roomScrollLocked = $derived(page.url.pathname.startsWith("/rooms/anime/"));
 
 async function refreshNotificationCounts() {
 	if (!data.session) {
@@ -45,6 +46,15 @@ $effect(() => {
 	});
 	return () => {
 		active = false;
+	};
+});
+
+$effect.pre(() => {
+	if (typeof document === "undefined") return;
+	const root = document.documentElement;
+	root.classList.toggle("room-scroll-lock", roomScrollLocked);
+	return () => {
+		root.classList.remove("room-scroll-lock");
 	};
 });
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -50,7 +50,6 @@ $effect(() => {
 });
 
 $effect.pre(() => {
-	if (typeof document === "undefined") return;
 	const root = document.documentElement;
 	root.classList.toggle("room-scroll-lock", roomScrollLocked);
 	return () => {

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -33,7 +33,6 @@ const openLeadMinutes = $derived(Math.round((scheduledMs - openMs) / (60 * 1000)
 const isGlobalLobby = $derived(data.room.kind === "global");
 const charCount = $derived(postContent.length);
 const overLimit = $derived(charCount > maxLen);
-const latestJumpArrow = $derived(postOrder === "oldest" ? "↓" : "↑");
 // ライブ更新で受信した投稿（load 由来の data.posts とは別に保持し、ID でマージする）
 let extraPosts = $state<Post[]>([]);
 let roomExperimentVisitId: string | null = null;
@@ -269,6 +268,7 @@ async function focusLatestPost(order: PostOrder = postOrder, behavior: ScrollBeh
 	await tick();
 	requestAnimationFrame(() => {
 		if (!postListEl) return;
+		if (programmaticScrollTimer) clearTimeout(programmaticScrollTimer);
 		programmaticScrollTimer = setTimeout(() => {
 			programmaticScrollTimer = undefined;
 			isFollowingLatest = true;
@@ -436,9 +436,13 @@ function formatCompactDate(iso: string) {
 					type="button"
 					class="new-posts-badge"
 					onclick={resumeLatestFollow}
-					aria-label="Jump to latest post"
+					aria-label="最新の投稿へ移動"
 				>
-					<span aria-hidden="true">{latestJumpArrow}</span>
+					{#if postOrder === "oldest"}
+						<span class="i-lucide-arrow-down latest-jump-icon" aria-hidden="true"></span>
+					{:else}
+						<span class="i-lucide-arrow-up latest-jump-icon" aria-hidden="true"></span>
+					{/if}
 					{#if unreadNewPostCount > 0}
 						<span class="new-posts-count">{unreadNewPostCount}</span>
 					{/if}
@@ -611,6 +615,12 @@ function formatCompactDate(iso: string) {
 	color: white;
 	font-size: 12px;
 	font-variant-numeric: tabular-nums;
+}
+
+.latest-jump-icon {
+	width: 16px;
+	height: 16px;
+	flex-shrink: 0;
 }
 
 @keyframes new-posts-pop {

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -15,7 +15,9 @@ let now = $state(Date.now());
 let intervalId: ReturnType<typeof setInterval>;
 let postContent = $state("");
 let textareaEl: HTMLTextAreaElement | null = $state(null);
+let postListEl: HTMLDivElement | null = $state(null);
 let mounted = $state(false);
+let isMobileViewport = $state(false);
 let postOrder = $state<PostOrder>("oldest");
 let lastPostCount = $state(0);
 let isFollowingLatest = $state(true);
@@ -31,11 +33,13 @@ const openLeadMinutes = $derived(Math.round((scheduledMs - openMs) / (60 * 1000)
 const isGlobalLobby = $derived(data.room.kind === "global");
 const charCount = $derived(postContent.length);
 const overLimit = $derived(charCount > maxLen);
+const latestJumpArrow = $derived(postOrder === "oldest" ? "↓" : "↑");
 // ライブ更新で受信した投稿（load 由来の data.posts とは別に保持し、ID でマージする）
 let extraPosts = $state<Post[]>([]);
 let roomExperimentVisitId: string | null = null;
 let roomExperimentHeartbeatTimer: ReturnType<typeof setInterval> | undefined;
 let roomExperimentExitSent = false;
+let mobileViewportQuery: MediaQueryList | null = null;
 
 function getRoomExperimentVisitStorageKey(sessionId: string) {
 	return `room-experiment-visit:${sessionId}`;
@@ -162,8 +166,12 @@ const status = $derived.by<RoomStatus>(() => {
 	if (now >= closeMs) return "ended";
 	return "open";
 });
+const showLatestJumpButton = $derived(status === "open" && (!isFollowingLatest || unreadNewPostCount > 0));
 
 onMount(() => {
+	mobileViewportQuery = window.matchMedia("(max-width: 960px)");
+	isMobileViewport = mobileViewportQuery.matches;
+	mobileViewportQuery.addEventListener("change", handleMobileViewportChange);
 	mounted = true;
 	lastPostCount = data.posts.length;
 	intervalId = setInterval(() => {
@@ -175,23 +183,26 @@ onMount(() => {
 	if (status === "open" && data.posts.length > 0) {
 		void focusLatestPost();
 	}
-	window.addEventListener("scroll", handleWindowScroll, { passive: true });
 	window.addEventListener("pagehide", handleRoomExperimentPageHide);
 	window.addEventListener("pageshow", handleRoomExperimentPageShow);
 	void startRoomExperimentTracking();
 });
 
 onDestroy(() => {
+	mobileViewportQuery?.removeEventListener("change", handleMobileViewportChange);
 	clearInterval(intervalId);
 	if (programmaticScrollTimer) clearTimeout(programmaticScrollTimer);
 	clearRoomExperimentHeartbeatTimer();
 	if (typeof window !== "undefined") {
-		window.removeEventListener("scroll", handleWindowScroll);
 		window.removeEventListener("pagehide", handleRoomExperimentPageHide);
 		window.removeEventListener("pageshow", handleRoomExperimentPageShow);
 	}
 	sendRoomExperimentExit();
 });
+
+function handleMobileViewportChange(event: MediaQueryListEvent) {
+	isMobileViewport = event.matches;
+}
 
 $effect(() => {
 	if (form && "success" in form && form.success) postContent = "";
@@ -240,13 +251,13 @@ $effect(() => {
 });
 
 function isNearLatestEdge(order: PostOrder = postOrder) {
-	const root = document.documentElement;
-	if (order === "newest") return window.scrollY <= latestEdgeThreshold;
-	const distanceToBottom = root.scrollHeight - (window.scrollY + window.innerHeight);
+	if (!postListEl) return true;
+	if (order === "newest") return postListEl.scrollTop <= latestEdgeThreshold;
+	const distanceToBottom = postListEl.scrollHeight - (postListEl.scrollTop + postListEl.clientHeight);
 	return distanceToBottom <= latestEdgeThreshold;
 }
 
-function handleWindowScroll() {
+function handlePostListScroll() {
 	if (!mounted || status !== "open") return;
 	if (programmaticScrollTimer) return;
 	const nearLatest = isNearLatestEdge();
@@ -257,12 +268,15 @@ function handleWindowScroll() {
 async function focusLatestPost(order: PostOrder = postOrder, behavior: ScrollBehavior = "auto") {
 	await tick();
 	requestAnimationFrame(() => {
-		const selector = order === "oldest" ? ".anime-room-post:last-of-type" : ".anime-room-post:first-of-type";
+		if (!postListEl) return;
 		programmaticScrollTimer = setTimeout(() => {
 			programmaticScrollTimer = undefined;
 			isFollowingLatest = true;
 		}, 450);
-		document.querySelector<HTMLElement>(selector)?.scrollIntoView({ block: "center", behavior });
+		postListEl.scrollTo({
+			top: order === "oldest" ? postListEl.scrollHeight : 0,
+			behavior,
+		});
 	});
 }
 
@@ -315,13 +329,15 @@ function formatCompactDate(iso: string) {
 
 <svelte:head> <title>{data.room.title} - Anipolis</title> </svelte:head>
 
-<div class="page-container">
+<div class="page-container room-page-container">
 	<div class="feed-column">
 		<div class="room-mobile-bar">
 			<span class="room-mobile-title">{data.room.title}</span>
-			<span class="room-mobile-timer event-timer--{status}">{timerLabel}</span>
-			{#if status === "open"}
-				<span class="event-timer-badge">受付中</span>
+			{#if !isGlobalLobby}
+				<span class="room-mobile-timer event-timer--{status}">{timerLabel}</span>
+				{#if status === "open"}
+					<span class="event-timer-badge">受付中</span>
+				{/if}
 			{/if}
 		</div>
 
@@ -336,8 +352,9 @@ function formatCompactDate(iso: string) {
 							bind:this={textareaEl}
 							class="composer-textarea"
 							name="content"
-							placeholder="いまの感想を投稿... (Shift+Enterで改行)"
-							rows="3"
+							placeholder={isMobileViewport ? "いまの感想を投稿..." : "いまの感想を投稿... (Shift+Enterで改行)"}
+							rows={isMobileViewport ? 1 : 3}
+							enterkeyhint="send"
 							bind:value={postContent}
 							maxlength={maxLen}
 							onkeydown={(e) => {
@@ -397,30 +414,40 @@ function formatCompactDate(iso: string) {
 			</button>
 		</div>
 
-		{#if allPosts.length === 0}
-			<div class="card anime-room-empty">まだ投稿はありません。最初の感想を残しましょう。</div>
-		{:else}
-			{#each displayedPosts as post (post.id)}
-				<div class="anime-room-post">
-					<LiveRoomPostCard
-						{post}
-						currentUserId={data.user?.id ?? null}
-						broadcastStartAt={data.room.scheduled_at}
-					/>
-				</div>
-			{/each}
-		{/if}
+		<div class="room-post-list-shell">
+			<div class="room-post-list scrollbar-thin-muted" bind:this={postListEl} onscroll={handlePostListScroll}>
+				{#if allPosts.length === 0}
+					<div class="card anime-room-empty">まだ投稿はありません。最初の感想を残しましょう。</div>
+				{:else}
+					{#each displayedPosts as post (post.id)}
+						<div class="anime-room-post">
+							<LiveRoomPostCard
+								{post}
+								currentUserId={data.user?.id ?? null}
+								broadcastStartAt={data.room.scheduled_at}
+							/>
+						</div>
+					{/each}
+				{/if}
+			</div>
 
-		{#if status === "open" && unreadNewPostCount > 0}
-			<button type="button" class="new-posts-badge" onclick={resumeLatestFollow}>
-				<span aria-hidden="true">↓</span>
-				<span>新着の投稿があります</span>
-				<span class="new-posts-count">{unreadNewPostCount}</span>
-			</button>
-		{/if}
+			{#if showLatestJumpButton}
+				<button
+					type="button"
+					class="new-posts-badge"
+					onclick={resumeLatestFollow}
+					aria-label="Jump to latest post"
+				>
+					<span aria-hidden="true">{latestJumpArrow}</span>
+					{#if unreadNewPostCount > 0}
+						<span class="new-posts-count">{unreadNewPostCount}</span>
+					{/if}
+				</button>
+			{/if}
+		</div>
 	</div>
 
-	<aside class="sidebar-column">
+	<aside class="sidebar-column scrollbar-thin-muted">
 		<div class="room-summary-card mb-4 rounded-xl border p-4 shadow-sm">
 			<div class="flex items-start">
 				<a href="/anime/{data.anime.id}" class="shrink-0" aria-label="アニメ詳細を開く">
@@ -491,9 +518,32 @@ function formatCompactDate(iso: string) {
 	color: var(--color-accent-hover);
 }
 
-.feed-column {
+.room-page-container {
+	max-width: none;
+	height: 100dvh;
+	margin: 0;
+	align-items: stretch;
+	overflow: hidden;
+	padding-right: max(24px, env(safe-area-inset-right));
+	padding-bottom: 24px;
+	padding-left: max(16px, calc((100% - (var(--content-max) + 48px)) / 2 + 16px));
+}
+
+.room-page-container > .feed-column {
 	display: flex;
+	flex: 0 0 var(--feed-width);
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
 	flex-direction: column;
+}
+
+.room-page-container > .sidebar-column {
+	flex: 1 1 var(--sidebar-width);
+	max-height: 100%;
+	overflow-x: hidden;
+	overflow-y: auto;
+	padding-bottom: 24px;
 }
 
 .room-mobile-bar {
@@ -503,23 +553,37 @@ function formatCompactDate(iso: string) {
 .event-posts-header,
 .room-order-toggle {
 	order: 1;
+	flex: 0 0 auto;
 }
 
-.anime-room-empty,
-.anime-room-post {
+.room-post-list-shell {
+	position: relative;
 	order: 2;
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+.room-post-list {
+	height: 100%;
+	min-height: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
+	overscroll-behavior: contain;
 }
 
 .new-posts-badge {
-	position: fixed;
+	position: absolute;
 	left: 50%;
-	bottom: 24px;
-	z-index: 145;
+	bottom: 12px;
+	z-index: 4;
 	display: inline-flex;
 	align-items: center;
+	justify-content: center;
 	gap: 8px;
-	max-width: calc(100vw - 32px);
-	padding: 9px 14px;
+	min-width: 40px;
+	min-height: 40px;
+	max-width: calc(100% - 32px);
+	padding: 8px 12px;
 	border: 1px solid color-mix(in srgb, var(--color-primary) 28%, transparent);
 	border-radius: 999px;
 	background: color-mix(in srgb, var(--color-surface) 92%, var(--color-primary));
@@ -565,7 +629,7 @@ function formatCompactDate(iso: string) {
 	align-self: flex-start;
 	gap: 2px;
 	padding: 3px;
-	margin: -4px 0 12px;
+	margin: -4px 0 10px;
 	background: var(--color-surface);
 	border: 1px solid var(--color-border);
 	border-radius: var(--radius-sm);
@@ -619,15 +683,6 @@ function formatCompactDate(iso: string) {
 	color: var(--color-primary);
 	font-weight: 600;
 }
-@media (max-width: 960px) {
-	.room-mobile-bar {
-		display: flex;
-	}
-
-	.new-posts-badge {
-		bottom: calc(76px + env(safe-area-inset-bottom));
-	}
-}
 
 /* ── ログイン/空状態 ── */
 .anime-room-login,
@@ -641,10 +696,98 @@ function formatCompactDate(iso: string) {
 .feed-column > .composer,
 .feed-column > .anime-room-login {
 	order: 3;
-	margin-top: 16px;
+	position: relative;
+	z-index: 2;
+	flex: 0 0 auto;
+	margin-top: 12px;
 }
 
 .feed-column > .composer {
-	margin-bottom: 0;
+	margin-bottom: 24px;
+}
+
+@media (max-width: 960px) {
+	.room-page-container {
+		height: calc(100dvh - 52px);
+		padding-right: 12px;
+		padding-bottom: calc(80px + env(safe-area-inset-bottom));
+		padding-left: 12px;
+	}
+
+	.room-page-container > .feed-column {
+		flex: 1 1 auto;
+	}
+
+	.room-mobile-bar {
+		display: flex;
+	}
+
+	.room-page-container .room-post-list {
+		padding-bottom: 14px;
+	}
+
+	.room-page-container .new-posts-badge {
+		bottom: 8px;
+	}
+
+	.room-page-container .feed-column > .composer {
+		margin-top: 8px;
+		margin-bottom: 0;
+		padding: 8px 10px;
+		border-radius: 14px;
+	}
+
+	.room-page-container .composer form,
+	.room-page-container .composer-body {
+		min-width: 0;
+		width: 100%;
+	}
+
+	.room-page-container .composer-body {
+		align-items: center;
+		gap: 8px;
+	}
+
+	.room-page-container .composer-textarea {
+		min-height: 24px;
+		max-height: 80px;
+		height: 24px;
+		line-height: 1.5;
+		font-size: 15px;
+		overflow-y: auto;
+	}
+
+	.room-page-container .composer-footer {
+		flex: 0 0 auto;
+		gap: 8px;
+		margin-top: 0;
+		padding-top: 0;
+		border-top: 0;
+	}
+
+	.room-page-container .composer-footer .char-count {
+		font-size: 12px;
+		line-height: 1;
+	}
+
+	.room-page-container .composer-footer .btn {
+		min-height: 32px;
+		padding: 6px 12px;
+		white-space: nowrap;
+	}
+}
+
+@media (max-width: 480px) {
+	.room-page-container {
+		padding-right: 8px;
+		padding-left: 8px;
+	}
+}
+
+@media (max-width: 375px) {
+	.room-page-container {
+		padding-right: 6px;
+		padding-left: 6px;
+	}
 }
 </style>


### PR DESCRIPTION
## Summary
- Fix the live room shell so page-level scrollbars do not appear/disappear during room entry or reload.
- Move the live room timeline to an internal scroll area with stable latest-post behavior and a compact latest-jump button.
- Align timeline/sidebar widths, add muted thin scrollbars, tighten post-card footer spacing, and refine mobile composer behavior.

## Root Cause
The room layout was still affected by the browser-level scrollbar lifecycle: entering or reloading a room briefly changed the available page width, which caused visible layout shifts. The room timeline and sidebar also mixed page-level and component-level scroll behavior.

## Validation
- `pnpm.cmd exec biome check src/app.css src/routes/+layout.svelte src/routes/rooms/anime/[id]/[date]/+page.svelte`
- `pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json`
- `git diff --check`
- Browser measurement confirmed the app width, feed left edge, and sidebar left edge stay stable across timeline -> room navigation and room reload.