### PR TITLE
タイムラインからルームリンクを付与できる機能を追加

### DIFF
--- a/src/lib/components/PostComposer.svelte
+++ b/src/lib/components/PostComposer.svelte
@@ -75,6 +75,21 @@ let selectedCwAnime = $state<AnimeResult | null>(null);
 let cwSearchDebounce: ReturnType<typeof setTimeout> | null = null;
 let cwInputEl = $state<HTMLInputElement | null>(null);
 
+// 実況ルームリンク
+type OpenRoom = {
+	id: string;
+	anime_id: number;
+	room_date: string;
+	room_kind: "episode" | "global";
+	room_key: string;
+	scheduled_at: string;
+	anime: { id: number; title: string; cover_url: string | null } | null;
+};
+let selectedRoom = $state<OpenRoom | null>(null);
+let roomModalOpen = $state(false);
+let openRooms = $state<OpenRoom[] | null>(null);
+let roomsLoading = $state(false);
+
 // @メンション
 let textareaEl = $state<HTMLTextAreaElement | null>(null);
 let mentionResults = $state<UserResult[]>([]);
@@ -199,6 +214,28 @@ function selectCwAnime(anime: AnimeResult) {
 }
 function clearCwAnime() {
 	selectedCwAnime = null;
+}
+
+async function openRoomSearch() {
+	roomModalOpen = true;
+	if (openRooms !== null) return;
+	roomsLoading = true;
+	try {
+		const res = await fetch("/api/rooms/open");
+		openRooms = await res.json();
+	} finally {
+		roomsLoading = false;
+	}
+}
+function closeRoomModal() {
+	roomModalOpen = false;
+}
+function selectRoom(room: OpenRoom) {
+	selectedRoom = room;
+	roomModalOpen = false;
+}
+function clearRoom() {
+	selectedRoom = null;
 }
 function handleCwQueryInput() {
 	if (cwSearchDebounce) clearTimeout(cwSearchDebounce);
@@ -344,7 +381,7 @@ const handleSubmit: SubmitFunction = () => {
 				{/if}
 			</div>
 
-			{#if selectedAnime || selectedCwAnime}
+			{#if selectedAnime || selectedCwAnime || selectedRoom}
 				<div class="flex flex-wrap gap-2 mt-2 mb-0.5">
 					{#if selectedAnime}
 						<span
@@ -379,15 +416,40 @@ const handleSubmit: SubmitFunction = () => {
 							</button>
 						</span>
 					{/if}
+
+					{#if selectedRoom}
+						<span
+							class="inline-flex items-center gap-1.5 max-w-full rounded-full border border-green-500/50 bg-green-950/40 px-3 py-1 text-sm font-semibold leading-tight text-green-300"
+						>
+							<span class="i-lucide-door-open shrink-0" aria-hidden="true"></span>
+							<span class="min-w-0 max-w-[24ch] truncate"
+								>{selectedRoom.anime?.title ?? "実況ルーム"}</span
+							>
+							<button
+								type="button"
+								class="-mr-1 inline-flex h-5 w-5 items-center justify-center rounded-full border-0 bg-transparent p-0 text-current opacity-70 hover:bg-white/15 hover:opacity-100"
+								onclick={clearRoom}
+								aria-label="ルームリンクを削除"
+							>
+								✕
+							</button>
+						</span>
+					{/if}
 				</div>
 			{/if}
 
 			{#if selectedAnime}
 				<input type="hidden" name="anime_id" value={selectedAnime.id}>
+			{:else if selectedRoom}
+				<input type="hidden" name="anime_id" value={selectedRoom.anime_id}>
 			{/if}
 
 			{#if selectedCwAnime}
 				<input type="hidden" name="cw_anime_id" value={selectedCwAnime.id}>
+			{/if}
+
+			{#if selectedRoom}
+				<input type="hidden" name="broadcast_room_session_id" value={selectedRoom.id}>
 			{/if}
 
 			{#if selectedExchangeShare}
@@ -552,6 +614,18 @@ const handleSubmit: SubmitFunction = () => {
 					</svg>
 				</button>
 
+				<!-- 実況ルームリンクボタン -->
+				<button
+					type="button"
+					class="composer-image-btn"
+					class:active={selectedRoom !== null}
+					onclick={openRoomSearch}
+					aria-label="実況ルームにリンク"
+					title="実況ルームにリンク"
+				>
+					<span class="i-lucide-door-open" style="width:18px;height:18px;" aria-hidden="true"></span>
+				</button>
+
 				<span class="char-count {countClass}">{remaining}</span>
 				<button type="submit" class="btn btn-primary" disabled={!canSubmit}>
 					{submitting ? '投稿中…' : '投稿'}
@@ -665,6 +739,53 @@ const handleSubmit: SubmitFunction = () => {
 								<span class="anime-search-item-title">{anime.title}</span>
 								{#if anime.title_en}
 									<span class="anime-search-item-sub">{anime.title_en}</span>
+								{/if}
+							</div>
+						</button>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- 実況ルーム選択モーダル -->
+{#if roomModalOpen}
+	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_noninteractive_element_interactions -->
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<div
+		class="anime-search-overlay"
+		onclick={(e) => { if (e.target === e.currentTarget) closeRoomModal(); }}
+		role="dialog"
+		aria-modal="true"
+		aria-label="実況ルームを選択"
+		tabindex="-1"
+		use:trapFocus
+	>
+		<div class="anime-search-modal">
+			<div class="anime-search-header">
+				<span class="anime-search-title">実況ルームを選択</span>
+				<button type="button" class="anime-search-close" onclick={closeRoomModal} aria-label="閉じる">✕</button>
+			</div>
+			<div class="anime-search-results">
+				{#if roomsLoading}
+					<p class="anime-search-empty">読み込み中…</p>
+				{:else if openRooms !== null && openRooms.length === 0}
+					<p class="anime-search-empty">現在開放中のルームはありません</p>
+				{:else if openRooms}
+					{#each openRooms as room}
+						<button type="button" class="anime-search-item" onclick={() => selectRoom(room)}>
+							{#if room.anime?.cover_url}
+								<img src={room.anime.cover_url} alt={room.anime.title} class="anime-search-thumb">
+							{:else}
+								<div class="anime-search-thumb anime-search-thumb-empty"></div>
+							{/if}
+							<div class="anime-search-item-info">
+								<span class="anime-search-item-title">{room.anime?.title ?? "不明"}</span>
+								{#if room.room_kind === "episode"}
+									<span class="anime-search-item-sub">{room.room_date}</span>
+								{:else}
+									<span class="anime-search-item-sub">総合ロビー</span>
 								{/if}
 							</div>
 						</button>

--- a/src/lib/components/PostComposer.svelte
+++ b/src/lib/components/PostComposer.svelte
@@ -78,12 +78,12 @@ let cwInputEl = $state<HTMLInputElement | null>(null);
 // 実況ルームリンク
 type OpenRoom = {
 	id: string;
-	anime_id: number;
+	anime_id: string;
 	room_date: string;
 	room_kind: "episode" | "global";
 	room_key: string;
 	scheduled_at: string;
-	anime: { id: number; title: string; cover_url: string | null } | null;
+	anime: { id: string; title: string; cover_url: string | null } | null;
 };
 let selectedRoom = $state<OpenRoom | null>(null);
 let roomModalOpen = $state(false);
@@ -218,11 +218,13 @@ function clearCwAnime() {
 
 async function openRoomSearch() {
 	roomModalOpen = true;
-	if (openRooms !== null) return;
 	roomsLoading = true;
 	try {
 		const res = await fetch("/api/rooms/open");
+		if (!res.ok) throw new Error(`HTTP ${res.status}`);
 		openRooms = await res.json();
+	} catch {
+		openRooms = [];
 	} finally {
 		roomsLoading = false;
 	}
@@ -773,7 +775,7 @@ const handleSubmit: SubmitFunction = () => {
 				{:else if openRooms !== null && openRooms.length === 0}
 					<p class="anime-search-empty">現在開放中のルームはありません</p>
 				{:else if openRooms}
-					{#each openRooms as room}
+					{#each openRooms as room (room.id)}
 						<button type="button" class="anime-search-item" onclick={() => selectRoom(room)}>
 							{#if room.anime?.cover_url}
 								<img src={room.anime.cover_url} alt={room.anime.title} class="anime-search-thumb">

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -2679,3 +2679,24 @@ export async function getAnimeMuteCandidate(supabase: SupabaseClient<Database>, 
 	if (!data) return null;
 	return { id: String(data.id), title: data.title, cover_url: data.cover_url ?? null };
 }
+
+export async function getOpenBroadcastRoomSessions(supabase: SupabaseClient<Database>) {
+	const now = new Date().toISOString();
+	const { data } = await supabase
+		.from("broadcast_room_sessions")
+		.select(
+			"id, anime_id, room_date, room_kind, room_key, scheduled_at, anime:anime!broadcast_room_sessions_anime_id_fkey ( id, title, cover_url )",
+		)
+		.lte("posting_opens_at", now)
+		.gte("posting_closes_at", now)
+		.order("scheduled_at");
+	return (data ?? []) as {
+		id: string;
+		anime_id: number;
+		room_date: string;
+		room_kind: "episode" | "global";
+		room_key: string;
+		scheduled_at: string;
+		anime: { id: number; title: string; cover_url: string | null } | null;
+	}[];
+}

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -2682,7 +2682,7 @@ export async function getAnimeMuteCandidate(supabase: SupabaseClient<Database>, 
 
 export async function getOpenBroadcastRoomSessions(supabase: SupabaseClient<Database>) {
 	const now = new Date().toISOString();
-	const { data } = await supabase
+	const { data, error } = await supabase
 		.from("broadcast_room_sessions")
 		.select(
 			"id, anime_id, room_date, room_kind, room_key, scheduled_at, anime:anime!broadcast_room_sessions_anime_id_fkey ( id, title, cover_url )",
@@ -2690,13 +2690,21 @@ export async function getOpenBroadcastRoomSessions(supabase: SupabaseClient<Data
 		.lte("posting_opens_at", now)
 		.gte("posting_closes_at", now)
 		.order("scheduled_at");
-	return (data ?? []) as {
-		id: string;
-		anime_id: number;
-		room_date: string;
-		room_kind: "episode" | "global";
-		room_key: string;
-		scheduled_at: string;
-		anime: { id: number; title: string; cover_url: string | null } | null;
-	}[];
+	if (error) {
+		console.error("getOpenBroadcastRoomSessions failed:", error);
+		return [];
+	}
+	type RawAnime = { id: number; title: string; cover_url: string | null };
+	return (data ?? []).map((row) => {
+		const anime = row.anime as unknown as RawAnime | null;
+		return {
+			id: row.id,
+			anime_id: String(row.anime_id),
+			room_date: row.room_date,
+			room_kind: row.room_kind as "episode" | "global",
+			room_key: row.room_key,
+			scheduled_at: row.scheduled_at,
+			anime: anime ? { id: String(anime.id), title: anime.title, cover_url: anime.cover_url ?? null } : null,
+		};
+	});
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -163,6 +163,7 @@ export const actions: Actions = {
 		const imageUrlsRaw = (form.get("image_urls") as string | null) ?? "[]";
 		const animeId = (form.get("anime_id") as string | null)?.trim() || null;
 		const cwAnimeId = (form.get("cw_anime_id") as string | null)?.trim() || null;
+		const broadcastRoomSessionId = (form.get("broadcast_room_session_id") as string | null)?.trim() || null;
 		const exchangeId = (form.get("exchange_id") as string | null)?.trim() || null;
 		let imageUrls: string[] = [];
 		try {
@@ -182,7 +183,7 @@ export const actions: Actions = {
 			exchangeShare?.received_anime.id ?? animeId,
 			null,
 			exchangeShare,
-			null,
+			broadcastRoomSessionId,
 			cwAnimeId,
 		);
 	},

--- a/src/routes/api/rooms/open/+server.ts
+++ b/src/routes/api/rooms/open/+server.ts
@@ -1,0 +1,9 @@
+import { json } from "@sveltejs/kit";
+import { getOpenBroadcastRoomSessions } from "$lib/server/queries";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) return json([], { status: 401 });
+	return json(await getOpenBroadcastRoomSessions(supabase));
+};

--- a/src/routes/posts/[id]/+page.server.ts
+++ b/src/routes/posts/[id]/+page.server.ts
@@ -78,13 +78,24 @@ export const actions: Actions = {
 		const content = (form.get("content") as string | null)?.trim() ?? "";
 		const imageUrlsRaw = (form.get("image_urls") as string | null) ?? "[]";
 		const animeId = (form.get("anime_id") as string | null)?.trim() || null;
+		const broadcastRoomSessionId = (form.get("broadcast_room_session_id") as string | null)?.trim() || null;
 		let imageUrls: string[] = [];
 		try {
 			imageUrls = JSON.parse(imageUrlsRaw);
 		} catch {
 			imageUrls = [];
 		}
-		return insertPostWithHashtags(supabase, user.id, content, params.id, imageUrls, animeId);
+		return insertPostWithHashtags(
+			supabase,
+			user.id,
+			content,
+			params.id,
+			imageUrls,
+			animeId,
+			null,
+			null,
+			broadcastRoomSessionId,
+		);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {


### PR DESCRIPTION
## Summary

- `PostComposer` フッターにドアアイコン（実況ルームリンク）ボタンを追加
- クリックすると現在開放中のルーム一覧モーダルが開き、選択するとプレビューチップ（緑）が表示される
- 投稿時に `broadcast_room_session_id` と `anime_id` が一緒に保存され、タイムラインの PostCard に `post-room-link` が自動表示される
- 返信コンポーザー（`/posts/[id]`）にも同様の対応済み

## Changes

- `src/lib/server/queries.ts` — `getOpenBroadcastRoomSessions()` 追加（`posting_opens_at ≤ now ≤ posting_closes_at` でフィルタ）
- `src/routes/api/rooms/open/+server.ts` — 新規 GET エンドポイント（要ログイン）
- `src/lib/components/PostComposer.svelte` — ルームボタン・モーダル・プレビューチップ・hidden inputs 追加
- `src/routes/+page.server.ts` / `src/routes/posts/[id]/+page.server.ts` — `broadcast_room_session_id` をフォームから読んで渡す

## Test plan

- [ ] PostComposer フッターにドアアイコンが表示される
- [ ] ルーム開放時間外はモーダルに「現在開放中のルームはありません」と表示される
- [ ] ルームを選択するとフッター上に緑色チップが表示され、✕で解除できる
- [ ] ルームリンク付きで投稿するとタイムラインに `post-room-link` が表示され、クリックでルームページへ遷移する
- [ ] ルームを選択しつつアニメ引用も設定した場合、両方のチップが並んで表示される（`anime_id` は引用アニメを優先）
- [ ] `pnpm check` 0 エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)