### PR TITLE
改行コード(CRLF/LF)汚染の恒久対応: .gitattributes を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# デフォルトでテキストファイルはすべて Git 内部で LF として管理し、チェックアウト時も LF にする
+* text=auto eol=lf
+
+# 画像やバイナリファイルは改行コード変換の対象外にする
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary


### PR DESCRIPTION
## Summary
- closes #110
- `.gitattributes` を追加し、テキストファイルの改行コードをリポジトリ全体でLFに統一（`* text=auto eol=lf`）。画像等のバイナリは対象外。
- issue記載の手順に沿って `git rm --cached -r .` → `git reset --hard` で再正規化を実施。リポジトリ内のテキストファイルは元々LFで保存されていたため、`.gitattributes` 以外に実質的な差分は発生しなかった。
- これにより `core.autocrlf=true` の環境でも、チェックアウト・ブランチ切替のたびに大量のファイルが「modified」として表示される問題が解消される。

## Test plan
- [ ] このブランチをチェックアウトした状態で `git status` が完全にクリーンであること
- [ ] 他のブランチへ切り替え・戻ってきても `git status` にCRLFノイズが再発しないこと
- [ ] `pnpm check` がパスすること

## メンバーへの共有事項
このPRをマージ後、既にローカルにクローン済みの開発者は、最新の `develop` を `pull` した上で、ローカルの改行コードがCRLFのままになっている場合は以下を各自の環境で実行してください。
```bash
git rm --cached -r .
git reset --hard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)