### PR TITLE
fix: プロフィール編集モーダルにアイコン画像の変更欄を追加 (close #108)

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -20,7 +20,9 @@ function isOnboardingExempt(pathname: string): boolean {
 export const load: ServerLoad = async ({ locals: { supabase, safeGetSession }, cookies, url }) => {
 	const { session, user } = await safeGetSession();
 
-	const { data: profile, error: profileError } = user ? await getProfileById(supabase, user.id) : { data: null, error: null };
+	const { data: profile, error: profileError } = user
+		? await getProfileById(supabase, user.id)
+		: { data: null, error: null };
 
 	if (profileError) {
 		error(500, "プロフィールの取得に失敗しました");

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -561,7 +561,6 @@ function isAiringToday(anime: AnimeListItem): boolean {
 					<a href="/anime" class="search-clear" title="フィルターをすべてクリア">✕</a>
 				{/if}
 			</div>
-
 		</form>
 
 		<nav class="tab-nav">

--- a/src/routes/profile/[username]/+page.svelte
+++ b/src/routes/profile/[username]/+page.svelte
@@ -28,6 +28,12 @@ let profileSubmitting = $state(false);
 let headerUploading = $state(false);
 let headerMessage = $state("");
 let headerPreviewUrl = $state<string | null>(null);
+let headerPendingFile = $state<File | null>(null);
+let headerPendingDelete = $state(false);
+let avatarUploading = $state(false);
+let avatarMessage = $state("");
+let avatarPreviewUrl = $state<string | null>(null);
+let avatarPendingFile = $state<File | null>(null);
 let showProfileEditModal = $state(false);
 let showUserReportModal = $state(false);
 let reportReason = $state("harassment");
@@ -53,11 +59,72 @@ const activeTab = $derived(
 	requestedTab === "images" || requestedTab === "list" || requestedTab === "likes" ? requestedTab : "posts",
 );
 const bioRemaining = $derived(160 - editBio.length);
-const editableHeaderUrl = $derived(headerPreviewUrl ?? profile.header_url);
+const editableHeaderUrl = $derived(headerPreviewUrl ?? (headerPendingDelete ? null : profile.header_url));
 
 const handleProfileSubmit: SubmitFunction = () => {
 	profileSubmitting = true;
 	return async ({ result, update }) => {
+		if (headerPendingFile) {
+			headerUploading = true;
+			headerMessage = "";
+			try {
+				const body = new FormData();
+				body.append("file", headerPendingFile);
+				const response = await fetch("/api/upload/profile-header", { method: "POST", body });
+				const res = (await response.json().catch(() => ({}))) as { message?: string };
+				if (!response.ok) throw new Error(res.message ?? "ヘッダー画像の更新に失敗しました");
+				if (headerPreviewUrl) {
+					URL.revokeObjectURL(headerPreviewUrl);
+					headerPreviewUrl = null;
+				}
+				headerPendingFile = null;
+			} catch (uploadError) {
+				headerMessage = uploadError instanceof Error ? uploadError.message : "ヘッダー画像の更新に失敗しました";
+				headerUploading = false;
+				profileSubmitting = false;
+				return;
+			}
+			headerUploading = false;
+		} else if (headerPendingDelete) {
+			headerUploading = true;
+			headerMessage = "";
+			try {
+				const response = await fetch("/api/upload/profile-header", { method: "DELETE" });
+				const res = (await response.json().catch(() => ({}))) as { message?: string };
+				if (!response.ok) throw new Error(res.message ?? "ヘッダー画像の削除に失敗しました");
+				headerPendingDelete = false;
+			} catch (deleteError) {
+				headerMessage = deleteError instanceof Error ? deleteError.message : "ヘッダー画像の削除に失敗しました";
+				headerUploading = false;
+				profileSubmitting = false;
+				return;
+			}
+			headerUploading = false;
+		}
+
+		if (avatarPendingFile) {
+			avatarUploading = true;
+			avatarMessage = "";
+			try {
+				const body = new FormData();
+				body.append("file", avatarPendingFile);
+				const response = await fetch("/api/upload/avatar", { method: "POST", body });
+				const res = (await response.json().catch(() => ({}))) as { message?: string };
+				if (!response.ok) throw new Error(res.message ?? "アイコン画像の更新に失敗しました");
+				if (avatarPreviewUrl) {
+					URL.revokeObjectURL(avatarPreviewUrl);
+					avatarPreviewUrl = null;
+				}
+				avatarPendingFile = null;
+			} catch (uploadError) {
+				avatarMessage = uploadError instanceof Error ? uploadError.message : "アイコン画像の更新に失敗しました";
+				avatarUploading = false;
+				profileSubmitting = false;
+				return;
+			}
+			avatarUploading = false;
+		}
+
 		profileSubmitting = false;
 		await update({ reset: false });
 		if (result.type === "success") {
@@ -81,14 +148,26 @@ function openProfileEditModal() {
 }
 
 function closeProfileEditModal() {
-	if (profileSubmitting || headerUploading) return;
+	if (profileSubmitting || headerUploading || avatarUploading) return;
 	showProfileEditModal = false;
 	headerMessage = "";
+	avatarMessage = "";
+	if (headerPreviewUrl) {
+		URL.revokeObjectURL(headerPreviewUrl);
+		headerPreviewUrl = null;
+	}
+	headerPendingFile = null;
+	headerPendingDelete = false;
+	if (avatarPreviewUrl) {
+		URL.revokeObjectURL(avatarPreviewUrl);
+		avatarPreviewUrl = null;
+	}
+	avatarPendingFile = null;
 	editDisplayName = data.profile.display_name ?? "";
 	editBio = data.profile.bio ?? "";
 }
 
-async function updateHeaderImage(event: Event) {
+function updateHeaderImage(event: Event) {
 	const input = event.currentTarget as HTMLInputElement;
 	const file = input.files?.[0];
 	if (!file) return;
@@ -105,42 +184,42 @@ async function updateHeaderImage(event: Event) {
 		return;
 	}
 
-	const previewUrl = URL.createObjectURL(file);
-	headerPreviewUrl = previewUrl;
-	headerUploading = true;
-	try {
-		const body = new FormData();
-		body.append("file", file);
-		const response = await fetch("/api/upload/profile-header", { method: "POST", body });
-		const result = (await response.json().catch(() => ({}))) as { message?: string };
-		if (!response.ok) throw new Error(result.message ?? "ヘッダー画像の更新に失敗しました");
-		await invalidateAll();
-		headerMessage = "ヘッダー画像を更新しました。";
-	} catch (uploadError) {
-		headerMessage = uploadError instanceof Error ? uploadError.message : "ヘッダー画像の更新に失敗しました";
-	} finally {
-		headerUploading = false;
-		headerPreviewUrl = null;
-		URL.revokeObjectURL(previewUrl);
-		input.value = "";
-	}
+	if (headerPreviewUrl) URL.revokeObjectURL(headerPreviewUrl);
+	headerPreviewUrl = URL.createObjectURL(file);
+	headerPendingFile = file;
+	headerPendingDelete = false;
 }
 
-async function removeHeaderImage() {
-	if (headerUploading || !profile.header_url) return;
-	headerUploading = true;
-	headerMessage = "";
-	try {
-		const response = await fetch("/api/upload/profile-header", { method: "DELETE" });
-		const result = (await response.json().catch(() => ({}))) as { message?: string };
-		if (!response.ok) throw new Error(result.message ?? "ヘッダー画像の削除に失敗しました");
-		await invalidateAll();
-		headerMessage = "ヘッダー画像を削除しました。";
-	} catch (removeError) {
-		headerMessage = removeError instanceof Error ? removeError.message : "ヘッダー画像の削除に失敗しました";
-	} finally {
-		headerUploading = false;
+function updateAvatarImage(event: Event) {
+	const input = event.currentTarget as HTMLInputElement;
+	const file = input.files?.[0];
+	if (!file) return;
+
+	avatarMessage = "";
+	if (!["image/jpeg", "image/png", "image/webp"].includes(file.type)) {
+		avatarMessage = "JPEG、PNG、WebP形式の画像を選択してください。";
+		input.value = "";
+		return;
 	}
+	if (file.size > 2 * 1024 * 1024) {
+		avatarMessage = "画像は2MB以内にしてください。";
+		input.value = "";
+		return;
+	}
+
+	if (avatarPreviewUrl) URL.revokeObjectURL(avatarPreviewUrl);
+	avatarPreviewUrl = URL.createObjectURL(file);
+	avatarPendingFile = file;
+}
+
+function removeHeaderImage() {
+	if (headerPreviewUrl) {
+		URL.revokeObjectURL(headerPreviewUrl);
+		headerPreviewUrl = null;
+	}
+	headerPendingFile = null;
+	headerPendingDelete = true;
+	headerMessage = "";
 }
 
 async function submitUserReport() {
@@ -428,6 +507,32 @@ const grouped = $derived(
 							{/if}
 
 							<div class="field">
+								<span class="field-label">アイコン画像</span>
+								<div class="profile-avatar-editor">
+									<UserAvatar
+										src={avatarPreviewUrl ?? profile.avatar_url}
+										username={profile.username}
+										size="lg"
+									/>
+								</div>
+								<div class="profile-header-editor-actions">
+									<label class="btn btn-outline profile-header-file-button">
+										{avatarUploading ? '処理中...' : '画像を選択'}
+										<input
+											type="file"
+											accept="image/jpeg,image/png,image/webp"
+											disabled={avatarUploading}
+											onchange={updateAvatarImage}
+										>
+									</label>
+								</div>
+								<p class="field-hint">JPEG、PNG、WebP・最大2MB。</p>
+								{#if avatarMessage}
+									<p class="profile-header-editor-message" aria-live="polite">{avatarMessage}</p>
+								{/if}
+							</div>
+
+							<div class="field">
 								<span class="field-label">ヘッダー画像</span>
 								<div class="profile-header-editor">
 									{#if editableHeaderUrl}
@@ -446,7 +551,7 @@ const grouped = $derived(
 											onchange={updateHeaderImage}
 										>
 									</label>
-									{#if profile.header_url}
+									{#if editableHeaderUrl}
 										<button
 											type="button"
 											class="btn btn-ghost"
@@ -894,6 +999,12 @@ const grouped = $derived(
 	min-height: 0;
 	padding: 14px;
 	overflow-y: auto;
+}
+
+.profile-avatar-editor {
+	display: flex;
+	align-items: center;
+	gap: 12px;
 }
 
 .profile-header-editor {

--- a/src/routes/profile/[username]/+page.svelte
+++ b/src/routes/profile/[username]/+page.svelte
@@ -64,6 +64,13 @@ const editableHeaderUrl = $derived(headerPreviewUrl ?? (headerPendingDelete ? nu
 const handleProfileSubmit: SubmitFunction = () => {
 	profileSubmitting = true;
 	return async ({ result, update }) => {
+		// プロフィールテキストの保存が失敗した場合は画像処理をスキップ
+		if (result.type !== "success") {
+			profileSubmitting = false;
+			await update({ reset: false });
+			return;
+		}
+
 		if (headerPendingFile) {
 			headerUploading = true;
 			headerMessage = "";
@@ -82,6 +89,7 @@ const handleProfileSubmit: SubmitFunction = () => {
 				headerMessage = uploadError instanceof Error ? uploadError.message : "ヘッダー画像の更新に失敗しました";
 				headerUploading = false;
 				profileSubmitting = false;
+				await update({ reset: false });
 				return;
 			}
 			headerUploading = false;
@@ -97,6 +105,7 @@ const handleProfileSubmit: SubmitFunction = () => {
 				headerMessage = deleteError instanceof Error ? deleteError.message : "ヘッダー画像の削除に失敗しました";
 				headerUploading = false;
 				profileSubmitting = false;
+				await update({ reset: false });
 				return;
 			}
 			headerUploading = false;
@@ -120,6 +129,7 @@ const handleProfileSubmit: SubmitFunction = () => {
 				avatarMessage = uploadError instanceof Error ? uploadError.message : "アイコン画像の更新に失敗しました";
 				avatarUploading = false;
 				profileSubmitting = false;
+				await update({ reset: false });
 				return;
 			}
 			avatarUploading = false;
@@ -127,11 +137,9 @@ const handleProfileSubmit: SubmitFunction = () => {
 
 		profileSubmitting = false;
 		await update({ reset: false });
-		if (result.type === "success") {
-			editDisplayName = data.profile.display_name ?? "";
-			editBio = data.profile.bio ?? "";
-			showProfileEditModal = false;
-		}
+		editDisplayName = data.profile.display_name ?? "";
+		editBio = data.profile.bio ?? "";
+		showProfileEditModal = false;
 	};
 };
 

--- a/src/routes/settings/mutes/+page.server.ts
+++ b/src/routes/settings/mutes/+page.server.ts
@@ -7,7 +7,10 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 	const { user } = await safeGetSession();
 	if (!user) redirect(303, "/");
 
-	const [mutedWords, mutes] = await Promise.all([getMutedWordRows(supabase, user.id), getAnimeMutes(supabase, user.id)]);
+	const [mutedWords, mutes] = await Promise.all([
+		getMutedWordRows(supabase, user.id),
+		getAnimeMutes(supabase, user.id),
+	]);
 
 	const parsedAnimeId = parsePositiveInt(url.searchParams.get("anime_id"));
 	const stagedAnimeId = parsedAnimeId !== null ? String(parsedAnimeId) : null;


### PR DESCRIPTION
## Summary

- プロフィール編集モーダルに**アイコン画像**の変更欄を追加（`/api/upload/avatar` は実装済みだったが UIへの導線がなかった）
- ヘッダー画像・アイコン画像ともにファイル選択時はプレビュー表示のみとし、**「保存する」ボタン押下時にアップロード**するよう変更
- 「キャンセル」または「×」で閉じた場合は選択ファイルを破棄し、元の状態に戻る
- 削除ボタンも保存時に実行（押下時はプレビューをクリアするのみ）

## Test plan

- [ ] プロフィール編集モーダルを開き、アイコン画像欄が表示されることを確認
- [ ] アイコン画像を選択するとプレビューが表示されること
- [ ] 「キャンセル」を押すとプレビューが破棄され元の画像が維持されること
- [ ] 「保存する」を押すとアイコン画像が実際に更新されること
- [ ] ヘッダー画像も同様に保存時のみアップロードされることを確認
- [ ] ヘッダー画像の削除も保存時に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)