### PR TITLE
実況ルームUI改善とタイムラインへのライブルーム導線を追加

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -579,11 +579,6 @@ textarea {
 	color: var(--color-text-muted);
 }
 
-.composer-textarea:focus-visible {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
-}
-
 .composer-footer {
 	display: flex;
 	align-items: center;

--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -9,6 +9,15 @@ type Props = {
 };
 
 let { open, rooms, onclose }: Props = $props();
+
+$effect(() => {
+	if (!open) return;
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (event.key === "Escape") onclose();
+	};
+	window.addEventListener("keydown", handleKeydown);
+	return () => window.removeEventListener("keydown", handleKeydown);
+});
 </script>
 
 {#if open}

--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+import { trapFocus } from "$lib/actions/trapFocus";
+import type { OpenBroadcastRoomSummary } from "$lib/types";
+
+type Props = {
+	open: boolean;
+	rooms: OpenBroadcastRoomSummary[] | null;
+	onclose: () => void;
+};
+
+let { open, rooms, onclose }: Props = $props();
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<div
+		class="anime-search-overlay"
+		onclick={(e) => {
+			if (e.target === e.currentTarget) onclose();
+		}}
+		role="dialog"
+		aria-modal="true"
+		aria-label="ライブ実況ルームを選択"
+		tabindex="-1"
+		use:trapFocus
+	>
+		<div class="anime-search-modal">
+			<div class="anime-search-header">
+				<span class="anime-search-title">ライブ実況ルームを選択</span>
+				<button type="button" class="anime-search-close" onclick={onclose} aria-label="閉じる">✕</button>
+			</div>
+			<div class="anime-search-results">
+				{#if rooms === null}
+					<p class="anime-search-empty">読み込み中…</p>
+				{:else if rooms.length === 0}
+					<p class="anime-search-empty">現在ライブ中の実況ルームはありません</p>
+				{:else}
+					{#each rooms as room (room.id)}
+						<a href="/rooms/anime/{room.anime_id}/{room.room_date}" class="anime-search-item">
+							{#if room.anime?.cover_url}
+								<img src={room.anime.cover_url} alt={room.anime.title} class="anime-search-thumb">
+							{:else}
+								<div class="anime-search-thumb anime-search-thumb-empty"></div>
+							{/if}
+							<div class="anime-search-item-info">
+								<span class="anime-search-item-title">{room.anime?.title ?? "不明"}</span>
+								<span class="anime-search-item-sub">{room.room_date}</span>
+							</div>
+						</a>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/LiveRoomPostCard.svelte
+++ b/src/lib/components/LiveRoomPostCard.svelte
@@ -584,11 +584,11 @@ async function submitReport(event: MouseEvent) {
 	--live-grid-gap: 7px;
 	--live-detail-start: calc(var(--live-row-pad-x) + var(--live-avatar-size) + var(--live-grid-gap));
 	position: relative;
-	border-bottom: 1px solid var(--color-border);
-	border-left: 2px solid color-mix(in srgb, var(--color-border) 72%, transparent);
+	border-left: 2px solid color-mix(in srgb, var(--color-border) 90%, transparent);
 	background: transparent;
 	transition: background 120ms ease;
 	-webkit-tap-highlight-color: transparent;
+	overflow-anchor: none;
 }
 
 .live-post-card:hover,
@@ -671,7 +671,7 @@ async function submitReport(event: MouseEvent) {
 	margin: 0;
 	overflow: hidden;
 	color: var(--color-text);
-	font-size: 13px;
+	font-size: 15px;
 	font-weight: 500;
 	line-height: 1.35;
 	word-break: break-word;
@@ -1052,7 +1052,7 @@ async function submitReport(event: MouseEvent) {
 	}
 
 	.live-content {
-		font-size: 12px;
+		font-size: 14px;
 	}
 
 	.live-time {

--- a/src/lib/components/LiveRoomsPanel.svelte
+++ b/src/lib/components/LiveRoomsPanel.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import type { OpenBroadcastRoomSummary } from "$lib/types";
+import LiveRoomPickerModal from "./LiveRoomPickerModal.svelte";
+
+interface Props {
+	rooms: OpenBroadcastRoomSummary[];
+}
+
+let { rooms }: Props = $props();
+
+const singleRoom = $derived(rooms.length === 1 ? rooms[0] : undefined);
+
+let pickerOpen = $state(false);
+
+function openPicker() {
+	pickerOpen = true;
+}
+
+function closePicker() {
+	pickerOpen = false;
+}
+</script>
+
+<section class="trending-panel live-rooms-panel">
+	<div class="trending-header">ライブ実況ルーム</div>
+
+	{#if rooms.length === 0}
+		<div class="trending-empty">現在ライブ中の実況ルームはありません</div>
+	{:else if singleRoom}
+		<a href="/rooms/anime/{singleRoom.anime_id}/{singleRoom.room_date}" class="trending-item live-room-entry">
+			{#if singleRoom.anime?.cover_url}
+				<img src={singleRoom.anime.cover_url} alt={singleRoom.anime.title} class="anime-search-thumb">
+			{:else}
+				<div class="anime-search-thumb anime-search-thumb-empty"></div>
+			{/if}
+			<span class="live-room-entry-info">
+				<span class="live-room-entry-title">{singleRoom.anime?.title ?? "不明"}</span>
+				<span class="live-room-entry-sub">配信中 · {singleRoom.room_date}</span>
+			</span>
+		</a>
+	{:else}
+		<button type="button" class="trending-item live-room-entry live-room-entry-button" onclick={openPicker}>
+			<span class="live-room-entry-info">
+				<span class="live-room-entry-title">ライブ実況ルームが{rooms.length}件あります</span>
+				<span class="live-room-entry-sub">タップして選択</span>
+			</span>
+		</button>
+	{/if}
+</section>
+
+<LiveRoomPickerModal open={pickerOpen} rooms={pickerOpen ? rooms : null} onclose={closePicker} />
+
+<style>
+.live-rooms-panel {
+	margin-bottom: 16px;
+}
+
+.live-room-entry {
+	width: 100%;
+	border: none;
+	background: none;
+	cursor: pointer;
+	font: inherit;
+	text-align: left;
+}
+
+.live-room-entry-info {
+	display: flex;
+	min-width: 0;
+	flex: 1;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.live-room-entry-title {
+	overflow: hidden;
+	color: var(--color-text);
+	font-weight: 600;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.live-room-entry-sub {
+	color: var(--color-text-muted);
+	font-size: 12px;
+}
+</style>

--- a/src/lib/components/PostComposer.svelte
+++ b/src/lib/components/PostComposer.svelte
@@ -1,5 +1,6 @@
 ﻿<script lang="ts">
 import type { SubmitFunction } from "@sveltejs/kit";
+import { onMount } from "svelte";
 import { enhance } from "$app/forms";
 import { replaceState } from "$app/navigation";
 import { page } from "$app/state";
@@ -33,6 +34,7 @@ interface Props {
 	initialExchangeShare?: AnimeExchangeShare | null;
 	watchingAnime?: AnimeResult[];
 	onsubmitsuccess?: () => void;
+	focusOnMount?: boolean;
 }
 
 let {
@@ -44,6 +46,7 @@ let {
 	initialExchangeShare = null,
 	watchingAnime = [],
 	onsubmitsuccess,
+	focusOnMount = false,
 }: Props = $props();
 
 const MAX_LENGTH = 280;
@@ -92,6 +95,10 @@ let roomsLoading = $state(false);
 
 // @メンション
 let textareaEl = $state<HTMLTextAreaElement | null>(null);
+
+onMount(() => {
+	if (focusOnMount) textareaEl?.focus();
+});
 let mentionResults = $state<UserResult[]>([]);
 let mentionDropdownOpen = $state(false);
 let mentionDebounce = $state<ReturnType<typeof setTimeout> | null>(null);

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -4,8 +4,9 @@ import { browser } from "$app/environment";
 import { goto, invalidateAll } from "$app/navigation";
 import { page } from "$app/state";
 import type { Database } from "$lib/supabase/database.types";
-import type { StoredAccount } from "$lib/types";
+import type { OpenBroadcastRoomSummary, StoredAccount } from "$lib/types";
 import AnimeIcon from "./AnimeIcon.svelte";
+import LiveRoomPickerModal from "./LiveRoomPickerModal.svelte";
 import UserAvatar from "./UserAvatar.svelte";
 
 type Profile = Database["public"]["Tables"]["profiles"]["Row"] | null;
@@ -38,6 +39,31 @@ function toggleTheme() {
 	theme = theme === "dark" ? "light" : "dark";
 	document.documentElement.setAttribute("data-theme", theme);
 	localStorage.setItem("theme", theme);
+}
+
+let liveRoomModalOpen = $state(false);
+let liveRooms = $state<OpenBroadcastRoomSummary[] | null>(null);
+
+async function openLiveRoomPicker() {
+	liveRoomModalOpen = true;
+	liveRooms = null;
+	try {
+		const res = await fetch("/api/rooms/open?kind=episode");
+		const rooms: OpenBroadcastRoomSummary[] = res.ok ? await res.json() : [];
+		const onlyRoom = rooms.length === 1 ? rooms[0] : undefined;
+		if (onlyRoom) {
+			liveRoomModalOpen = false;
+			await goto(`/rooms/anime/${onlyRoom.anime_id}/${onlyRoom.room_date}`);
+			return;
+		}
+		liveRooms = rooms;
+	} catch {
+		liveRooms = [];
+	}
+}
+
+function closeLiveRoomPicker() {
+	liveRoomModalOpen = false;
 }
 
 const displayName = $derived(profile?.display_name || profile?.username || session?.user?.email?.split("@")[0] || "");
@@ -121,51 +147,65 @@ function isActive(path: string): boolean {
 		<span class="anipolis-logo-icon size-22" aria-hidden="true"></span>
 		<span>Anipolis</span>
 	</a>
-	<button
-		type="button"
-		class="mobile-theme-btn"
-		onclick={toggleTheme}
-		aria-label={theme === 'dark' ? 'ライトモードに切替' : 'ダークモードに切替'}
-	>
-		{#if theme === 'dark'}
-			<svg
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				aria-hidden="true"
+	<div class="mobile-header-actions">
+		{#if session}
+			<button
+				type="button"
+				class="mobile-live-room-btn"
+				onclick={openLiveRoomPicker}
+				aria-label="ライブ実況ルーム"
 			>
-				<circle cx="12" cy="12" r="5" />
-				<line x1="12" y1="1" x2="12" y2="3" />
-				<line x1="12" y1="21" x2="12" y2="23" />
-				<line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-				<line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-				<line x1="1" y1="12" x2="3" y2="12" />
-				<line x1="21" y1="12" x2="23" y2="12" />
-				<line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-				<line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-			</svg>
-		{:else}
-			<svg
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				aria-hidden="true"
-			>
-				<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-			</svg>
+				<span class="i-lucide-radio" aria-hidden="true"></span>
+			</button>
 		{/if}
-	</button>
+		<button
+			type="button"
+			class="mobile-theme-btn"
+			onclick={toggleTheme}
+			aria-label={theme === 'dark' ? 'ライトモードに切替' : 'ダークモードに切替'}
+		>
+			{#if theme === 'dark'}
+				<svg
+					width="20"
+					height="20"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<circle cx="12" cy="12" r="5" />
+					<line x1="12" y1="1" x2="12" y2="3" />
+					<line x1="12" y1="21" x2="12" y2="23" />
+					<line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+					<line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+					<line x1="1" y1="12" x2="3" y2="12" />
+					<line x1="21" y1="12" x2="23" y2="12" />
+					<line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+					<line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+				</svg>
+			{:else}
+				<svg
+					width="20"
+					height="20"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+				</svg>
+			{/if}
+		</button>
+	</div>
 </header>
+
+<LiveRoomPickerModal open={liveRoomModalOpen} rooms={liveRooms} onclose={closeLiveRoomPicker} />
 
 <!-- Mobile drawer backdrop -->
 {#if drawerOpen}
@@ -889,7 +929,8 @@ function isActive(path: string): boolean {
 }
 
 .mobile-hamburger,
-.mobile-theme-btn {
+.mobile-theme-btn,
+.mobile-live-room-btn {
 	background: none;
 	border: none;
 	cursor: pointer;
@@ -899,6 +940,12 @@ function isActive(path: string): boolean {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+}
+
+.mobile-header-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
 }
 
 .mobile-header-logo {

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -16,6 +16,7 @@ import type {
 	BroadcastStatus,
 	Event,
 	Notification,
+	OpenBroadcastRoomSummary,
 	Post,
 	RawPost,
 	ReactionType,
@@ -2680,9 +2681,12 @@ export async function getAnimeMuteCandidate(supabase: SupabaseClient<Database>, 
 	return { id: String(data.id), title: data.title, cover_url: data.cover_url ?? null };
 }
 
-export async function getOpenBroadcastRoomSessions(supabase: SupabaseClient<Database>) {
+export async function getOpenBroadcastRoomSessions(
+	supabase: SupabaseClient<Database>,
+	options?: { kind?: "episode" | "global" },
+): Promise<OpenBroadcastRoomSummary[]> {
 	const now = new Date().toISOString();
-	const { data, error } = await supabase
+	let query = supabase
 		.from("broadcast_room_sessions")
 		.select(
 			"id, anime_id, room_date, room_kind, room_key, scheduled_at, anime:anime!broadcast_room_sessions_anime_id_fkey ( id, title, cover_url )",
@@ -2690,6 +2694,8 @@ export async function getOpenBroadcastRoomSessions(supabase: SupabaseClient<Data
 		.lte("posting_opens_at", now)
 		.gte("posting_closes_at", now)
 		.order("scheduled_at");
+	if (options?.kind) query = query.eq("room_kind", options.kind);
+	const { data, error } = await query;
 	if (error) {
 		console.error("getOpenBroadcastRoomSessions failed:", error);
 		return [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -437,6 +437,21 @@ function buildAnimeRoomHref(
 	return session?.room_date ? `/rooms/anime/${String(anime.id)}/${session.room_date}` : null;
 }
 
+export function calcEpisodeNumberFromDate(
+	roomDate: string | null,
+	airedFrom: string | null,
+	broadcastTime: string | null,
+): number | null {
+	if (!roomDate || !airedFrom) return null;
+	const airedFromDate = new Date(`${airedFrom.slice(0, 10)}T00:00:00`);
+	const slotDate = new Date(`${roomDate}T00:00:00`);
+	const broadcastHour = broadcastTime ? Number(broadcastTime.split(":")[0]) : 0;
+	if (broadcastHour >= 24) slotDate.setDate(slotDate.getDate() + 1);
+	const msDiff = slotDate.getTime() - airedFromDate.getTime();
+	if (msDiff < 0) return null;
+	return Math.floor(Math.round(msDiff / 86_400_000) / 7) + 1;
+}
+
 function calcEpisodeNumber(
 	rawSession: RawPost["broadcast_room_session"],
 	airedFrom: string | null,
@@ -444,14 +459,7 @@ function calcEpisodeNumber(
 ): number | null {
 	const session = Array.isArray(rawSession) ? rawSession[0] : rawSession;
 	if (session?.room_kind === "global") return null;
-	if (!session?.room_date || !airedFrom) return null;
-	const airedFromDate = new Date(`${airedFrom.slice(0, 10)}T00:00:00`);
-	const slotDate = new Date(`${session.room_date}T00:00:00`);
-	const broadcastHour = broadcastTime ? Number(broadcastTime.split(":")[0]) : 0;
-	if (broadcastHour >= 24) slotDate.setDate(slotDate.getDate() + 1);
-	const msDiff = slotDate.getTime() - airedFromDate.getTime();
-	if (msDiff < 0) return null;
-	return Math.floor(Math.round(msDiff / 86_400_000) / 7) + 1;
+	return calcEpisodeNumberFromDate(session?.room_date ?? null, airedFrom, broadcastTime);
 }
 
 export function buildAnimeRoomLabel(anime: Pick<AnimeQuote, "title" | "official_hashtag" | "episode_number">): string {
@@ -542,6 +550,16 @@ export interface BroadcastRoomSession {
 	duration_minutes: number;
 	posting_opens_at: string;
 	posting_closes_at: string;
+}
+
+export interface OpenBroadcastRoomSummary {
+	id: string;
+	anime_id: string;
+	room_date: string;
+	room_kind: "episode" | "global";
+	room_key: string;
+	scheduled_at: string;
+	anime: { id: string; title: string; cover_url: string | null } | null;
 }
 
 export interface BroadcastRoomOverride {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -12,6 +12,7 @@ import {
 	getAnimeRankingTrending,
 	getFollowingProfiles,
 	getHomeTimelinePosts,
+	getOpenBroadcastRoomSessions,
 	getTimelinePostsWithReposts,
 	getUserAnimeList,
 } from "$lib/server/queries";
@@ -82,25 +83,28 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		"#アニメトレード でおすすめが届きました！";
 
 	if (tab === "following" && followingProfiles !== null && followingProfiles.length === 0) {
-		const [trendingResult, animeTrending, quoteAnimeResult, exchangeShare, watchingAnime] = await Promise.all([
-			supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
-			getAnimeRankingTrending(supabase, 5),
-			quoteAnimeId
-				? supabase
-						.from("anime")
-						.select("id, title, title_en, cover_url, official_hashtag")
-						.eq("id", Number(quoteAnimeId))
-						.single()
-				: Promise.resolve({ data: null }),
-			user && shareExchangeId
-				? getAnimeExchangeShareForUser(supabase, user.id, shareExchangeId)
-				: Promise.resolve(null),
-			user ? getUserAnimeList(supabase, user.id, "watching") : Promise.resolve([]),
-		]);
+		const [trendingResult, animeTrending, quoteAnimeResult, exchangeShare, watchingAnime, liveRooms] =
+			await Promise.all([
+				supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
+				getAnimeRankingTrending(supabase, 5),
+				quoteAnimeId
+					? supabase
+							.from("anime")
+							.select("id, title, title_en, cover_url, official_hashtag")
+							.eq("id", Number(quoteAnimeId))
+							.single()
+					: Promise.resolve({ data: null }),
+				user && shareExchangeId
+					? getAnimeExchangeShareForUser(supabase, user.id, shareExchangeId)
+					: Promise.resolve(null),
+				user ? getUserAnimeList(supabase, user.id, "watching") : Promise.resolve([]),
+				user ? getOpenBroadcastRoomSessions(supabase, { kind: "episode" }) : Promise.resolve([]),
+			]);
 		return {
 			posts: [],
 			trending: trendingResult.data ?? [],
 			animeTrending,
+			liveRooms,
 			profile,
 			tab,
 			initialAnime: quoteAnimeResult.data
@@ -118,27 +122,30 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		};
 	}
 
-	const [posts, trendingResult, animeTrending, quoteAnimeResult, exchangeShare, watchingAnime] = await Promise.all([
-		fetchPosts(),
-		supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
-		getAnimeRankingTrending(supabase, 5),
-		quoteAnimeId
-			? supabase
-					.from("anime")
-					.select("id, title, title_en, cover_url, official_hashtag")
-					.eq("id", Number(quoteAnimeId))
-					.single()
-			: Promise.resolve({ data: null }),
-		user && shareExchangeId
-			? getAnimeExchangeShareForUser(supabase, user.id, shareExchangeId)
-			: Promise.resolve(null),
-		user ? getUserAnimeList(supabase, user.id, "watching") : Promise.resolve([]),
-	]);
+	const [posts, trendingResult, animeTrending, quoteAnimeResult, exchangeShare, watchingAnime, liveRooms] =
+		await Promise.all([
+			fetchPosts(),
+			supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
+			getAnimeRankingTrending(supabase, 5),
+			quoteAnimeId
+				? supabase
+						.from("anime")
+						.select("id, title, title_en, cover_url, official_hashtag")
+						.eq("id", Number(quoteAnimeId))
+						.single()
+				: Promise.resolve({ data: null }),
+			user && shareExchangeId
+				? getAnimeExchangeShareForUser(supabase, user.id, shareExchangeId)
+				: Promise.resolve(null),
+			user ? getUserAnimeList(supabase, user.id, "watching") : Promise.resolve([]),
+			user ? getOpenBroadcastRoomSessions(supabase, { kind: "episode" }) : Promise.resolve([]),
+		]);
 
 	return {
 		posts,
 		trending: trendingResult.data ?? [],
 		animeTrending,
+		liveRooms,
 		profile,
 		tab,
 		before: before?.createdAt ?? null,

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -82,24 +82,27 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 	const buildExchangeInitialContent = (_exchangeShare: AnimeExchangeShare | null) =>
 		"#アニメトレード でおすすめが届きました！";
 
+	const fetchSidebarExtras = () =>
+		Promise.all([
+			supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
+			getAnimeRankingTrending(supabase, 5),
+			quoteAnimeId
+				? supabase
+						.from("anime")
+						.select("id, title, title_en, cover_url, official_hashtag")
+						.eq("id", Number(quoteAnimeId))
+						.single()
+				: Promise.resolve({ data: null }),
+			user && shareExchangeId
+				? getAnimeExchangeShareForUser(supabase, user.id, shareExchangeId)
+				: Promise.resolve(null),
+			user ? getUserAnimeList(supabase, user.id, "watching") : Promise.resolve([]),
+			user ? getOpenBroadcastRoomSessions(supabase, { kind: "episode" }) : Promise.resolve([]),
+		] as const);
+
 	if (tab === "following" && followingProfiles !== null && followingProfiles.length === 0) {
 		const [trendingResult, animeTrending, quoteAnimeResult, exchangeShare, watchingAnime, liveRooms] =
-			await Promise.all([
-				supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
-				getAnimeRankingTrending(supabase, 5),
-				quoteAnimeId
-					? supabase
-							.from("anime")
-							.select("id, title, title_en, cover_url, official_hashtag")
-							.eq("id", Number(quoteAnimeId))
-							.single()
-					: Promise.resolve({ data: null }),
-				user && shareExchangeId
-					? getAnimeExchangeShareForUser(supabase, user.id, shareExchangeId)
-					: Promise.resolve(null),
-				user ? getUserAnimeList(supabase, user.id, "watching") : Promise.resolve([]),
-				user ? getOpenBroadcastRoomSessions(supabase, { kind: "episode" }) : Promise.resolve([]),
-			]);
+			await fetchSidebarExtras();
 		return {
 			posts: [],
 			trending: trendingResult.data ?? [],
@@ -122,24 +125,8 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		};
 	}
 
-	const [posts, trendingResult, animeTrending, quoteAnimeResult, exchangeShare, watchingAnime, liveRooms] =
-		await Promise.all([
-			fetchPosts(),
-			supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
-			getAnimeRankingTrending(supabase, 5),
-			quoteAnimeId
-				? supabase
-						.from("anime")
-						.select("id, title, title_en, cover_url, official_hashtag")
-						.eq("id", Number(quoteAnimeId))
-						.single()
-				: Promise.resolve({ data: null }),
-			user && shareExchangeId
-				? getAnimeExchangeShareForUser(supabase, user.id, shareExchangeId)
-				: Promise.resolve(null),
-			user ? getUserAnimeList(supabase, user.id, "watching") : Promise.resolve([]),
-			user ? getOpenBroadcastRoomSessions(supabase, { kind: "episode" }) : Promise.resolve([]),
-		]);
+	const [[trendingResult, animeTrending, quoteAnimeResult, exchangeShare, watchingAnime, liveRooms], posts] =
+		await Promise.all([fetchSidebarExtras(), fetchPosts()]);
 
 	return {
 		posts,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { goto } from "$app/navigation";
+import LiveRoomsPanel from "$lib/components/LiveRoomsPanel.svelte";
 import PostCard from "$lib/components/PostCard.svelte";
 import PostCardSkeleton from "$lib/components/PostCardSkeleton.svelte";
 import PostComposer from "$lib/components/PostComposer.svelte";
@@ -232,6 +233,9 @@ $effect(() => {
 	</main>
 
 	<aside class="sidebar-column">
+		{#if data.user}
+			<LiveRoomsPanel rooms={data.liveRooms} />
+		{/if}
 		<TrendingPanel trending={data.trending} animeTrending={data.animeTrending} />
 	</aside>
 </div>
@@ -271,6 +275,7 @@ $effect(() => {
 				initialExchangeShare={data.initialExchangeShare}
 				watchingAnime={data.watchingAnime}
 				onsubmitsuccess={closeModal}
+				focusOnMount
 			/>
 		</div>
 	</div>

--- a/src/routes/api/rooms/open/+server.ts
+++ b/src/routes/api/rooms/open/+server.ts
@@ -2,8 +2,11 @@ import { json } from "@sveltejs/kit";
 import { getOpenBroadcastRoomSessions } from "$lib/server/queries";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = async ({ locals: { supabase, safeGetSession } }) => {
+export const GET: RequestHandler = async ({ url, locals: { supabase, safeGetSession } }) => {
 	const { user } = await safeGetSession();
 	if (!user) return json([], { status: 401 });
-	return json(await getOpenBroadcastRoomSessions(supabase));
+	const kindParam = url.searchParams.get("kind");
+	const kind: "episode" | "global" | undefined =
+		kindParam === "episode" || kindParam === "global" ? kindParam : undefined;
+	return json(await getOpenBroadcastRoomSessions(supabase, kind ? { kind } : undefined));
 };

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -19,6 +19,7 @@ import {
 	getActiveRoomExperimentRunForAnime as getActiveExperimentRun,
 } from "$lib/server/room-experiments";
 import type { Anime } from "$lib/types";
+import { calcEpisodeNumberFromDate } from "$lib/types";
 import type { Actions, PageServerLoad } from "./$types";
 
 function dateKeyToDate(value: string) {
@@ -85,6 +86,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	if (!session) throw error(404, "放送ルームが見つかりません");
 
 	const hashtag = roomHashtag(anime);
+	const episodeNumber = calcEpisodeNumberFromDate(session.room_date, anime.aired_from, anime.broadcast_time);
 	const roomExperimentSupabase = user ? createRoomExperimentServiceClient() : null;
 	const [posts, trending, animeTrending, roomExperimentRun, roomExitSurveyLoadState] = await Promise.all([
 		getBroadcastRoomPosts(supabase, session.id, user?.id ?? null, { limit: 100, ascending: true }),
@@ -105,7 +107,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 			posting_opens_at: session.posting_opens_at,
 			posting_closes_at: session.posting_closes_at,
 			duration_minutes: session.duration_minutes,
-			title: `${anime.title} 放送ルーム`,
+			title: episodeNumber != null ? `${anime.title} ${episodeNumber}話` : `${anime.title} 放送ルーム`,
 		},
 		posts,
 		trending: trending.data ?? [],

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -42,6 +42,11 @@ const openMs = $derived(new Date(data.room.posting_opens_at).getTime());
 const closeMs = $derived(new Date(data.room.posting_closes_at).getTime());
 const openLeadMinutes = $derived(Math.round((scheduledMs - openMs) / (60 * 1000)));
 const isGlobalLobby = $derived(data.room.kind === "global");
+const roomNameLabel = $derived(
+	data.room.title.startsWith(data.anime.title)
+		? data.room.title.slice(data.anime.title.length).trim()
+		: data.room.title,
+);
 const charCount = $derived(postContent.length);
 const overLimit = $derived(charCount > maxLen);
 const surveyPostCount = $derived(data.roomExitSurvey.postCount + localSurveyPostCount);
@@ -481,8 +486,11 @@ function formatCompactDate(iso: string) {
 <div class="page-container room-page-container">
 	<div class="feed-column">
 		<div class="room-mobile-bar">
-			<span class="room-mobile-title">{data.room.title}</span>
-			{#if !isGlobalLobby}
+			<span class="room-mobile-title"
+				><a href="/anime/{data.anime.id}" class="anime-title-link">{data.anime.title}</a
+				><span class="hierarchy-separator"> ❯ </span>{roomNameLabel}</span
+			>
+			{#if !isGlobalLobby && status !== "ended"}
 				<span class="room-mobile-timer event-timer--{status}">{timerLabel}</span>
 				{#if status === "open"}
 					<span class="event-timer-badge">受付中</span>
@@ -543,7 +551,7 @@ function formatCompactDate(iso: string) {
 			<div class="card anime-room-login">投稿受付は放送開始{openLeadMinutes}分前から始まります。</div>
 		{:else}
 			<div class="card anime-room-login">
-				このルームの投稿受付は終了しました。<a href="/?quote_anime={data.anime.id}">通常投稿で感想を残す</a>
+				このルームの投稿受付は終了しました。<a href="/?quote_anime={data.anime.id}">引用投稿で感想を残す</a>
 			</div>
 		{/if}
 
@@ -558,7 +566,7 @@ function formatCompactDate(iso: string) {
 				aria-pressed={postOrder === "oldest"}
 				onclick={() => setPostOrder("oldest")}
 			>
-				古い順
+				時系列順
 			</button>
 			<button
 				type="button"
@@ -620,7 +628,10 @@ function formatCompactDate(iso: string) {
 				</a>
 				<div class="flex min-h-20 min-w-0 flex-1 flex-col justify-between pl-3">
 					<div class="min-w-0">
-						<h1 class="room-summary-title line-clamp-1 text-sm font-bold">{data.room.title}</h1>
+						<h1 class="room-summary-title line-clamp-1 text-sm font-bold">
+							<a href="/anime/{data.anime.id}" class="anime-title-link">{data.anime.title}</a
+							><span class="hierarchy-separator"> ❯ </span>{roomNameLabel}
+						</h1>
 						{#if !isGlobalLobby}
 							<div class="mt-2 flex min-w-0 items-center gap-2">
 								{#if status === "ended"}
@@ -678,7 +689,34 @@ function formatCompactDate(iso: string) {
 }
 
 .room-summary-title {
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
 	color: var(--color-text);
+}
+
+.anime-title-link {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+	text-decoration: none;
+	color: inherit;
+	padding: 4px 2px;
+	margin: -4px -2px;
+	transition: opacity 0.2s;
+}
+
+.anime-title-link:hover,
+.anime-title-link:active {
+	opacity: 0.7;
+}
+
+.hierarchy-separator {
+	flex-shrink: 0;
+	font-size: 0.85em;
+	color: var(--color-text-muted);
+	margin: 0 4px;
 }
 
 .room-summary-status {
@@ -849,11 +887,6 @@ function formatCompactDate(iso: string) {
 	color: white;
 }
 
-:global(.room-composer-textarea:focus-visible) {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
-}
-
 /* ── モバイル用コンパクトバー (サイドバー非表示時のみ表示) ── */
 .room-mobile-bar {
 	display: none;
@@ -867,11 +900,12 @@ function formatCompactDate(iso: string) {
 	overflow: hidden;
 }
 .room-mobile-title {
+	display: inline-flex;
+	align-items: center;
 	font-size: 13px;
 	font-weight: 600;
 	color: var(--color-text);
 	overflow: hidden;
-	text-overflow: ellipsis;
 	white-space: nowrap;
 	flex: 1;
 	min-width: 0;
@@ -922,7 +956,8 @@ function formatCompactDate(iso: string) {
 	margin-top: 12px;
 }
 
-.feed-column > .composer {
+.feed-column > .composer,
+.feed-column > .anime-room-login {
 	margin-bottom: 24px;
 }
 

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -488,7 +488,7 @@ function formatCompactDate(iso: string) {
 		<div class="room-mobile-bar">
 			<span class="room-mobile-title"
 				><a href="/anime/{data.anime.id}" class="anime-title-link">{data.anime.title}</a
-				><span class="hierarchy-separator"> ❯ </span>{roomNameLabel}</span
+				><span class="hierarchy-separator"> ❯ </span><span class="room-name-label">{roomNameLabel}</span></span
 			>
 			{#if !isGlobalLobby && status !== "ended"}
 				<span class="room-mobile-timer event-timer--{status}">{timerLabel}</span>
@@ -628,9 +628,10 @@ function formatCompactDate(iso: string) {
 				</a>
 				<div class="flex min-h-20 min-w-0 flex-1 flex-col justify-between pl-3">
 					<div class="min-w-0">
-						<h1 class="room-summary-title line-clamp-1 text-sm font-bold">
+						<h1 class="room-summary-title text-sm font-bold">
 							<a href="/anime/{data.anime.id}" class="anime-title-link">{data.anime.title}</a
-							><span class="hierarchy-separator"> ❯ </span>{roomNameLabel}
+							><span class="hierarchy-separator"> ❯ </span
+							><span class="room-name-label">{roomNameLabel}</span>
 						</h1>
 						{#if !isGlobalLobby}
 							<div class="mt-2 flex min-w-0 items-center gap-2">
@@ -692,7 +693,15 @@ function formatCompactDate(iso: string) {
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
+	overflow: hidden;
 	color: var(--color-text);
+}
+
+.room-name-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
 }
 
 .anime-title-link {


### PR DESCRIPTION
## Summary
- 投稿ボックスの入力時の青いフォーカス枠を削除
- 実況ルームヘッダーをパンくず形式（作品名リンク ❯ 部屋名/話数）に変更、個別放送ルームでは実際の話数を表示するように変更
- 終了ルームの投稿ボックスの文言修正（「通常投稿」→「引用投稿」）・下部余白の追加
- 実況ルームの投稿本文のフォントサイズを拡大
- 投稿展開時に周辺の投稿がずれる現象を `overflow-anchor: none` で修正
- 投稿間の区切り線を削除し、左のアクセント線を強調して一体感を向上
- 並び替えラベル「古い順」を「時系列順」に変更
- モバイル投稿モーダルを開いた際に本文入力欄へ自動フォーカス
- タイムライン（PC右サイドバー／モバイルトップバー）に、ログインユーザー向けの「開放中のライブ実況ルームへのリンク」を新設。総合ロビーは除外し、開放中ルームが1件なら直接遷移、2件以上ならモーダルで選択

## Test plan
- [ ] `pnpm check` がパスすること（既知の無関係な `marked` モジュールエラーを除く）
- [ ] 実況ルームページで、パンくずタイトルのリンク遷移・話数表示・展開時のレイアウト安定を確認
- [ ] タイムラインで、未ログイン時にライブルーム導線が表示されないこと
- [ ] ログイン時、開放中ルーム0件/1件/2件以上それぞれの表示・遷移を確認（PC・モバイル両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)