### PR TITLE
検証ルームでアンケートが送信できない問題を修正

### DIFF
--- a/src/lib/server/room-experiments.ts
+++ b/src/lib/server/room-experiments.ts
@@ -415,23 +415,41 @@ export async function createRoomExperimentVisit(
 	if (!run) return { tracked: false };
 
 	const now = new Date().toISOString();
-	const { data, error } = await supabase
+	const { data: inserted, error: insertError } = await supabase
 		.from("room_experiment_visits")
-		.upsert(
-			{
-				run_id: run.id,
-				anime_id: run.anime_id,
-				broadcast_room_session_id: session.id,
-				user_id: userId,
-				client_visit_key: clientVisitKey,
-				last_seen_at: now,
-				exited_at: null,
-				user_agent: options.userAgent?.slice(0, 500) ?? null,
-			},
-			{ onConflict: "run_id,user_id,broadcast_room_session_id,client_visit_key" },
-		)
+		.insert({
+			run_id: run.id,
+			anime_id: run.anime_id,
+			broadcast_room_session_id: session.id,
+			user_id: userId,
+			client_visit_key: clientVisitKey,
+			entered_at: now,
+			last_seen_at: now,
+			exited_at: null,
+			user_agent: options.userAgent?.slice(0, 500) ?? null,
+		})
 		.select("id")
 		.single();
+
+	// entered_at is set explicitly (matching last_seen_at) so the insert can never race against the
+	// DB's own now() and violate room_experiment_visits_seen_check (last_seen_at >= entered_at).
+	// On a repeat visit (same run/user/session/client_visit_key) this insert hits the unique index and
+	// falls through to an update, which must omit entered_at — the validate trigger rejects any change to it.
+	let data = inserted;
+	let error = insertError;
+	if (insertError?.code === "23505") {
+		const updated = await supabase
+			.from("room_experiment_visits")
+			.update({ last_seen_at: now, exited_at: null })
+			.eq("run_id", run.id)
+			.eq("user_id", userId)
+			.eq("broadcast_room_session_id", session.id)
+			.eq("client_visit_key", clientVisitKey)
+			.select("id")
+			.single();
+		data = updated.data;
+		error = updated.error;
+	}
 
 	if (error || !data) {
 		console.error("room experiment visit create error:", error);


### PR DESCRIPTION
## Summary
- 放送回ルーム検証機能で、入室記録(`room_experiment_visits`)が一件も作成されず、終了後アンケート送信が常に失敗し、訪問数・滞在時間などvisit依存の集計指標が全て0になる不具合を修正
- 原因: `entered_at`(DB側`DEFAULT now()`)と、リクエスト送信前にNode.js側で計算していた`last_seen_at`のタイムスタンプにネットワーク往復分のズレが生じ、CHECK制約`last_seen_at >= entered_at`にほぼ確実に違反していた。失敗はサーバーログにのみ残り、クライアント側はベストエフォート設計でエラーを握りつぶすため症状に気づけなかった
- `entered_at`を`last_seen_at`と同じタイムスタンプで明示的に指定してINSERTするよう変更し、重複visit(再訪問)時はUPDATEにフォールバック(`entered_at`は変更しない、変更禁止トリガーとの整合性のため)

投稿数・投稿者数は`posts`テーブルを直接参照する別経路のため元々正常でした。

## Test plan
- [x] 本番DBに対して修正前後の条件を直接INSERTし、修正前は`room_experiment_visits_seen_check`違反で失敗、修正後は成功することを確認(投入したテスト行は削除済み)
- [x] `tsc --noEmit` で型エラーがないことを確認
- [ ] 実際の検証runで、入室 → 投稿 → 終了後アンケート送信 → 管理ダッシュボードでvisit系指標が正しく集計されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)