### PR TITLE
[codex] Add room exit survey

### DIFF
--- a/src/lib/components/ExitSurveyModal.svelte
+++ b/src/lib/components/ExitSurveyModal.svelte
@@ -1,0 +1,416 @@
+<script lang="ts">
+import { trapFocus } from "$lib/actions/trapFocus";
+import type { RoomExitSurveyComparisonWithX, RoomExitSurveyNextParticipation } from "$lib/types";
+
+type SurveyAnswers = {
+	overallRating: number;
+	sharedExperienceRating: number;
+	readabilityRating: number;
+	nextParticipation: RoomExitSurveyNextParticipation;
+	comparisonWithX: RoomExitSurveyComparisonWithX;
+	goodPoints: string | null;
+	improvementPoints: string | null;
+};
+
+type RatingField = "overallRating" | "sharedExperienceRating" | "readabilityRating";
+
+type Props = {
+	submitting?: boolean;
+	errorMessage?: string | null;
+	onSubmit: (answers: SurveyAnswers) => void;
+	onSkip: () => void;
+};
+
+let { submitting = false, errorMessage = null, onSubmit, onSkip }: Props = $props();
+
+let overallRating: number | null = $state(null);
+let sharedExperienceRating: number | null = $state(null);
+let readabilityRating: number | null = $state(null);
+let nextParticipation: RoomExitSurveyNextParticipation | "" = $state("");
+let comparisonWithX: RoomExitSurveyComparisonWithX | "" = $state("");
+let goodPoints = $state("");
+let improvementPoints = $state("");
+
+const ratingLabels: Record<RatingField, string> = {
+	overallRating: "今回の実況ルームは楽しかったですか？",
+	sharedExperienceRating: "他の人と一緒に見ている感覚はありましたか？",
+	readabilityRating: "投稿の流れは見やすかったですか？",
+};
+
+const ratingCaptions: Record<RatingField, [string, string, string]> = {
+	overallRating: ["楽しくなかった", "どちらともいえない", "とても楽しかった"],
+	sharedExperienceRating: ["なかった", "どちらともいえない", "強くあった"],
+	readabilityRating: ["見づらかった", "どちらともいえない", "とても見やすかった"],
+};
+
+const nextParticipationOptions: Array<{ value: RoomExitSurveyNextParticipation; label: string }> = [
+	{ value: "must_join", label: "必ず参加したい" },
+	{ value: "want_join", label: "できれば参加したい" },
+	{ value: "not_sure", label: "わからない" },
+	{ value: "not_really", label: "あまり参加したくない" },
+	{ value: "not_join", label: "参加したくない" },
+];
+
+const comparisonOptions: Array<{ value: RoomExitSurveyComparisonWithX; label: string }> = [
+	{ value: "anipolis_better", label: "Anipolisの方がよい" },
+	{ value: "anipolis_slightly_better", label: "どちらかといえばAnipolis" },
+	{ value: "same", label: "どちらともいえない" },
+	{ value: "x_slightly_better", label: "どちらかといえばX / Twitter" },
+	{ value: "x_better", label: "X / Twitterの方がよい" },
+	{ value: "cannot_compare", label: "普段X / Twitterで実況しないので比較できない" },
+];
+
+const canSubmit = $derived(
+	overallRating != null &&
+		sharedExperienceRating != null &&
+		readabilityRating != null &&
+		nextParticipation !== "" &&
+		comparisonWithX !== "",
+);
+
+function ratingValue(field: RatingField) {
+	if (field === "overallRating") return overallRating;
+	if (field === "sharedExperienceRating") return sharedExperienceRating;
+	return readabilityRating;
+}
+
+function setRating(field: RatingField, value: number) {
+	if (field === "overallRating") overallRating = value;
+	else if (field === "sharedExperienceRating") sharedExperienceRating = value;
+	else readabilityRating = value;
+}
+
+function trimOptionalText(value: string) {
+	const trimmed = value.trim();
+	return trimmed ? trimmed.slice(0, 1000) : null;
+}
+
+function submit() {
+	if (!canSubmit || submitting) return;
+	onSubmit({
+		overallRating: overallRating ?? 3,
+		sharedExperienceRating: sharedExperienceRating ?? 3,
+		readabilityRating: readabilityRating ?? 3,
+		nextParticipation: nextParticipation as RoomExitSurveyNextParticipation,
+		comparisonWithX: comparisonWithX as RoomExitSurveyComparisonWithX,
+		goodPoints: trimOptionalText(goodPoints),
+		improvementPoints: trimOptionalText(improvementPoints),
+	});
+}
+</script>
+
+<div class="survey-backdrop" role="presentation">
+	<div
+		class="survey-modal"
+		use:trapFocus
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="exit-survey-title"
+		tabindex="-1"
+	>
+		<div class="survey-header">
+			<h2 id="exit-survey-title">ご参加ありがとうございました！</h2>
+			<p>
+				今回の実況ルームについて、1分だけ感想を教えてください。<br>
+				今後の改善に使わせていただきます。
+			</p>
+		</div>
+
+		<div class="survey-body">
+			{#each Object.keys(ratingLabels) as field (field)}
+				{@const ratingField = field as RatingField}
+				<section class="survey-question">
+					<h3>{ratingLabels[ratingField]}</h3>
+					<div class="rating-row" role="radiogroup" aria-label={ratingLabels[ratingField]}>
+						{#each [1, 2, 3, 4, 5] as value}
+							<button
+								type="button"
+								class:active={ratingValue(ratingField) === value}
+								aria-pressed={ratingValue(ratingField) === value}
+								disabled={submitting}
+								onclick={() => setRating(ratingField, value)}
+							>
+								{value}
+							</button>
+						{/each}
+					</div>
+					<div class="rating-caption">
+						<span>{ratingCaptions[ratingField][0]}</span>
+						<span>{ratingCaptions[ratingField][1]}</span>
+						<span>{ratingCaptions[ratingField][2]}</span>
+					</div>
+				</section>
+			{/each}
+
+			<section class="survey-question">
+				<h3>次回も同じ作品の実況ルームがあれば参加したいですか？</h3>
+				<div class="option-stack">
+					{#each nextParticipationOptions as option}
+						<label class="option-row">
+							<input
+								type="radio"
+								name="next-participation"
+								value={option.value}
+								bind:group={nextParticipation}
+								disabled={submitting}
+							>
+							<span>{option.label}</span>
+						</label>
+					{/each}
+				</div>
+			</section>
+
+			<section class="survey-question">
+				<h3>X / Twitterで実況する場合と比べてどうでしたか？</h3>
+				<div class="option-stack">
+					{#each comparisonOptions as option}
+						<label class="option-row">
+							<input
+								type="radio"
+								name="comparison-with-x"
+								value={option.value}
+								bind:group={comparisonWithX}
+								disabled={submitting}
+							>
+							<span>{option.label}</span>
+						</label>
+					{/each}
+				</div>
+			</section>
+
+			<label class="text-question">
+				<span>よかった点があれば教えてください</span>
+				<textarea bind:value={goodPoints} maxlength="1000" rows="3" disabled={submitting}></textarea>
+			</label>
+
+			<label class="text-question">
+				<span>使いにくかった点・改善してほしい点があれば教えてください</span>
+				<textarea bind:value={improvementPoints} maxlength="1000" rows="3" disabled={submitting}></textarea>
+			</label>
+		</div>
+
+		{#if errorMessage}
+			<p class="survey-error">{errorMessage}</p>
+		{/if}
+
+		<div class="survey-actions">
+			<button class="skip-button" type="button" disabled={submitting} onclick={onSkip}>スキップして退出</button>
+			<button class="submit-button" type="button" disabled={!canSubmit || submitting} onclick={submit}>
+				{submitting ? "送信中..." : "送信して退出"}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+.survey-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 100;
+	display: grid;
+	place-items: center;
+	background: rgb(0 0 0 / 0.54);
+	padding: 16px;
+}
+
+.survey-modal {
+	display: flex;
+	width: min(640px, 100%);
+	max-height: min(88dvh, 760px);
+	flex-direction: column;
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	background: var(--color-surface);
+	box-shadow: 0 24px 64px rgb(0 0 0 / 0.34);
+	color: var(--color-text);
+	overflow: hidden;
+}
+
+.survey-header {
+	padding: 20px 22px 14px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.survey-header h2 {
+	margin: 0 0 8px;
+	font-size: 20px;
+	line-height: 1.3;
+}
+
+.survey-header p {
+	margin: 0;
+	color: var(--color-text-muted);
+	font-size: 14px;
+	line-height: 1.7;
+}
+
+.survey-body {
+	display: grid;
+	gap: 18px;
+	padding: 18px 22px;
+	overflow-y: auto;
+}
+
+.survey-question h3,
+.text-question span {
+	display: block;
+	margin: 0 0 10px;
+	font-size: 14px;
+	font-weight: 800;
+	line-height: 1.5;
+}
+
+.rating-row {
+	display: grid;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: 6px;
+}
+
+.rating-row button {
+	min-width: 0;
+	min-height: 38px;
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	background: var(--color-bg);
+	color: var(--color-text);
+	font-weight: 800;
+}
+
+.rating-row button.active {
+	border-color: var(--color-accent);
+	background: var(--color-accent);
+	color: white;
+}
+
+.rating-caption {
+	display: flex;
+	justify-content: space-between;
+	gap: 8px;
+	margin-top: 7px;
+	color: var(--color-text-muted);
+	font-size: 11px;
+	line-height: 1.3;
+}
+
+.rating-caption span:nth-child(2) {
+	text-align: center;
+}
+
+.rating-caption span:last-child {
+	text-align: right;
+}
+
+.option-stack {
+	display: grid;
+	gap: 8px;
+}
+
+.option-row {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	min-height: 36px;
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	background: var(--color-bg);
+	padding: 8px 10px;
+	font-size: 14px;
+	line-height: 1.35;
+}
+
+.option-row input {
+	flex: 0 0 auto;
+	accent-color: var(--color-accent);
+}
+
+.text-question textarea {
+	width: 100%;
+	min-height: 78px;
+	resize: vertical;
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	background: var(--color-bg);
+	color: var(--color-text);
+	padding: 10px 12px;
+	font: inherit;
+	line-height: 1.5;
+}
+
+.survey-error {
+	margin: 0 22px 14px;
+	border: 1px solid var(--color-danger);
+	border-radius: 8px;
+	background: color-mix(in srgb, var(--color-danger) 10%, var(--color-surface));
+	color: var(--color-text);
+	padding: 10px 12px;
+	font-size: 13px;
+	font-weight: 700;
+}
+
+.survey-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	padding: 14px 22px 20px;
+	border-top: 1px solid var(--color-border);
+}
+
+.skip-button,
+.submit-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	border-radius: 8px;
+	padding: 0 14px;
+	font-weight: 800;
+}
+
+.skip-button {
+	border: 1px solid var(--color-border);
+	background: var(--color-surface);
+	color: var(--color-text);
+}
+
+.submit-button {
+	border: 1px solid var(--color-accent);
+	background: var(--color-accent);
+	color: white;
+}
+
+.skip-button:disabled,
+.submit-button:disabled,
+.rating-row button:disabled,
+.option-row input:disabled,
+.text-question textarea:disabled {
+	cursor: not-allowed;
+	opacity: 0.58;
+}
+
+@media (max-width: 560px) {
+	.survey-backdrop {
+		align-items: end;
+		padding: 10px;
+	}
+
+	.survey-modal {
+		max-height: calc(100dvh - 20px);
+	}
+
+	.survey-header,
+	.survey-body,
+	.survey-actions {
+		padding-right: 14px;
+		padding-left: 14px;
+	}
+
+	.survey-actions {
+		flex-direction: column-reverse;
+	}
+
+	.skip-button,
+	.submit-button {
+		width: 100%;
+	}
+}
+</style>

--- a/src/lib/components/ExitSurveyModal.svelte
+++ b/src/lib/components/ExitSurveyModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { tick } from "svelte";
 import { trapFocus } from "$lib/actions/trapFocus";
 import type { RoomExitSurveyComparisonWithX, RoomExitSurveyNextParticipation } from "$lib/types";
 
@@ -80,24 +81,30 @@ function setRating(field: RatingField, value: number) {
 	else readabilityRating = value;
 }
 
-function moveRating(field: RatingField, direction: -1 | 1) {
+function nextRatingValue(field: RatingField, direction: -1 | 1) {
 	const current = ratingValue(field) ?? 3;
-	setRating(field, Math.min(5, Math.max(1, current + direction)));
+	return Math.min(5, Math.max(1, current + direction));
+}
+
+async function setRatingAndFocus(field: RatingField, value: number) {
+	setRating(field, value);
+	await tick();
+	document.querySelector<HTMLButtonElement>(`[data-rating-field="${field}"][data-rating-value="${value}"]`)?.focus();
 }
 
 function handleRatingKeydown(event: KeyboardEvent, field: RatingField, value: number) {
 	if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
 		event.preventDefault();
-		moveRating(field, -1);
+		void setRatingAndFocus(field, nextRatingValue(field, -1));
 	} else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
 		event.preventDefault();
-		moveRating(field, 1);
+		void setRatingAndFocus(field, nextRatingValue(field, 1));
 	} else if (event.key === "Home") {
 		event.preventDefault();
-		setRating(field, 1);
+		void setRatingAndFocus(field, 1);
 	} else if (event.key === "End") {
 		event.preventDefault();
-		setRating(field, 5);
+		void setRatingAndFocus(field, 5);
 	} else if (event.key === " " || event.key === "Enter") {
 		event.preventDefault();
 		setRating(field, value);
@@ -153,6 +160,8 @@ function submit() {
 								role="radio"
 								class:active={selected}
 								aria-checked={selected}
+								data-rating-field={ratingField}
+								data-rating-value={value}
 								tabindex={selected || (ratingValue(ratingField) == null && value === 1) ? 0 : -1}
 								disabled={submitting}
 								onclick={() => setRating(ratingField, value)}

--- a/src/lib/components/ExitSurveyModal.svelte
+++ b/src/lib/components/ExitSurveyModal.svelte
@@ -80,6 +80,30 @@ function setRating(field: RatingField, value: number) {
 	else readabilityRating = value;
 }
 
+function moveRating(field: RatingField, direction: -1 | 1) {
+	const current = ratingValue(field) ?? 3;
+	setRating(field, Math.min(5, Math.max(1, current + direction)));
+}
+
+function handleRatingKeydown(event: KeyboardEvent, field: RatingField, value: number) {
+	if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+		event.preventDefault();
+		moveRating(field, -1);
+	} else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+		event.preventDefault();
+		moveRating(field, 1);
+	} else if (event.key === "Home") {
+		event.preventDefault();
+		setRating(field, 1);
+	} else if (event.key === "End") {
+		event.preventDefault();
+		setRating(field, 5);
+	} else if (event.key === " " || event.key === "Enter") {
+		event.preventDefault();
+		setRating(field, value);
+	}
+}
+
 function trimOptionalText(value: string) {
 	const trimmed = value.trim();
 	return trimmed ? trimmed.slice(0, 1000) : null;
@@ -123,12 +147,16 @@ function submit() {
 					<h3>{ratingLabels[ratingField]}</h3>
 					<div class="rating-row" role="radiogroup" aria-label={ratingLabels[ratingField]}>
 						{#each [1, 2, 3, 4, 5] as value}
+							{@const selected = ratingValue(ratingField) === value}
 							<button
 								type="button"
-								class:active={ratingValue(ratingField) === value}
-								aria-pressed={ratingValue(ratingField) === value}
+								role="radio"
+								class:active={selected}
+								aria-checked={selected}
+								tabindex={selected || (ratingValue(ratingField) == null && value === 1) ? 0 : -1}
 								disabled={submitting}
 								onclick={() => setRating(ratingField, value)}
+								onkeydown={(event) => handleRatingKeydown(event, ratingField, value)}
 							>
 								{value}
 							</button>

--- a/src/lib/server/rate-limit.test.ts
+++ b/src/lib/server/rate-limit.test.ts
@@ -85,4 +85,13 @@ describe("isApiRateLimited", () => {
 		expect(isApiRateLimited(`/api/room-experiment-visits/${visitId}/exit`, "POST", ip)).toBe(true);
 		expect(isApiRateLimited(`/api/room-experiment-visits/${visitId}/heartbeat`, "GET", ip)).toBe(false);
 	});
+
+	it("limits room exit survey submissions by POST", () => {
+		const ip = `ip-room-exit-survey-${Math.random()}`;
+		for (let i = 0; i < 20; i += 1) {
+			expect(isApiRateLimited("/api/room-exit-surveys", "POST", ip)).toBe(false);
+		}
+		expect(isApiRateLimited("/api/room-exit-surveys", "POST", ip)).toBe(true);
+		expect(isApiRateLimited("/api/room-exit-surveys", "GET", ip)).toBe(false);
+	});
 });

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -66,6 +66,7 @@ export const API_RATE_RULES: RateRule[] = [
 		limit: 180,
 		windowMs: 60_000,
 	},
+	{ name: "room-exit-survey", pattern: /^\/api\/room-exit-surveys$/, methods: ["POST"], limit: 20, windowMs: 60_000 },
 	{ name: "account-switch", pattern: /^\/api\/account-switch$/, methods: ["POST"], limit: 10, windowMs: 60_000 },
 ];
 

--- a/src/lib/server/room-exit-survey.test.ts
+++ b/src/lib/server/room-exit-survey.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+	isDuplicateRoomExitSurveyError,
+	parseRoomExitSurveyRequest,
+	ROOM_EXIT_SURVEY_VERSION,
+	summarizeRoomExitSurveyRows,
+	toRoomExitSurveyInsert,
+} from "./room-exit-survey";
+
+const sessionId = "11111111-1111-4111-8111-111111111111";
+const runId = "22222222-2222-4222-8222-222222222222";
+
+describe("parseRoomExitSurveyRequest", () => {
+	it("accepts a complete submit payload", () => {
+		const parsed = parseRoomExitSurveyRequest({
+			action: "submit",
+			anime_id: 123,
+			broadcast_room_session_id: sessionId,
+			experiment_run_id: runId,
+			stayed_seconds: 181,
+			post_count: 1,
+			answers: {
+				overallRating: 5,
+				sharedExperienceRating: 4,
+				readabilityRating: 3,
+				nextParticipation: "want_join",
+				comparisonWithX: "anipolis_better",
+				goodPoints: "  live flow was fun  ",
+				improvementPoints: "",
+			},
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok || parsed.value.action !== "submit") throw new Error("unexpected parse result");
+		expect(parsed.value.surveyVersion).toBe(ROOM_EXIT_SURVEY_VERSION);
+		expect(parsed.value.answers.goodPoints).toBe("live flow was fun");
+		expect(parsed.value.answers.improvementPoints).toBeNull();
+	});
+
+	it("rejects submit payloads with missing required answers", () => {
+		const parsed = parseRoomExitSurveyRequest({
+			action: "submit",
+			anime_id: 123,
+			broadcast_room_session_id: sessionId,
+			experiment_run_id: runId,
+			stayed_seconds: 181,
+			post_count: 0,
+			answers: {
+				overallRating: 5,
+				sharedExperienceRating: 4,
+				readabilityRating: 3,
+				nextParticipation: "want_join",
+			},
+		});
+
+		expect(parsed.ok).toBe(false);
+	});
+
+	it("accepts skip payloads without answers", () => {
+		const parsed = parseRoomExitSurveyRequest({
+			action: "skip",
+			anime_id: 123,
+			broadcast_room_session_id: sessionId,
+			experiment_run_id: runId,
+			stayed_seconds: 20,
+			post_count: 0,
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) throw new Error("unexpected parse result");
+		expect(parsed.value.action).toBe("skip");
+	});
+});
+
+describe("toRoomExitSurveyInsert", () => {
+	it("builds a skipped insert row", () => {
+		const parsed = parseRoomExitSurveyRequest({
+			action: "skip",
+			anime_id: 123,
+			broadcast_room_session_id: sessionId,
+			experiment_run_id: runId,
+			stayed_seconds: 20,
+			post_count: 0,
+		});
+		if (!parsed.ok) throw new Error("unexpected parse result");
+
+		expect(toRoomExitSurveyInsert("user-1", parsed.value)).toMatchObject({
+			user_id: "user-1",
+			anime_id: 123,
+			broadcast_room_session_id: sessionId,
+			experiment_run_id: runId,
+			skipped: true,
+			answers: {},
+		});
+	});
+});
+
+describe("isDuplicateRoomExitSurveyError", () => {
+	it("detects unique violation errors", () => {
+		expect(isDuplicateRoomExitSurveyError({ code: "23505" })).toBe(true);
+		expect(isDuplicateRoomExitSurveyError({ code: "42501" })).toBe(false);
+	});
+});
+
+describe("summarizeRoomExitSurveyRows", () => {
+	it("summarizes averages, option distributions, skips, and comments", () => {
+		const summary = summarizeRoomExitSurveyRows([
+			{
+				broadcast_room_session_id: sessionId,
+				room_title: "1話",
+				submitted_at: "2026-07-02T10:00:00.000Z",
+				stayed_seconds: 240,
+				post_count: 2,
+				overall_rating: 5,
+				shared_experience_rating: 4,
+				readability_rating: 3,
+				next_participation: "want_join",
+				comparison_with_x: "anipolis_better",
+				good_points: "Fun",
+				improvement_points: null,
+				skipped: false,
+			},
+			{
+				broadcast_room_session_id: sessionId,
+				room_title: "1話",
+				submitted_at: "2026-07-02T11:00:00.000Z",
+				stayed_seconds: 60,
+				post_count: 0,
+				overall_rating: null,
+				shared_experience_rating: null,
+				readability_rating: null,
+				next_participation: null,
+				comparison_with_x: null,
+				good_points: null,
+				improvement_points: null,
+				skipped: true,
+			},
+		]);
+
+		expect(summary.response_count).toBe(2);
+		expect(summary.submitted_count).toBe(1);
+		expect(summary.skipped_count).toBe(1);
+		expect(summary.average_overall_rating).toBe(5);
+		expect(summary.next_participation_counts.want_join).toBe(1);
+		expect(summary.comparison_with_x_counts.anipolis_better).toBe(1);
+		expect(summary.comments).toHaveLength(1);
+		expect(summary.comments[0]?.good_points).toBe("Fun");
+	});
+});

--- a/src/lib/server/room-exit-survey.test.ts
+++ b/src/lib/server/room-exit-survey.test.ts
@@ -141,6 +141,71 @@ describe("isDuplicateRoomExitSurveyError", () => {
 });
 
 describe("saveRoomExitSurveyResponse", () => {
+	it("rejects surveys for ended experiment runs", async () => {
+		const writer = createWriterClient();
+		const result = await saveRoomExitSurveyResponse(
+			writer.client as never,
+			createValidatorClient({
+				broadcast_room_sessions: {
+					data: {
+						id: sessionId,
+						anime_id: 123,
+						room_kind: "episode",
+						posting_closes_at: "2026-07-02T10:30:00Z",
+					},
+					error: null,
+				},
+				room_experiment_runs: {
+					data: {
+						id: runId,
+						anime_id: 123,
+						started_at: "2026-07-02T10:00:00Z",
+						ended_at: "2026-07-02T11:00:00Z",
+					},
+					error: null,
+				},
+				room_experiment_visits: { data: { id: "visit-1" }, error: null },
+			}) as never,
+			userId,
+			skipRequest(),
+		);
+
+		expect(result).toEqual({ ok: false, status: 400, message: "Survey target experiment has ended" });
+		expect(writer.insert).not.toHaveBeenCalled();
+	});
+
+	it("rejects sessions outside the experiment window", async () => {
+		const writer = createWriterClient();
+		const result = await saveRoomExitSurveyResponse(
+			writer.client as never,
+			createValidatorClient({
+				broadcast_room_sessions: {
+					data: {
+						id: sessionId,
+						anime_id: 123,
+						room_kind: "episode",
+						posting_closes_at: "2026-07-02T09:30:00Z",
+					},
+					error: null,
+				},
+				room_experiment_runs: {
+					data: { id: runId, anime_id: 123, started_at: "2026-07-02T10:00:00Z", ended_at: null },
+					error: null,
+				},
+				room_experiment_visits: { data: { id: "visit-1" }, error: null },
+			}) as never,
+			userId,
+			skipRequest(),
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			status: 400,
+			message: "Survey target room is outside the experiment window",
+		});
+		expect(writer.insert).not.toHaveBeenCalled();
+	});
+
 	it("requires a matching experiment visit before inserting", async () => {
 		const writer = createWriterClient();
 		const result = await saveRoomExitSurveyResponse(

--- a/src/lib/server/room-exit-survey.test.ts
+++ b/src/lib/server/room-exit-survey.test.ts
@@ -1,14 +1,52 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	isDuplicateRoomExitSurveyError,
 	parseRoomExitSurveyRequest,
 	ROOM_EXIT_SURVEY_VERSION,
+	saveRoomExitSurveyResponse,
 	summarizeRoomExitSurveyRows,
 	toRoomExitSurveyInsert,
 } from "./room-exit-survey";
 
 const sessionId = "11111111-1111-4111-8111-111111111111";
 const runId = "22222222-2222-4222-8222-222222222222";
+const userId = "33333333-3333-4333-8333-333333333333";
+
+function createValidatorClient(responses: Record<string, { data: unknown; error: unknown }>) {
+	return {
+		from: vi.fn((table: string) => {
+			const chain = {
+				select: vi.fn(() => chain),
+				eq: vi.fn(() => chain),
+				maybeSingle: vi.fn(async () => responses[table] ?? { data: null, error: null }),
+			};
+			return chain;
+		}),
+	};
+}
+
+function createWriterClient(error: unknown = null) {
+	const insert = vi.fn(async () => ({ error }));
+	return {
+		client: {
+			from: vi.fn(() => ({ insert })),
+		},
+		insert,
+	};
+}
+
+function skipRequest() {
+	const parsed = parseRoomExitSurveyRequest({
+		action: "skip",
+		anime_id: 123,
+		broadcast_room_session_id: sessionId,
+		experiment_run_id: runId,
+		stayed_seconds: 200,
+		post_count: 1,
+	});
+	if (!parsed.ok) throw new Error("unexpected parse result");
+	return parsed.value;
+}
 
 describe("parseRoomExitSurveyRequest", () => {
 	it("accepts a complete submit payload", () => {
@@ -99,6 +137,64 @@ describe("isDuplicateRoomExitSurveyError", () => {
 	it("detects unique violation errors", () => {
 		expect(isDuplicateRoomExitSurveyError({ code: "23505" })).toBe(true);
 		expect(isDuplicateRoomExitSurveyError({ code: "42501" })).toBe(false);
+	});
+});
+
+describe("saveRoomExitSurveyResponse", () => {
+	it("requires a matching experiment visit before inserting", async () => {
+		const writer = createWriterClient();
+		const result = await saveRoomExitSurveyResponse(
+			writer.client as never,
+			createValidatorClient({
+				broadcast_room_sessions: {
+					data: {
+						id: sessionId,
+						anime_id: 123,
+						room_kind: "episode",
+						posting_closes_at: "2026-07-02T10:30:00Z",
+					},
+					error: null,
+				},
+				room_experiment_runs: {
+					data: { id: runId, anime_id: 123, started_at: "2026-07-02T10:00:00Z", ended_at: null },
+					error: null,
+				},
+				room_experiment_visits: { data: null, error: null },
+			}) as never,
+			userId,
+			skipRequest(),
+		);
+
+		expect(result).toEqual({ ok: false, status: 403, message: "Survey target visit was not found" });
+		expect(writer.insert).not.toHaveBeenCalled();
+	});
+
+	it("inserts when run, session, and visit match", async () => {
+		const writer = createWriterClient();
+		const result = await saveRoomExitSurveyResponse(
+			writer.client as never,
+			createValidatorClient({
+				broadcast_room_sessions: {
+					data: {
+						id: sessionId,
+						anime_id: 123,
+						room_kind: "episode",
+						posting_closes_at: "2026-07-02T10:30:00Z",
+					},
+					error: null,
+				},
+				room_experiment_runs: {
+					data: { id: runId, anime_id: 123, started_at: "2026-07-02T10:00:00Z", ended_at: null },
+					error: null,
+				},
+				room_experiment_visits: { data: { id: "visit-1" }, error: null },
+			}) as never,
+			userId,
+			skipRequest(),
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(writer.insert).toHaveBeenCalledWith(expect.objectContaining({ user_id: userId, skipped: true }));
 	});
 });
 

--- a/src/lib/server/room-exit-survey.ts
+++ b/src/lib/server/room-exit-survey.ts
@@ -1,0 +1,368 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "$lib/supabase/database.types";
+import type {
+	RoomExitSurveyComment,
+	RoomExitSurveyComparisonWithX,
+	RoomExitSurveyNextParticipation,
+	RoomExitSurveySummary,
+} from "$lib/types";
+
+export const ROOM_EXIT_SURVEY_VERSION = "room_exit_v1";
+
+const MAX_FREE_TEXT_LENGTH = 1000;
+const NEXT_PARTICIPATION_VALUES = ["must_join", "want_join", "not_sure", "not_really", "not_join"] as const;
+const COMPARISON_WITH_X_VALUES = [
+	"anipolis_better",
+	"anipolis_slightly_better",
+	"same",
+	"x_slightly_better",
+	"x_better",
+	"cannot_compare",
+] as const;
+
+type RoomExitSurveyAction = "submit" | "skip";
+
+export type RoomExitSurveyAnswers = {
+	overallRating: number;
+	sharedExperienceRating: number;
+	readabilityRating: number;
+	nextParticipation: RoomExitSurveyNextParticipation;
+	comparisonWithX: RoomExitSurveyComparisonWithX;
+	goodPoints: string | null;
+	improvementPoints: string | null;
+};
+
+export type ParsedRoomExitSurveyRequest =
+	| {
+			action: "submit";
+			animeId: number;
+			broadcastRoomSessionId: string;
+			experimentRunId: string;
+			surveyVersion: string;
+			stayedSeconds: number;
+			postCount: number;
+			answers: RoomExitSurveyAnswers;
+	  }
+	| {
+			action: "skip";
+			animeId: number;
+			broadcastRoomSessionId: string;
+			experimentRunId: string;
+			surveyVersion: string;
+			stayedSeconds: number;
+			postCount: number;
+	  };
+
+export type RoomExitSurveyAggregateRow = {
+	broadcast_room_session_id: string;
+	room_title?: string | null;
+	submitted_at: string;
+	stayed_seconds: number;
+	post_count: number;
+	overall_rating: number | null;
+	shared_experience_rating: number | null;
+	readability_rating: number | null;
+	next_participation: RoomExitSurveyNextParticipation | null;
+	comparison_with_x: RoomExitSurveyComparisonWithX | null;
+	good_points: string | null;
+	improvement_points: string | null;
+	skipped: boolean;
+};
+
+type ParseResult = { ok: true; value: ParsedRoomExitSurveyRequest } | { ok: false; status: number; message: string };
+
+type SaveResult =
+	| { ok: true; duplicate?: false }
+	| { ok: true; duplicate: true }
+	| { ok: false; status: number; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAction(value: unknown): RoomExitSurveyAction | null {
+	return value === "submit" || value === "skip" ? value : null;
+}
+
+function parsePositiveInteger(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) return null;
+	return value;
+}
+
+function parseNonNegativeInteger(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return null;
+	return value;
+}
+
+function parseUuid(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed) ? trimmed : null;
+}
+
+function parseRating(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isInteger(value)) return null;
+	return value >= 1 && value <= 5 ? value : null;
+}
+
+function parseNextParticipation(value: unknown): RoomExitSurveyNextParticipation | null {
+	return typeof value === "string" && NEXT_PARTICIPATION_VALUES.includes(value as RoomExitSurveyNextParticipation)
+		? (value as RoomExitSurveyNextParticipation)
+		: null;
+}
+
+function parseComparisonWithX(value: unknown): RoomExitSurveyComparisonWithX | null {
+	return typeof value === "string" && COMPARISON_WITH_X_VALUES.includes(value as RoomExitSurveyComparisonWithX)
+		? (value as RoomExitSurveyComparisonWithX)
+		: null;
+}
+
+function normalizeFreeText(value: unknown): string | null {
+	if (value == null) return null;
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	return trimmed.slice(0, MAX_FREE_TEXT_LENGTH);
+}
+
+function parseSubmitAnswers(value: unknown): RoomExitSurveyAnswers | null {
+	if (!isRecord(value)) return null;
+	const overallRating = parseRating(value["overallRating"]);
+	const sharedExperienceRating = parseRating(value["sharedExperienceRating"]);
+	const readabilityRating = parseRating(value["readabilityRating"]);
+	const nextParticipation = parseNextParticipation(value["nextParticipation"]);
+	const comparisonWithX = parseComparisonWithX(value["comparisonWithX"]);
+	if (
+		overallRating == null ||
+		sharedExperienceRating == null ||
+		readabilityRating == null ||
+		!nextParticipation ||
+		!comparisonWithX
+	) {
+		return null;
+	}
+
+	return {
+		overallRating,
+		sharedExperienceRating,
+		readabilityRating,
+		nextParticipation,
+		comparisonWithX,
+		goodPoints: normalizeFreeText(value["goodPoints"]),
+		improvementPoints: normalizeFreeText(value["improvementPoints"]),
+	};
+}
+
+export function parseRoomExitSurveyRequest(body: unknown): ParseResult {
+	if (!isRecord(body)) return { ok: false, status: 400, message: "Invalid request body" };
+
+	const action = parseAction(body["action"]);
+	const animeId = parsePositiveInteger(body["anime_id"]);
+	const broadcastRoomSessionId = parseUuid(body["broadcast_room_session_id"]);
+	const experimentRunId = parseUuid(body["experiment_run_id"]);
+	const stayedSeconds = parseNonNegativeInteger(body["stayed_seconds"]);
+	const postCount = parseNonNegativeInteger(body["post_count"]);
+	const surveyVersion =
+		typeof body["survey_version"] === "string" && body["survey_version"].trim()
+			? body["survey_version"].trim().slice(0, 40)
+			: ROOM_EXIT_SURVEY_VERSION;
+
+	if (
+		!action ||
+		!animeId ||
+		!broadcastRoomSessionId ||
+		!experimentRunId ||
+		stayedSeconds == null ||
+		postCount == null
+	) {
+		return { ok: false, status: 400, message: "Invalid survey metadata" };
+	}
+
+	if (action === "skip") {
+		return {
+			ok: true,
+			value: {
+				action,
+				animeId,
+				broadcastRoomSessionId,
+				experimentRunId,
+				surveyVersion,
+				stayedSeconds,
+				postCount,
+			},
+		};
+	}
+
+	const answers = parseSubmitAnswers(body["answers"]);
+	if (!answers) return { ok: false, status: 400, message: "Invalid survey answers" };
+
+	return {
+		ok: true,
+		value: {
+			action,
+			animeId,
+			broadcastRoomSessionId,
+			experimentRunId,
+			surveyVersion,
+			stayedSeconds,
+			postCount,
+			answers,
+		},
+	};
+}
+
+export function isDuplicateRoomExitSurveyError(error: unknown): boolean {
+	return isRecord(error) && error["code"] === "23505";
+}
+
+function answersToJson(answers: RoomExitSurveyAnswers): Json {
+	return {
+		overallRating: answers.overallRating,
+		sharedExperienceRating: answers.sharedExperienceRating,
+		readabilityRating: answers.readabilityRating,
+		nextParticipation: answers.nextParticipation,
+		comparisonWithX: answers.comparisonWithX,
+		goodPoints: answers.goodPoints,
+		improvementPoints: answers.improvementPoints,
+	};
+}
+
+export function toRoomExitSurveyInsert(
+	userId: string,
+	request: ParsedRoomExitSurveyRequest,
+): Database["public"]["Tables"]["room_exit_survey_responses"]["Insert"] {
+	if (request.action === "skip") {
+		return {
+			user_id: userId,
+			anime_id: request.animeId,
+			broadcast_room_session_id: request.broadcastRoomSessionId,
+			experiment_run_id: request.experimentRunId,
+			survey_version: request.surveyVersion,
+			stayed_seconds: request.stayedSeconds,
+			post_count: request.postCount,
+			answers: {},
+			skipped: true,
+		};
+	}
+
+	return {
+		user_id: userId,
+		anime_id: request.animeId,
+		broadcast_room_session_id: request.broadcastRoomSessionId,
+		experiment_run_id: request.experimentRunId,
+		survey_version: request.surveyVersion,
+		stayed_seconds: request.stayedSeconds,
+		post_count: request.postCount,
+		overall_rating: request.answers.overallRating,
+		shared_experience_rating: request.answers.sharedExperienceRating,
+		readability_rating: request.answers.readabilityRating,
+		next_participation: request.answers.nextParticipation,
+		comparison_with_x: request.answers.comparisonWithX,
+		good_points: request.answers.goodPoints,
+		improvement_points: request.answers.improvementPoints,
+		answers: answersToJson(request.answers),
+		skipped: false,
+	};
+}
+
+export async function saveRoomExitSurveyResponse(
+	writer: SupabaseClient<Database>,
+	validator: SupabaseClient<Database>,
+	userId: string,
+	request: ParsedRoomExitSurveyRequest,
+): Promise<SaveResult> {
+	const [{ data: session, error: sessionError }, { data: run, error: runError }] = await Promise.all([
+		validator
+			.from("broadcast_room_sessions")
+			.select("id, anime_id, room_kind")
+			.eq("id", request.broadcastRoomSessionId)
+			.maybeSingle(),
+		validator.from("room_experiment_runs").select("id, anime_id").eq("id", request.experimentRunId).maybeSingle(),
+	]);
+
+	if (sessionError || runError) {
+		console.error("room exit survey validation query failed:", { sessionError, runError });
+		return { ok: false, status: 500, message: "Survey validation failed" };
+	}
+	if (!session || !run || session.room_kind !== "episode") {
+		return { ok: false, status: 400, message: "Survey target room is invalid" };
+	}
+	if (session.anime_id !== request.animeId || run.anime_id !== request.animeId) {
+		return { ok: false, status: 400, message: "Survey target anime mismatch" };
+	}
+
+	const { error } = await writer.from("room_exit_survey_responses").insert(toRoomExitSurveyInsert(userId, request));
+	if (!error) return { ok: true };
+	if (isDuplicateRoomExitSurveyError(error)) return { ok: true, duplicate: true };
+
+	console.error("room exit survey insert failed:", error);
+	return { ok: false, status: 500, message: "Survey insert failed" };
+}
+
+function emptyOptionCounts<T extends string>(values: readonly T[]): Record<T, number> {
+	return Object.fromEntries(values.map((value) => [value, 0])) as Record<T, number>;
+}
+
+function createEmptySummary(): RoomExitSurveySummary {
+	return {
+		response_count: 0,
+		submitted_count: 0,
+		skipped_count: 0,
+		average_overall_rating: null,
+		average_shared_experience_rating: null,
+		average_readability_rating: null,
+		next_participation_counts: emptyOptionCounts(NEXT_PARTICIPATION_VALUES),
+		comparison_with_x_counts: emptyOptionCounts(COMPARISON_WITH_X_VALUES),
+		comments: [],
+	};
+}
+
+function average(total: number, count: number): number | null {
+	return count > 0 ? total / count : null;
+}
+
+export function summarizeRoomExitSurveyRows(rows: RoomExitSurveyAggregateRow[]): RoomExitSurveySummary {
+	const summary = createEmptySummary();
+	let overallTotal = 0;
+	let sharedTotal = 0;
+	let readabilityTotal = 0;
+	let ratingCount = 0;
+	const comments: RoomExitSurveyComment[] = [];
+
+	for (const row of rows) {
+		summary.response_count += 1;
+		if (row.skipped) {
+			summary.skipped_count += 1;
+			continue;
+		}
+
+		summary.submitted_count += 1;
+		if (row.overall_rating != null && row.shared_experience_rating != null && row.readability_rating != null) {
+			overallTotal += row.overall_rating;
+			sharedTotal += row.shared_experience_rating;
+			readabilityTotal += row.readability_rating;
+			ratingCount += 1;
+		}
+		if (row.next_participation) summary.next_participation_counts[row.next_participation] += 1;
+		if (row.comparison_with_x) summary.comparison_with_x_counts[row.comparison_with_x] += 1;
+
+		if (row.good_points || row.improvement_points) {
+			comments.push({
+				submitted_at: row.submitted_at,
+				room_title: row.room_title ?? null,
+				good_points: row.good_points,
+				improvement_points: row.improvement_points,
+				stayed_seconds: row.stayed_seconds,
+				post_count: row.post_count,
+			});
+		}
+	}
+
+	summary.average_overall_rating = average(overallTotal, ratingCount);
+	summary.average_shared_experience_rating = average(sharedTotal, ratingCount);
+	summary.average_readability_rating = average(readabilityTotal, ratingCount);
+	summary.comments = comments
+		.sort((a, b) => new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime())
+		.slice(0, 20);
+	return summary;
+}

--- a/src/lib/server/room-exit-survey.ts
+++ b/src/lib/server/room-exit-survey.ts
@@ -76,6 +76,11 @@ type SaveResult =
 	| { ok: true; duplicate: true }
 	| { ok: false; status: number; message: string };
 
+export type RoomExitSurveyLoadState = {
+	alreadyAnswered: boolean;
+	postCount: number;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -265,23 +270,80 @@ export function toRoomExitSurveyInsert(
 	};
 }
 
+function isSessionInRunWindow(session: { posting_closes_at: string | null }, run: { started_at: string }): boolean {
+	if (!session.posting_closes_at) return true;
+	const roomClosesMs = new Date(session.posting_closes_at).getTime();
+	const runStartsMs = new Date(run.started_at).getTime();
+	if (!Number.isFinite(roomClosesMs) || !Number.isFinite(runStartsMs)) return true;
+	return roomClosesMs >= runStartsMs;
+}
+
+export async function getRoomExitSurveyLoadState(
+	supabase: SupabaseClient<Database>,
+	userId: string | null | undefined,
+	sessionId: string,
+): Promise<RoomExitSurveyLoadState> {
+	if (!userId) return { alreadyAnswered: false, postCount: 0 };
+
+	const [surveyResponse, surveyPostCount] = await Promise.all([
+		supabase
+			.from("room_exit_survey_responses")
+			.select("id")
+			.eq("user_id", userId)
+			.eq("broadcast_room_session_id", sessionId)
+			.eq("survey_version", ROOM_EXIT_SURVEY_VERSION)
+			.maybeSingle(),
+		supabase
+			.from("posts")
+			.select("id", { count: "exact", head: true })
+			.eq("user_id", userId)
+			.eq("broadcast_room_session_id", sessionId)
+			.is("parent_id", null)
+			.eq("hidden_by_admin", false),
+	]);
+
+	if (surveyResponse.error) {
+		console.error("room exit survey lookup failed:", surveyResponse.error);
+	}
+	if (surveyPostCount.error) {
+		console.error("room exit survey post count lookup failed:", surveyPostCount.error);
+	}
+
+	return {
+		alreadyAnswered: Boolean(surveyResponse.data),
+		postCount: surveyPostCount.count ?? 0,
+	};
+}
+
 export async function saveRoomExitSurveyResponse(
 	writer: SupabaseClient<Database>,
 	validator: SupabaseClient<Database>,
 	userId: string,
 	request: ParsedRoomExitSurveyRequest,
 ): Promise<SaveResult> {
-	const [{ data: session, error: sessionError }, { data: run, error: runError }] = await Promise.all([
-		validator
-			.from("broadcast_room_sessions")
-			.select("id, anime_id, room_kind")
-			.eq("id", request.broadcastRoomSessionId)
-			.maybeSingle(),
-		validator.from("room_experiment_runs").select("id, anime_id").eq("id", request.experimentRunId).maybeSingle(),
-	]);
+	const [{ data: session, error: sessionError }, { data: run, error: runError }, { data: visit, error: visitError }] =
+		await Promise.all([
+			validator
+				.from("broadcast_room_sessions")
+				.select("id, anime_id, room_kind, posting_closes_at")
+				.eq("id", request.broadcastRoomSessionId)
+				.maybeSingle(),
+			validator
+				.from("room_experiment_runs")
+				.select("id, anime_id, started_at, ended_at")
+				.eq("id", request.experimentRunId)
+				.maybeSingle(),
+			validator
+				.from("room_experiment_visits")
+				.select("id")
+				.eq("run_id", request.experimentRunId)
+				.eq("broadcast_room_session_id", request.broadcastRoomSessionId)
+				.eq("user_id", userId)
+				.maybeSingle(),
+		]);
 
-	if (sessionError || runError) {
-		console.error("room exit survey validation query failed:", { sessionError, runError });
+	if (sessionError || runError || visitError) {
+		console.error("room exit survey validation query failed:", { sessionError, runError, visitError });
 		return { ok: false, status: 500, message: "Survey validation failed" };
 	}
 	if (!session || !run || session.room_kind !== "episode") {
@@ -289,6 +351,15 @@ export async function saveRoomExitSurveyResponse(
 	}
 	if (session.anime_id !== request.animeId || run.anime_id !== request.animeId) {
 		return { ok: false, status: 400, message: "Survey target anime mismatch" };
+	}
+	if (run.ended_at) {
+		return { ok: false, status: 400, message: "Survey target experiment has ended" };
+	}
+	if (!isSessionInRunWindow(session, run)) {
+		return { ok: false, status: 400, message: "Survey target room is outside the experiment window" };
+	}
+	if (!visit) {
+		return { ok: false, status: 403, message: "Survey target visit was not found" };
 	}
 
 	const { error } = await writer.from("room_exit_survey_responses").insert(toRoomExitSurveyInsert(userId, request));

--- a/src/lib/server/room-experiments.test.ts
+++ b/src/lib/server/room-experiments.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isSchemaUnavailableError } from "./room-experiments";
+
+describe("isSchemaUnavailableError", () => {
+	it("detects missing schema and schema-cache errors", () => {
+		expect(isSchemaUnavailableError({ code: "42P01", message: "relation does not exist" })).toBe(true);
+		expect(isSchemaUnavailableError({ code: "42703", message: "column does not exist" })).toBe(true);
+		expect(
+			isSchemaUnavailableError({ code: "PGRST205", message: "Could not find the table in the schema cache" }),
+		).toBe(true);
+		expect(isSchemaUnavailableError({ message: "Could not find a relationship in the schema cache" })).toBe(true);
+	});
+
+	it("does not hide permission or runtime errors", () => {
+		expect(isSchemaUnavailableError({ code: "42501", message: "permission denied" })).toBe(false);
+		expect(isSchemaUnavailableError({ message: "could not find user profile" })).toBe(false);
+		expect(isSchemaUnavailableError(new Error("network timeout"))).toBe(false);
+		expect(isSchemaUnavailableError(null)).toBe(false);
+	});
+});

--- a/src/lib/server/room-experiments.ts
+++ b/src/lib/server/room-experiments.ts
@@ -593,7 +593,7 @@ export async function getRoomExperimentDashboardData(
 			)
 			.in("experiment_run_id", runIds),
 	]);
-	const surveysUnavailable = surveysError && isSchemaUnavailableError(surveysError);
+	const surveysUnavailable = Boolean(surveysError && isSchemaUnavailableError(surveysError));
 	if (surveysUnavailable) {
 		console.warn("room exit survey dashboard data unavailable:", surveysError);
 	}
@@ -616,7 +616,10 @@ export async function getRoomExperimentDashboardData(
 		return session?.room_kind === "episode";
 	});
 	const sessions = ((sessionRows ?? []) as unknown as SessionInfo[]).filter((row) => row.room_kind === "episode");
-	const surveys = ((surveysUnavailable ? [] : (surveyRows ?? [])) as unknown as SurveyRow[]) ?? [];
+	const surveys = ((surveysUnavailable ? [] : (surveyRows ?? [])) as unknown as SurveyRow[]).filter((row) => {
+		const session = getSessionFromSurvey(row);
+		return session?.room_kind === "episode";
+	});
 
 	return {
 		searchResults,

--- a/src/lib/server/room-experiments.ts
+++ b/src/lib/server/room-experiments.ts
@@ -1,8 +1,16 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildTitleSearchFilter } from "$lib/server/queries";
+import { type RoomExitSurveyAggregateRow, summarizeRoomExitSurveyRows } from "$lib/server/room-exit-survey";
 import { createServiceRoleClient } from "$lib/server/supabase-admin";
 import type { Database } from "$lib/supabase/database.types";
-import type { RoomExperimentAnimeSearchResult, RoomExperimentDashboardRun, RoomExperimentRun } from "$lib/types";
+import type {
+	RoomExitSurveyComparisonWithX,
+	RoomExitSurveyNextParticipation,
+	RoomExitSurveySummary,
+	RoomExperimentAnimeSearchResult,
+	RoomExperimentDashboardRun,
+	RoomExperimentRun,
+} from "$lib/types";
 import {
 	calculateRoomExperimentMetrics,
 	type ExperimentPostCandidate,
@@ -85,6 +93,30 @@ type SessionInfo = {
 	posting_closes_at: string | null;
 };
 
+type SurveyRow = RoomExitSurveyAggregateRow & {
+	experiment_run_id: string;
+	next_participation: RoomExitSurveyNextParticipation | null;
+	comparison_with_x: RoomExitSurveyComparisonWithX | null;
+	session:
+		| {
+				id: string;
+				room_date: string;
+				room_kind: string;
+				room_key: string;
+				scheduled_at: string;
+				posting_closes_at: string | null;
+		  }
+		| {
+				id: string;
+				room_date: string;
+				room_kind: string;
+				room_key: string;
+				scheduled_at: string;
+				posting_closes_at: string | null;
+		  }[]
+		| null;
+};
+
 export function createRoomExperimentServiceClient(): SupabaseClient<Database> | null {
 	try {
 		return createServiceRoleClient();
@@ -99,7 +131,35 @@ function firstMaybeArray<T>(value: T | T[] | null): T | null {
 	return value;
 }
 
-function toDashboardRun(row: RunRow, rooms: ExperimentRoomInput[]): RoomExperimentDashboardRun {
+export function isSchemaUnavailableError(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+	const record = error as Record<string, unknown>;
+	const code = typeof record["code"] === "string" ? record["code"] : "";
+	const message = typeof record["message"] === "string" ? record["message"].toLowerCase() : "";
+	const couldNotFindSchemaObject =
+		message.includes("could not find") &&
+		(message.includes("table") ||
+			message.includes("column") ||
+			message.includes("relationship") ||
+			message.includes("schema"));
+	return (
+		code === "42P01" ||
+		code === "42703" ||
+		code === "PGRST200" ||
+		code === "PGRST204" ||
+		code === "PGRST205" ||
+		message.includes("schema cache") ||
+		message.includes("does not exist") ||
+		couldNotFindSchemaObject
+	);
+}
+
+function toDashboardRun(
+	row: RunRow,
+	rooms: ExperimentRoomInput[],
+	surveyBySession: Map<string, RoomExitSurveySummary>,
+	survey: RoomExitSurveySummary,
+): RoomExperimentDashboardRun {
 	const anime = firstMaybeArray(row.anime);
 	const metrics = calculateRoomExperimentMetrics({
 		id: row.id,
@@ -117,7 +177,13 @@ function toDashboardRun(row: RunRow, rooms: ExperimentRoomInput[]): RoomExperime
 		label: row.label,
 		notes: row.notes,
 		summary: metrics.summary,
-		rooms: metrics.rooms.sort((a, b) => (a.scheduled_at ?? "").localeCompare(b.scheduled_at ?? "")),
+		survey,
+		rooms: metrics.rooms
+			.sort((a, b) => (a.scheduled_at ?? "").localeCompare(b.scheduled_at ?? ""))
+			.map((room) => ({
+				...room,
+				survey: surveyBySession.get(room.broadcast_room_session_id) ?? summarizeRoomExitSurveyRows([]),
+			})),
 	};
 }
 
@@ -165,6 +231,39 @@ function getSessionFromPost(row: PostRow): SessionInfo | null {
 		: null;
 }
 
+function getSessionFromSurvey(row: SurveyRow): SessionInfo | null {
+	const session = firstMaybeArray(row.session);
+	return session
+		? {
+				id: session.id,
+				room_date: session.room_date,
+				room_kind: session.room_kind,
+				room_key: session.room_key,
+				scheduled_at: session.scheduled_at,
+				posting_closes_at: session.posting_closes_at,
+			}
+		: null;
+}
+
+function toSurveyAggregateRow(row: SurveyRow): RoomExitSurveyAggregateRow {
+	const session = getSessionFromSurvey(row);
+	return {
+		broadcast_room_session_id: row.broadcast_room_session_id,
+		room_title: session ? roomTitle(session) : null,
+		submitted_at: row.submitted_at,
+		stayed_seconds: row.stayed_seconds,
+		post_count: row.post_count,
+		overall_rating: row.overall_rating,
+		shared_experience_rating: row.shared_experience_rating,
+		readability_rating: row.readability_rating,
+		next_participation: row.next_participation,
+		comparison_with_x: row.comparison_with_x,
+		good_points: row.good_points,
+		improvement_points: row.improvement_points,
+		skipped: row.skipped,
+	};
+}
+
 export async function getActiveRoomExperimentRunForAnime(
 	supabase: SupabaseClient<Database>,
 	animeId: string | number,
@@ -209,9 +308,12 @@ export async function searchRoomExperimentAnime(
 			.limit(10),
 		supabase.from("room_experiment_runs").select("id, anime_id").is("ended_at", null),
 	]);
-	if (animeError || activeRunsError) {
+	if (animeError || (activeRunsError && !isSchemaUnavailableError(activeRunsError))) {
 		console.error("room experiment anime search query failed:", { animeError, activeRunsError });
 		throw new Error("room experiment anime search query failed");
+	}
+	if (activeRunsError) {
+		console.warn("room experiment active run lookup unavailable:", activeRunsError);
 	}
 
 	const activeRunByAnime = new Map(
@@ -444,6 +546,10 @@ export async function getRoomExperimentDashboardData(
 			.order("started_at", { ascending: false }),
 	]);
 	if (runsError) {
+		if (isSchemaUnavailableError(runsError)) {
+			console.warn("room experiment dashboard unavailable:", runsError);
+			return { runs: [], searchResults };
+		}
 		console.error("room experiment runs query failed:", runsError);
 		throw new Error("room experiment runs query failed");
 	}
@@ -459,6 +565,7 @@ export async function getRoomExperimentDashboardData(
 		{ data: visitRows, error: visitsError },
 		{ data: postRows, error: postsError },
 		{ data: sessionRows, error: sessionsError },
+		{ data: surveyRows, error: surveysError },
 	] = await Promise.all([
 		supabase
 			.from("room_experiment_visits")
@@ -479,9 +586,24 @@ export async function getRoomExperimentDashboardData(
 			.select("id, anime_id, room_date, room_kind, room_key, scheduled_at, posting_closes_at")
 			.in("anime_id", animeIds)
 			.eq("room_kind", "episode"),
+		supabase
+			.from("room_exit_survey_responses")
+			.select(
+				"experiment_run_id, broadcast_room_session_id, submitted_at, stayed_seconds, post_count, overall_rating, shared_experience_rating, readability_rating, next_participation, comparison_with_x, good_points, improvement_points, skipped, session:broadcast_room_sessions!room_exit_survey_responses_broadcast_room_session_id_fkey ( id, room_date, room_kind, room_key, scheduled_at, posting_closes_at )",
+			)
+			.in("experiment_run_id", runIds),
 	]);
-	if (visitsError || postsError || sessionsError) {
-		console.error("room experiment dashboard query failed:", { visitsError, postsError, sessionsError });
+	const surveysUnavailable = surveysError && isSchemaUnavailableError(surveysError);
+	if (surveysUnavailable) {
+		console.warn("room exit survey dashboard data unavailable:", surveysError);
+	}
+	if (visitsError || postsError || sessionsError || (surveysError && !surveysUnavailable)) {
+		console.error("room experiment dashboard query failed:", {
+			visitsError,
+			postsError,
+			sessionsError,
+			surveysError,
+		});
 		throw new Error("room experiment dashboard query failed");
 	}
 
@@ -494,6 +616,7 @@ export async function getRoomExperimentDashboardData(
 		return session?.room_kind === "episode";
 	});
 	const sessions = ((sessionRows ?? []) as unknown as SessionInfo[]).filter((row) => row.room_kind === "episode");
+	const surveys = ((surveysUnavailable ? [] : (surveyRows ?? [])) as unknown as SurveyRow[]) ?? [];
 
 	return {
 		searchResults,
@@ -501,6 +624,8 @@ export async function getRoomExperimentDashboardData(
 			const sessionById = new Map<string, SessionInfo>();
 			const visitsBySession = new Map<string, ExperimentVisitInput[]>();
 			const postsBySession = new Map<string, ExperimentPostCandidate[]>();
+			const surveyRowsBySession = new Map<string, RoomExitSurveyAggregateRow[]>();
+			const runSurveyRows = surveys.filter((row) => row.experiment_run_id === run.id).map(toSurveyAggregateRow);
 
 			for (const session of sessions) {
 				if (shouldIncludeSessionForRun(session, run)) sessionById.set(session.id, session);
@@ -529,6 +654,19 @@ export async function getRoomExperimentDashboardData(
 				postsBySession.set(session.id, group);
 			}
 
+			for (const survey of runSurveyRows) {
+				const group = surveyRowsBySession.get(survey.broadcast_room_session_id) ?? [];
+				group.push(survey);
+				surveyRowsBySession.set(survey.broadcast_room_session_id, group);
+			}
+
+			const surveyBySession = new Map(
+				[...surveyRowsBySession.entries()].map(([sessionId, rows]) => [
+					sessionId,
+					summarizeRoomExitSurveyRows(rows),
+				]),
+			);
+
 			const rooms = [...sessionById.values()].map((session) => ({
 				broadcast_room_session_id: session.id,
 				room_title: roomTitle(session),
@@ -543,7 +681,7 @@ export async function getRoomExperimentDashboardData(
 				}),
 			}));
 
-			return toDashboardRun(run, rooms);
+			return toDashboardRun(run, rooms, surveyBySession, summarizeRoomExitSurveyRows(runSurveyRows));
 		}),
 	};
 }

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1000,6 +1000,92 @@ export type Database = {
 					},
 				];
 			};
+			room_exit_survey_responses: {
+				Row: {
+					id: string;
+					user_id: string;
+					anime_id: number;
+					broadcast_room_session_id: string;
+					experiment_run_id: string;
+					survey_version: string;
+					stayed_seconds: number;
+					post_count: number;
+					overall_rating: number | null;
+					shared_experience_rating: number | null;
+					readability_rating: number | null;
+					next_participation: string | null;
+					comparison_with_x: string | null;
+					good_points: string | null;
+					improvement_points: string | null;
+					answers: Json;
+					skipped: boolean;
+					submitted_at: string;
+				};
+				Insert: {
+					id?: string;
+					user_id: string;
+					anime_id: number;
+					broadcast_room_session_id: string;
+					experiment_run_id: string;
+					survey_version?: string;
+					stayed_seconds?: number;
+					post_count?: number;
+					overall_rating?: number | null;
+					shared_experience_rating?: number | null;
+					readability_rating?: number | null;
+					next_participation?: string | null;
+					comparison_with_x?: string | null;
+					good_points?: string | null;
+					improvement_points?: string | null;
+					answers?: Json;
+					skipped?: boolean;
+					submitted_at?: string;
+				};
+				Update: {
+					survey_version?: string;
+					stayed_seconds?: number;
+					post_count?: number;
+					overall_rating?: number | null;
+					shared_experience_rating?: number | null;
+					readability_rating?: number | null;
+					next_participation?: string | null;
+					comparison_with_x?: string | null;
+					good_points?: string | null;
+					improvement_points?: string | null;
+					answers?: Json;
+					skipped?: boolean;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "room_exit_survey_responses_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "profiles";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_exit_survey_responses_anime_id_fkey";
+						columns: ["anime_id"];
+						isOneToOne: false;
+						referencedRelation: "anime";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_exit_survey_responses_broadcast_room_session_id_fkey";
+						columns: ["broadcast_room_session_id"];
+						isOneToOne: false;
+						referencedRelation: "broadcast_room_sessions";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "room_exit_survey_responses_experiment_run_id_fkey";
+						columns: ["experiment_run_id"];
+						isOneToOne: false;
+						referencedRelation: "room_experiment_runs";
+						referencedColumns: ["id"];
+					},
+				];
+			};
 			broadcast_notification_subscriptions: {
 				Row: {
 					user_id: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -588,16 +588,18 @@ export interface RoomExperimentRoomMetric {
 	average_stay_seconds: number | null;
 	bounce_rate_under_60s: number | null;
 	early_exit_rate: number | null;
+	survey: RoomExitSurveySummary;
 }
 
 export type RoomExperimentSummaryMetric = Omit<
 	RoomExperimentRoomMetric,
-	"broadcast_room_session_id" | "room_title" | "episode_number" | "scheduled_at" | "posting_closes_at"
+	"broadcast_room_session_id" | "room_title" | "episode_number" | "scheduled_at" | "posting_closes_at" | "survey"
 >;
 
 export interface RoomExperimentDashboardRun extends RoomExperimentRun {
 	summary: RoomExperimentSummaryMetric;
 	rooms: RoomExperimentRoomMetric[];
+	survey: RoomExitSurveySummary;
 }
 
 export interface RoomExperimentAnimeSearchResult {
@@ -606,6 +608,37 @@ export interface RoomExperimentAnimeSearchResult {
 	cover_url: string | null;
 	room_type: string;
 	active_run_id: string | null;
+}
+
+export type RoomExitSurveyNextParticipation = "must_join" | "want_join" | "not_sure" | "not_really" | "not_join";
+
+export type RoomExitSurveyComparisonWithX =
+	| "anipolis_better"
+	| "anipolis_slightly_better"
+	| "same"
+	| "x_slightly_better"
+	| "x_better"
+	| "cannot_compare";
+
+export interface RoomExitSurveyComment {
+	submitted_at: string;
+	room_title: string | null;
+	good_points: string | null;
+	improvement_points: string | null;
+	stayed_seconds: number;
+	post_count: number;
+}
+
+export interface RoomExitSurveySummary {
+	response_count: number;
+	submitted_count: number;
+	skipped_count: number;
+	average_overall_rating: number | null;
+	average_shared_experience_rating: number | null;
+	average_readability_rating: number | null;
+	next_participation_counts: Record<RoomExitSurveyNextParticipation, number>;
+	comparison_with_x_counts: Record<RoomExitSurveyComparisonWithX, number>;
+	comments: RoomExitSurveyComment[];
 }
 
 export interface StoredAccount {

--- a/src/routes/admin/room-experiments/+page.svelte
+++ b/src/routes/admin/room-experiments/+page.svelte
@@ -51,6 +51,31 @@ function formatDuration(seconds: number | null) {
 	return rest ? `${minutes}分${rest}秒` : `${minutes}分`;
 }
 
+function formatAverage(value: number | null) {
+	return value == null ? "-" : value.toFixed(1);
+}
+
+const nextParticipationLabels: Record<string, string> = {
+	must_join: "必ず参加したい",
+	want_join: "できれば参加したい",
+	not_sure: "わからない",
+	not_really: "あまり参加したくない",
+	not_join: "参加したくない",
+};
+
+const comparisonWithXLabels: Record<string, string> = {
+	anipolis_better: "Anipolisの方がよい",
+	anipolis_slightly_better: "どちらかといえばAnipolis",
+	same: "どちらともいえない",
+	x_slightly_better: "どちらかといえばX / Twitter",
+	x_better: "X / Twitterの方がよい",
+	cannot_compare: "比較できない",
+};
+
+function optionCounts(counts: Record<string, number>, labels: Record<string, string>) {
+	return Object.entries(labels).map(([value, label]) => ({ value, label, count: counts[value] ?? 0 }));
+}
+
 const closeStopModalAfterSubmit: SubmitFunction = () => {
 	return async ({ result, update }) => {
 		await update();
@@ -166,6 +191,71 @@ const closeStopModalAfterSubmit: SubmitFunction = () => {
 							</div>
 						</div>
 
+						<div class="survey-panel">
+							<div class="survey-panel-header">
+								<h3>退出時アンケート</h3>
+								<span>{run.survey.response_count}件 / スキップ {run.survey.skipped_count}件</span>
+							</div>
+							{#if run.survey.response_count === 0}
+								<p class="survey-empty">まだアンケート回答はありません。</p>
+							{:else}
+								<div class="survey-metrics">
+									<div>
+										<span>楽しさ</span
+										><strong>{formatAverage(run.survey.average_overall_rating)}</strong>
+									</div>
+									<div>
+										<span>一緒に見ている感</span
+										><strong>{formatAverage(run.survey.average_shared_experience_rating)}</strong>
+									</div>
+									<div>
+										<span>見やすさ</span
+										><strong>{formatAverage(run.survey.average_readability_rating)}</strong>
+									</div>
+									<div><span>回答</span><strong>{run.survey.submitted_count}</strong></div>
+								</div>
+								<div class="survey-distributions">
+									<div>
+										<h4>次回参加</h4>
+										{#each optionCounts(run.survey.next_participation_counts, nextParticipationLabels) as option}
+											<div class="survey-option-row">
+												<span>{option.label}</span>
+												<strong>{option.count}</strong>
+											</div>
+										{/each}
+									</div>
+									<div>
+										<h4>X / Twitter比較</h4>
+										{#each optionCounts(run.survey.comparison_with_x_counts, comparisonWithXLabels) as option}
+											<div class="survey-option-row">
+												<span>{option.label}</span>
+												<strong>{option.count}</strong>
+											</div>
+										{/each}
+									</div>
+								</div>
+								{#if run.survey.comments.length > 0}
+									<div class="survey-comments">
+										<h4>自由記述</h4>
+										{#each run.survey.comments as comment}
+											<article class="survey-comment">
+												<div>
+													<span>{comment.room_title ?? "-"}</span>
+													<time>{formatDate(comment.submitted_at)}</time>
+												</div>
+												{#if comment.good_points}
+													<p><strong>よかった点</strong>{comment.good_points}</p>
+												{/if}
+												{#if comment.improvement_points}
+													<p><strong>改善点</strong>{comment.improvement_points}</p>
+												{/if}
+											</article>
+										{/each}
+									</div>
+								{/if}
+							{/if}
+						</div>
+
 						<div class="room-table-wrap">
 							<table>
 								<thead>
@@ -182,12 +272,15 @@ const closeStopModalAfterSubmit: SubmitFunction = () => {
 										<th>平均滞在</th>
 										<th>即離脱</th>
 										<th>終了前離脱</th>
+										<th>アンケート</th>
+										<th>平均</th>
+										<th>スキップ</th>
 									</tr>
 								</thead>
 								<tbody>
 									{#if run.rooms.length === 0}
 										<tr>
-											<td colspan="12" class="empty-cell">
+											<td colspan="15" class="empty-cell">
 												まだ放送回ルーム内の計測データはありません。
 											</td>
 										</tr>
@@ -206,6 +299,9 @@ const closeStopModalAfterSubmit: SubmitFunction = () => {
 												<td>{formatDuration(room.average_stay_seconds)}</td>
 												<td>{formatPercent(room.bounce_rate_under_60s)}</td>
 												<td>{formatPercent(room.early_exit_rate)}</td>
+												<td>{room.survey.response_count}</td>
+												<td>{formatAverage(room.survey.average_overall_rating)}</td>
+												<td>{room.survey.skipped_count}</td>
 											</tr>
 										{/each}
 									{/if}
@@ -462,6 +558,127 @@ const closeStopModalAfterSubmit: SubmitFunction = () => {
 	line-height: 1;
 }
 
+.survey-panel {
+	border-top: 1px solid var(--color-border);
+	padding: 14px 16px 16px;
+}
+
+.survey-panel-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin-bottom: 12px;
+}
+
+.survey-panel-header h3,
+.survey-distributions h4,
+.survey-comments h4 {
+	margin: 0;
+	font-size: 14px;
+}
+
+.survey-panel-header span,
+.survey-empty {
+	color: var(--color-text-muted);
+	font-size: 13px;
+}
+
+.survey-empty {
+	margin: 0;
+}
+
+.survey-metrics {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 1px;
+	margin-bottom: 12px;
+	background: var(--color-border);
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.survey-metrics div {
+	min-width: 0;
+	background: var(--color-surface);
+	padding: 10px 12px;
+}
+
+.survey-metrics span {
+	display: block;
+	color: var(--color-text-muted);
+	font-size: 12px;
+	font-weight: 700;
+}
+
+.survey-metrics strong {
+	display: block;
+	margin-top: 4px;
+	font-size: 20px;
+	line-height: 1;
+}
+
+.survey-distributions {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 12px;
+}
+
+.survey-distributions > div,
+.survey-comments {
+	border: 1px solid var(--color-border);
+	border-radius: 8px;
+	padding: 12px;
+}
+
+.survey-option-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+	margin-top: 8px;
+	color: var(--color-text-muted);
+	font-size: 13px;
+}
+
+.survey-option-row strong {
+	color: var(--color-text);
+}
+
+.survey-comments {
+	margin-top: 12px;
+}
+
+.survey-comment {
+	margin-top: 10px;
+	border-top: 1px solid var(--color-border);
+	padding-top: 10px;
+}
+
+.survey-comment:first-of-type {
+	border-top: 0;
+	padding-top: 0;
+}
+
+.survey-comment div {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+	color: var(--color-text-muted);
+	font-size: 12px;
+}
+
+.survey-comment p {
+	margin: 8px 0 0;
+	white-space: pre-wrap;
+	line-height: 1.6;
+}
+
+.survey-comment p strong {
+	margin-right: 8px;
+	color: var(--color-text-muted);
+}
+
 .room-table-wrap {
 	overflow-x: auto;
 	border-top: 1px solid var(--color-border);
@@ -470,7 +687,7 @@ const closeStopModalAfterSubmit: SubmitFunction = () => {
 table {
 	width: 100%;
 	border-collapse: collapse;
-	min-width: 980px;
+	min-width: 1120px;
 }
 
 th,
@@ -559,7 +776,9 @@ th {
 	}
 
 	.search-form,
-	.metric-strip {
+	.metric-strip,
+	.survey-metrics,
+	.survey-distributions {
 		grid-template-columns: 1fr;
 	}
 

--- a/src/routes/admin/room-experiments/+page.svelte
+++ b/src/routes/admin/room-experiments/+page.svelte
@@ -4,6 +4,7 @@ import { onMount } from "svelte";
 import { enhance } from "$app/forms";
 import { invalidateAll } from "$app/navigation";
 import { trapFocus } from "$lib/actions/trapFocus";
+import type { RoomExitSurveyComparisonWithX, RoomExitSurveyNextParticipation } from "$lib/types";
 import type { PageProps } from "./$types";
 
 let { data, form }: PageProps = $props();
@@ -55,7 +56,7 @@ function formatAverage(value: number | null) {
 	return value == null ? "-" : value.toFixed(1);
 }
 
-const nextParticipationLabels: Record<string, string> = {
+const nextParticipationLabels: Record<RoomExitSurveyNextParticipation, string> = {
 	must_join: "必ず参加したい",
 	want_join: "できれば参加したい",
 	not_sure: "わからない",
@@ -63,7 +64,7 @@ const nextParticipationLabels: Record<string, string> = {
 	not_join: "参加したくない",
 };
 
-const comparisonWithXLabels: Record<string, string> = {
+const comparisonWithXLabels: Record<RoomExitSurveyComparisonWithX, string> = {
 	anipolis_better: "Anipolisの方がよい",
 	anipolis_slightly_better: "どちらかといえばAnipolis",
 	same: "どちらともいえない",
@@ -72,8 +73,12 @@ const comparisonWithXLabels: Record<string, string> = {
 	cannot_compare: "比較できない",
 };
 
-function optionCounts(counts: Record<string, number>, labels: Record<string, string>) {
-	return Object.entries(labels).map(([value, label]) => ({ value, label, count: counts[value] ?? 0 }));
+function optionCounts<T extends string>(counts: Record<T, number>, labels: Record<T, string>) {
+	return (Object.entries(labels) as Array<[T, string]>).map(([value, label]) => ({
+		value,
+		label,
+		count: counts[value] ?? 0,
+	}));
 }
 
 const closeStopModalAfterSubmit: SubmitFunction = () => {

--- a/src/routes/api/room-exit-surveys/+server.ts
+++ b/src/routes/api/room-exit-surveys/+server.ts
@@ -1,0 +1,28 @@
+import { error, json } from "@sveltejs/kit";
+import { parseRoomExitSurveyRequest, saveRoomExitSurveyResponse } from "$lib/server/room-exit-survey";
+import { createRoomExperimentServiceClient } from "$lib/server/room-experiments";
+import type { RequestHandler } from "./$types";
+
+async function readBody(request: Request): Promise<unknown> {
+	try {
+		return await request.json();
+	} catch {
+		return null;
+	}
+}
+
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { user } = await safeGetSession();
+	if (!user) error(401, "ログインが必要です");
+
+	const parsed = parseRoomExitSurveyRequest(await readBody(request));
+	if (!parsed.ok) error(parsed.status, parsed.message);
+
+	const validator = createRoomExperimentServiceClient();
+	if (!validator) error(503, "Survey validation is unavailable");
+
+	const result = await saveRoomExitSurveyResponse(supabase, validator, user.id, parsed.value);
+	if (!result.ok) error(result.status, result.message);
+
+	return json({ ok: true, duplicate: result.duplicate === true });
+};

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -13,6 +13,7 @@ import {
 	getBroadcastRoomPosts,
 	getBroadcastRoomSession,
 } from "$lib/server/queries";
+import { ROOM_EXIT_SURVEY_VERSION } from "$lib/server/room-exit-survey";
 import {
 	createRoomExperimentServiceClient,
 	getActiveRoomExperimentRunForAnime as getActiveExperimentRun,
@@ -85,12 +86,36 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 
 	const hashtag = roomHashtag(anime);
 	const roomExperimentSupabase = user ? createRoomExperimentServiceClient() : null;
-	const [posts, trending, animeTrending, roomExperimentRun] = await Promise.all([
+	const [posts, trending, animeTrending, roomExperimentRun, surveyResponse, surveyPostCount] = await Promise.all([
 		getBroadcastRoomPosts(supabase, session.id, user?.id ?? null, { limit: 100, ascending: true }),
 		supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
 		getAnimeRankingTrending(supabase, 5),
 		roomExperimentSupabase ? getActiveExperimentRun(roomExperimentSupabase, anime.id) : Promise.resolve(null),
+		user
+			? supabase
+					.from("room_exit_survey_responses")
+					.select("id")
+					.eq("user_id", user.id)
+					.eq("broadcast_room_session_id", session.id)
+					.eq("survey_version", ROOM_EXIT_SURVEY_VERSION)
+					.maybeSingle()
+			: Promise.resolve({ data: null, error: null }),
+		user
+			? supabase
+					.from("posts")
+					.select("id", { count: "exact", head: true })
+					.eq("user_id", user.id)
+					.eq("broadcast_room_session_id", session.id)
+					.is("parent_id", null)
+					.eq("hidden_by_admin", false)
+			: Promise.resolve({ count: 0, error: null }),
 	]);
+	if (surveyResponse.error) {
+		console.error("room exit survey lookup failed:", surveyResponse.error);
+	}
+	if (surveyPostCount.error) {
+		console.error("room exit survey post count lookup failed:", surveyPostCount.error);
+	}
 
 	return {
 		anime,
@@ -112,6 +137,12 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		roomExperiment: {
 			enabled: Boolean(user && roomExperimentRun),
 			sessionId: roomExperimentRun ? session.id : undefined,
+		},
+		roomExitSurvey: {
+			experimentRunId: roomExperimentRun?.id ?? null,
+			alreadyAnswered: Boolean(surveyResponse.data),
+			postCount: surveyPostCount.count ?? 0,
+			surveyVersion: ROOM_EXIT_SURVEY_VERSION,
 		},
 	};
 };

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -13,7 +13,7 @@ import {
 	getBroadcastRoomPosts,
 	getBroadcastRoomSession,
 } from "$lib/server/queries";
-import { ROOM_EXIT_SURVEY_VERSION } from "$lib/server/room-exit-survey";
+import { getRoomExitSurveyLoadState, ROOM_EXIT_SURVEY_VERSION } from "$lib/server/room-exit-survey";
 import {
 	createRoomExperimentServiceClient,
 	getActiveRoomExperimentRunForAnime as getActiveExperimentRun,
@@ -86,36 +86,13 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 
 	const hashtag = roomHashtag(anime);
 	const roomExperimentSupabase = user ? createRoomExperimentServiceClient() : null;
-	const [posts, trending, animeTrending, roomExperimentRun, surveyResponse, surveyPostCount] = await Promise.all([
+	const [posts, trending, animeTrending, roomExperimentRun, roomExitSurveyLoadState] = await Promise.all([
 		getBroadcastRoomPosts(supabase, session.id, user?.id ?? null, { limit: 100, ascending: true }),
 		supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
 		getAnimeRankingTrending(supabase, 5),
 		roomExperimentSupabase ? getActiveExperimentRun(roomExperimentSupabase, anime.id) : Promise.resolve(null),
-		user
-			? supabase
-					.from("room_exit_survey_responses")
-					.select("id")
-					.eq("user_id", user.id)
-					.eq("broadcast_room_session_id", session.id)
-					.eq("survey_version", ROOM_EXIT_SURVEY_VERSION)
-					.maybeSingle()
-			: Promise.resolve({ data: null, error: null }),
-		user
-			? supabase
-					.from("posts")
-					.select("id", { count: "exact", head: true })
-					.eq("user_id", user.id)
-					.eq("broadcast_room_session_id", session.id)
-					.is("parent_id", null)
-					.eq("hidden_by_admin", false)
-			: Promise.resolve({ count: 0, error: null }),
+		getRoomExitSurveyLoadState(supabase, user?.id, session.id),
 	]);
-	if (surveyResponse.error) {
-		console.error("room exit survey lookup failed:", surveyResponse.error);
-	}
-	if (surveyPostCount.error) {
-		console.error("room exit survey post count lookup failed:", surveyPostCount.error);
-	}
 
 	return {
 		anime,
@@ -140,8 +117,8 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		},
 		roomExitSurvey: {
 			experimentRunId: roomExperimentRun?.id ?? null,
-			alreadyAnswered: Boolean(surveyResponse.data),
-			postCount: surveyPostCount.count ?? 0,
+			alreadyAnswered: roomExitSurveyLoadState.alreadyAnswered,
+			postCount: roomExitSurveyLoadState.postCount,
 			surveyVersion: ROOM_EXIT_SURVEY_VERSION,
 		},
 	};

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -477,6 +477,10 @@ function formatCompactDate(iso: string) {
 					<span class="event-timer-badge">受付中</span>
 				{/if}
 			{/if}
+			<button type="button" class="room-mobile-exit" onclick={handleExitRoom} aria-label="騾蜃ｺ縺吶ｋ">
+				<span class="i-lucide-log-out" aria-hidden="true"></span>
+				<span>騾蜃ｺ</span>
+			</button>
 		</div>
 
 		{#if data.user && status === "open"}
@@ -863,6 +867,22 @@ function formatCompactDate(iso: string) {
 	color: var(--color-text-muted);
 	white-space: nowrap;
 	flex-shrink: 0;
+}
+.room-mobile-exit {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+	border: 0;
+	background: transparent;
+	color: var(--color-text-muted);
+	font: inherit;
+	font-size: 12px;
+	font-weight: 700;
+	cursor: pointer;
+}
+.room-mobile-exit:hover {
+	color: var(--color-accent-hover);
 }
 .room-mobile-timer.event-timer--open {
 	color: var(--color-primary);

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -152,7 +152,7 @@ function shouldShowExitSurvey() {
 
 async function leaveRoom() {
 	sendRoomExperimentExit();
-	await goto(`/anime/${data.anime.id}`);
+	await goto("/");
 }
 
 async function handleExitRoom() {

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -477,9 +477,9 @@ function formatCompactDate(iso: string) {
 					<span class="event-timer-badge">受付中</span>
 				{/if}
 			{/if}
-			<button type="button" class="room-mobile-exit" onclick={handleExitRoom} aria-label="騾蜃ｺ縺吶ｋ">
+			<button type="button" class="room-mobile-exit" onclick={handleExitRoom} aria-label="退出する">
 				<span class="i-lucide-log-out" aria-hidden="true"></span>
-				<span>騾蜃ｺ</span>
+				<span>退出</span>
 			</button>
 		</div>
 

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -2,9 +2,11 @@
 import type { SubmitFunction } from "@sveltejs/kit";
 import { onDestroy, onMount, tick } from "svelte";
 import { enhance } from "$app/forms";
+import { goto } from "$app/navigation";
+import ExitSurveyModal from "$lib/components/ExitSurveyModal.svelte";
 import LiveRoomPostCard from "$lib/components/LiveRoomPostCard.svelte";
 import TrendingPanel from "$lib/components/TrendingPanel.svelte";
-import type { Post } from "$lib/types";
+import type { Post, RoomExitSurveyComparisonWithX, RoomExitSurveyNextParticipation } from "$lib/types";
 import type { ActionData, PageData } from "./$types";
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -25,6 +27,12 @@ let postOrder = $state<PostOrder>("oldest");
 let lastPostCount = $state(0);
 let isFollowingLatest = $state(true);
 let unreadNewPostCount = $state(0);
+let enteredAt = Date.now();
+let localSurveyPostCount = $state(0);
+let surveyOpen = $state(false);
+let surveyHandled = $state(false);
+let surveySubmitting = $state(false);
+let surveyErrorMessage: string | null = $state(null);
 let programmaticScrollTimer: ReturnType<typeof setTimeout> | undefined;
 
 const maxLen = 280;
@@ -36,6 +44,7 @@ const openLeadMinutes = $derived(Math.round((scheduledMs - openMs) / (60 * 1000)
 const isGlobalLobby = $derived(data.room.kind === "global");
 const charCount = $derived(postContent.length);
 const overLimit = $derived(charCount > maxLen);
+const surveyPostCount = $derived(data.roomExitSurvey.postCount + localSurveyPostCount);
 // ライブ更新で受信した投稿（load 由来の data.posts とは別に保持し、ID でマージする）
 let extraPosts = $state<Post[]>([]);
 let roomExperimentVisitId: string | null = null;
@@ -129,6 +138,94 @@ function sendRoomExperimentExit() {
 	void fetch(url, { method: "POST", keepalive: true }).catch(() => undefined);
 }
 
+function getStayedSeconds() {
+	return Math.max(0, Math.floor((Date.now() - enteredAt) / 1000));
+}
+
+function shouldShowExitSurvey() {
+	if (surveyHandled) return false;
+	if (!data.user) return false;
+	if (!data.roomExitSurvey.experimentRunId) return false;
+	if (data.roomExitSurvey.alreadyAnswered) return false;
+	return getStayedSeconds() >= 180 || surveyPostCount >= 1;
+}
+
+async function leaveRoom() {
+	sendRoomExperimentExit();
+	await goto(`/anime/${data.anime.id}`);
+}
+
+async function handleExitRoom() {
+	if (shouldShowExitSurvey()) {
+		surveyErrorMessage = null;
+		surveyOpen = true;
+		return;
+	}
+	surveyHandled = true;
+	await leaveRoom();
+}
+
+type RoomExitSurveySubmitAnswers = {
+	overallRating: number;
+	sharedExperienceRating: number;
+	readabilityRating: number;
+	nextParticipation: RoomExitSurveyNextParticipation;
+	comparisonWithX: RoomExitSurveyComparisonWithX;
+	goodPoints: string | null;
+	improvementPoints: string | null;
+};
+
+async function postRoomExitSurvey(action: "submit" | "skip", answers?: RoomExitSurveySubmitAnswers) {
+	const res = await fetch("/api/room-exit-surveys", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			action,
+			anime_id: data.anime.id,
+			broadcast_room_session_id: data.room.session_id,
+			experiment_run_id: data.roomExitSurvey.experimentRunId,
+			survey_version: data.roomExitSurvey.surveyVersion,
+			stayed_seconds: getStayedSeconds(),
+			post_count: surveyPostCount,
+			...(answers ? { answers } : {}),
+		}),
+	});
+	if (!res.ok) throw new Error(`room exit survey failed: ${res.status}`);
+}
+
+async function handleSurveySubmit(answers: RoomExitSurveySubmitAnswers) {
+	if (surveySubmitting) return;
+	surveySubmitting = true;
+	surveyErrorMessage = null;
+	try {
+		await postRoomExitSurvey("submit", answers);
+		surveyHandled = true;
+		surveyOpen = false;
+		await leaveRoom();
+	} catch (error) {
+		console.error("room exit survey submit failed:", error);
+		surveyErrorMessage = "送信に失敗しました。通信状況を確認してもう一度お試しください。";
+	} finally {
+		surveySubmitting = false;
+	}
+}
+
+async function handleSurveySkip() {
+	if (surveySubmitting) return;
+	surveySubmitting = true;
+	surveyErrorMessage = null;
+	try {
+		await postRoomExitSurvey("skip");
+	} catch (error) {
+		console.error("room exit survey skip failed:", error);
+	} finally {
+		surveyHandled = true;
+		surveySubmitting = false;
+		surveyOpen = false;
+		await leaveRoom();
+	}
+}
+
 function handleRoomExperimentPageHide(event: PageTransitionEvent) {
 	if (event.persisted) {
 		clearRoomExperimentHeartbeatTimer();
@@ -168,8 +265,9 @@ function handleWindowPointerDown(event: PointerEvent) {
 
 const handleCreatePost: SubmitFunction = () => {
 	keepComposerFocused = true;
-	return async ({ update }) => {
+	return async ({ result, update }) => {
 		await update({ reset: false });
+		if (result.type === "success") localSurveyPostCount += 1;
 		await focusComposerTextarea({ preventScroll: true });
 	};
 };
@@ -525,6 +623,9 @@ function formatCompactDate(iso: string) {
 						{/if}
 					</div>
 					<div class="mt-2 flex items-center justify-end gap-2">
+						<button type="button" class="room-summary-exit shrink-0 text-xs transition-colors" onclick={handleExitRoom}>
+							退出する
+						</button>
 						<a href="/schedule" class="room-summary-back shrink-0 text-xs transition-colors">
 							← 週間スケジュールへ戻る
 						</a>
@@ -536,6 +637,15 @@ function formatCompactDate(iso: string) {
 		<TrendingPanel trending={data.trending} animeTrending={data.animeTrending} />
 	</aside>
 </div>
+
+{#if surveyOpen}
+	<ExitSurveyModal
+		submitting={surveySubmitting}
+		errorMessage={surveyErrorMessage}
+		onSubmit={handleSurveySubmit}
+		onSkip={handleSurveySkip}
+	/>
+{/if}
 
 <style>
 .room-summary-card {
@@ -562,11 +672,23 @@ function formatCompactDate(iso: string) {
 }
 
 .room-summary-muted,
-.room-summary-back {
+.room-summary-exit {
 	color: var(--color-text-muted);
 }
 
-.room-summary-back:hover {
+.room-summary-exit {
+	border: 0;
+	background: transparent;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+}
+
+.room-summary-back {
+	display: none;
+}
+
+.room-summary-exit:hover {
 	color: var(--color-accent-hover);
 }
 

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -76,6 +76,12 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 			enabled: false,
 			sessionId: undefined,
 		},
+		roomExitSurvey: {
+			experimentRunId: null,
+			alreadyAnswered: false,
+			postCount: 0,
+			surveyVersion: "room_exit_v1",
+		},
 	};
 };
 

--- a/supabase/migrations/090_room_exit_survey_responses.sql
+++ b/supabase/migrations/090_room_exit_survey_responses.sql
@@ -1,0 +1,330 @@
+-- In-app exit survey for episode broadcast room experiment runs.
+-- Keep the prerequisite experiment tables here as a defensive backfill for
+-- environments where 088_room_experiment_analytics.sql has not been applied.
+
+CREATE TABLE IF NOT EXISTS public.room_experiment_runs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    anime_id bigint NOT NULL REFERENCES public.anime(id) ON DELETE CASCADE,
+    started_at timestamptz NOT NULL DEFAULT now(),
+    ended_at timestamptz,
+    created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+    ended_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+    label text CHECK (label IS NULL OR char_length(label) <= 100),
+    notes text CHECK (notes IS NULL OR char_length(notes) <= 1000),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT room_experiment_runs_time_check CHECK (ended_at IS NULL OR ended_at >= started_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS room_experiment_runs_one_active_per_anime
+    ON public.room_experiment_runs (anime_id)
+    WHERE ended_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS room_experiment_runs_started_idx
+    ON public.room_experiment_runs (started_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.room_experiment_visits (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id uuid NOT NULL REFERENCES public.room_experiment_runs(id) ON DELETE CASCADE,
+    anime_id bigint NOT NULL REFERENCES public.anime(id) ON DELETE CASCADE,
+    broadcast_room_session_id uuid NOT NULL REFERENCES public.broadcast_room_sessions(id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    client_visit_key text NOT NULL CHECK (char_length(client_visit_key) BETWEEN 1 AND 120),
+    entered_at timestamptz NOT NULL DEFAULT now(),
+    last_seen_at timestamptz NOT NULL DEFAULT now(),
+    exited_at timestamptz,
+    heartbeat_count integer NOT NULL DEFAULT 0 CHECK (heartbeat_count >= 0),
+    user_agent text CHECK (user_agent IS NULL OR char_length(user_agent) <= 500),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT room_experiment_visits_seen_check CHECK (last_seen_at >= entered_at),
+    CONSTRAINT room_experiment_visits_exit_check CHECK (exited_at IS NULL OR exited_at >= entered_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS room_experiment_visits_unique_client_visit
+    ON public.room_experiment_visits (
+        run_id,
+        user_id,
+        broadcast_room_session_id,
+        client_visit_key
+    );
+
+CREATE INDEX IF NOT EXISTS room_experiment_visits_run_session_idx
+    ON public.room_experiment_visits (run_id, broadcast_room_session_id);
+
+CREATE INDEX IF NOT EXISTS room_experiment_visits_active_idx
+    ON public.room_experiment_visits (run_id, last_seen_at DESC)
+    WHERE exited_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.touch_room_experiment_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS room_experiment_runs_touch_updated_at ON public.room_experiment_runs;
+CREATE TRIGGER room_experiment_runs_touch_updated_at
+    BEFORE UPDATE ON public.room_experiment_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_room_experiment_updated_at();
+
+DROP TRIGGER IF EXISTS room_experiment_visits_touch_updated_at ON public.room_experiment_visits;
+CREATE TRIGGER room_experiment_visits_touch_updated_at
+    BEFORE UPDATE ON public.room_experiment_visits
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_room_experiment_updated_at();
+
+CREATE OR REPLACE FUNCTION public.validate_room_experiment_visit()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+    target_run public.room_experiment_runs%ROWTYPE;
+    target_session public.broadcast_room_sessions%ROWTYPE;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        IF NEW.run_id IS DISTINCT FROM OLD.run_id
+           OR NEW.anime_id IS DISTINCT FROM OLD.anime_id
+           OR NEW.broadcast_room_session_id IS DISTINCT FROM OLD.broadcast_room_session_id
+           OR NEW.user_id IS DISTINCT FROM OLD.user_id
+           OR NEW.client_visit_key IS DISTINCT FROM OLD.client_visit_key
+           OR NEW.entered_at IS DISTINCT FROM OLD.entered_at THEN
+            RAISE EXCEPTION 'room experiment visit identity fields cannot be changed'
+                USING ERRCODE = 'check_violation';
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        SELECT * INTO target_run
+        FROM public.room_experiment_runs
+        WHERE id = NEW.run_id
+        FOR UPDATE;
+    ELSE
+        SELECT * INTO target_run
+        FROM public.room_experiment_runs
+        WHERE id = NEW.run_id;
+    END IF;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'room experiment run does not exist'
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    IF TG_OP = 'INSERT' AND target_run.ended_at IS NOT NULL THEN
+        RAISE EXCEPTION 'room experiment run is not active'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT * INTO target_session
+    FROM public.broadcast_room_sessions
+    WHERE id = NEW.broadcast_room_session_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'broadcast room session does not exist'
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    IF target_session.room_kind <> 'episode' THEN
+        RAISE EXCEPTION 'room experiment visits are only allowed for episode rooms'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF NEW.anime_id IS DISTINCT FROM target_run.anime_id
+       OR NEW.anime_id IS DISTINCT FROM target_session.anime_id THEN
+        RAISE EXCEPTION 'room experiment anime mismatch'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS room_experiment_visits_validate ON public.room_experiment_visits;
+CREATE TRIGGER room_experiment_visits_validate
+    BEFORE INSERT OR UPDATE ON public.room_experiment_visits
+    FOR EACH ROW
+    EXECUTE FUNCTION public.validate_room_experiment_visit();
+
+ALTER TABLE public.room_experiment_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_experiment_visits ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "room_experiment_runs_select_admin" ON public.room_experiment_runs;
+CREATE POLICY "room_experiment_runs_select_admin"
+    ON public.room_experiment_runs
+    FOR SELECT
+    TO authenticated
+    USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "room_experiment_runs_insert_admin" ON public.room_experiment_runs;
+CREATE POLICY "room_experiment_runs_insert_admin"
+    ON public.room_experiment_runs
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        created_by = auth.uid()
+        AND public.is_current_user_admin()
+    );
+
+DROP POLICY IF EXISTS "room_experiment_runs_update_admin" ON public.room_experiment_runs;
+CREATE POLICY "room_experiment_runs_update_admin"
+    ON public.room_experiment_runs
+    FOR UPDATE
+    TO authenticated
+    USING (public.is_current_user_admin())
+    WITH CHECK (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "room_experiment_visits_select_own_or_admin" ON public.room_experiment_visits;
+CREATE POLICY "room_experiment_visits_select_own_or_admin"
+    ON public.room_experiment_visits
+    FOR SELECT
+    TO authenticated
+    USING (
+        user_id = auth.uid()
+        OR public.is_current_user_admin()
+    );
+
+DROP POLICY IF EXISTS "room_experiment_visits_insert_own" ON public.room_experiment_visits;
+CREATE POLICY "room_experiment_visits_insert_own"
+    ON public.room_experiment_visits
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "room_experiment_visits_update_own" ON public.room_experiment_visits;
+-- Visit updates are performed only through trusted server-side API helpers.
+
+CREATE TABLE IF NOT EXISTS public.room_exit_survey_responses (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    anime_id integer NOT NULL REFERENCES public.anime(id) ON DELETE CASCADE,
+    broadcast_room_session_id uuid NOT NULL REFERENCES public.broadcast_room_sessions(id) ON DELETE CASCADE,
+    experiment_run_id uuid NOT NULL REFERENCES public.room_experiment_runs(id) ON DELETE CASCADE,
+    survey_version text NOT NULL DEFAULT 'room_exit_v1'
+        CHECK (char_length(survey_version) BETWEEN 1 AND 40),
+    stayed_seconds integer NOT NULL DEFAULT 0 CHECK (stayed_seconds >= 0),
+    post_count integer NOT NULL DEFAULT 0 CHECK (post_count >= 0),
+    overall_rating smallint CHECK (overall_rating BETWEEN 1 AND 5),
+    shared_experience_rating smallint CHECK (shared_experience_rating BETWEEN 1 AND 5),
+    readability_rating smallint CHECK (readability_rating BETWEEN 1 AND 5),
+    next_participation text CHECK (
+        next_participation IS NULL OR next_participation IN (
+            'must_join',
+            'want_join',
+            'not_sure',
+            'not_really',
+            'not_join'
+        )
+    ),
+    comparison_with_x text CHECK (
+        comparison_with_x IS NULL OR comparison_with_x IN (
+            'anipolis_better',
+            'anipolis_slightly_better',
+            'same',
+            'x_slightly_better',
+            'x_better',
+            'cannot_compare'
+        )
+    ),
+    good_points text CHECK (good_points IS NULL OR char_length(good_points) <= 1000),
+    improvement_points text CHECK (improvement_points IS NULL OR char_length(improvement_points) <= 1000),
+    answers jsonb NOT NULL DEFAULT '{}'::jsonb,
+    skipped boolean NOT NULL DEFAULT false,
+    submitted_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT room_exit_survey_responses_required_answers_check CHECK (
+        skipped
+        OR (
+            overall_rating IS NOT NULL
+            AND shared_experience_rating IS NOT NULL
+            AND readability_rating IS NOT NULL
+            AND next_participation IS NOT NULL
+            AND comparison_with_x IS NOT NULL
+        )
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS room_exit_survey_responses_user_session_version_uidx
+    ON public.room_exit_survey_responses (user_id, broadcast_room_session_id, survey_version);
+
+CREATE INDEX IF NOT EXISTS room_exit_survey_responses_anime_idx
+    ON public.room_exit_survey_responses (anime_id);
+
+CREATE INDEX IF NOT EXISTS room_exit_survey_responses_experiment_run_idx
+    ON public.room_exit_survey_responses (experiment_run_id);
+
+CREATE INDEX IF NOT EXISTS room_exit_survey_responses_session_idx
+    ON public.room_exit_survey_responses (broadcast_room_session_id);
+
+CREATE INDEX IF NOT EXISTS room_exit_survey_responses_submitted_at_idx
+    ON public.room_exit_survey_responses (submitted_at DESC);
+
+CREATE OR REPLACE FUNCTION public.validate_room_exit_survey_response()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+    target_run public.room_experiment_runs%ROWTYPE;
+    target_session public.broadcast_room_sessions%ROWTYPE;
+BEGIN
+    SELECT * INTO target_run
+    FROM public.room_experiment_runs
+    WHERE id = NEW.experiment_run_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'room experiment run does not exist'
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    SELECT * INTO target_session
+    FROM public.broadcast_room_sessions
+    WHERE id = NEW.broadcast_room_session_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'broadcast room session does not exist'
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    IF target_session.room_kind <> 'episode' THEN
+        RAISE EXCEPTION 'room exit surveys are only allowed for episode rooms'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF NEW.anime_id IS DISTINCT FROM target_run.anime_id
+       OR NEW.anime_id IS DISTINCT FROM target_session.anime_id THEN
+        RAISE EXCEPTION 'room exit survey anime mismatch'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS room_exit_survey_responses_validate ON public.room_exit_survey_responses;
+CREATE TRIGGER room_exit_survey_responses_validate
+    BEFORE INSERT OR UPDATE ON public.room_exit_survey_responses
+    FOR EACH ROW
+    EXECUTE FUNCTION public.validate_room_exit_survey_response();
+
+ALTER TABLE public.room_exit_survey_responses ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "room_exit_survey_responses_insert_own" ON public.room_exit_survey_responses;
+CREATE POLICY "room_exit_survey_responses_insert_own"
+    ON public.room_exit_survey_responses
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "room_exit_survey_responses_select_own_or_admin" ON public.room_exit_survey_responses;
+CREATE POLICY "room_exit_survey_responses_select_own_or_admin"
+    ON public.room_exit_survey_responses
+    FOR SELECT
+    TO authenticated
+    USING (
+        user_id = auth.uid()
+        OR public.is_current_user_admin()
+    );

--- a/supabase/migrations/090_room_exit_survey_responses.sql
+++ b/supabase/migrations/090_room_exit_survey_responses.sql
@@ -201,7 +201,7 @@ DROP POLICY IF EXISTS "room_experiment_visits_update_own" ON public.room_experim
 CREATE TABLE IF NOT EXISTS public.room_exit_survey_responses (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-    anime_id integer NOT NULL REFERENCES public.anime(id) ON DELETE CASCADE,
+    anime_id bigint NOT NULL REFERENCES public.anime(id) ON DELETE CASCADE,
     broadcast_room_session_id uuid NOT NULL REFERENCES public.broadcast_room_sessions(id) ON DELETE CASCADE,
     experiment_run_id uuid NOT NULL REFERENCES public.room_experiment_runs(id) ON DELETE CASCADE,
     survey_version text NOT NULL DEFAULT 'room_exit_v1'
@@ -317,7 +317,16 @@ CREATE POLICY "room_exit_survey_responses_insert_own"
     ON public.room_exit_survey_responses
     FOR INSERT
     TO authenticated
-    WITH CHECK (user_id = auth.uid());
+    WITH CHECK (
+        user_id = auth.uid()
+        AND EXISTS (
+            SELECT 1
+            FROM public.room_experiment_visits visit
+            WHERE visit.run_id = room_exit_survey_responses.experiment_run_id
+              AND visit.broadcast_room_session_id = room_exit_survey_responses.broadcast_room_session_id
+              AND visit.user_id = auth.uid()
+        )
+    );
 
 DROP POLICY IF EXISTS "room_exit_survey_responses_select_own_or_admin" ON public.room_exit_survey_responses;
 CREATE POLICY "room_exit_survey_responses_select_own_or_admin"


### PR DESCRIPTION
## Summary
- Add an in-app exit survey for targeted episode broadcast room experiment runs.
- Save submit/skip responses through a new authenticated API and Supabase table.
- Show survey totals, averages, distributions, and anonymized comments in the existing room experiments admin dashboard.
- Make the admin dashboard tolerate missing/unrefreshed experiment or survey schema instead of failing with a 500.

## Notes
- Survey display is limited to the explicit exit button path for v1.
- Migration `090_room_exit_survey_responses.sql` defensively creates the room experiment prerequisite tables if an environment has not applied `088_room_experiment_analytics.sql` yet.

## Validation
- `pnpm.cmd check:svelte`
- `pnpm.cmd check:types`
- `pnpm.cmd test:unit`
- Targeted `pnpm.cmd exec biome check ...`

`pnpm.cmd lint` is still blocked by existing broad formatter/CRLF churn outside this change set; targeted Biome checks for the touched files passed.