### PR TITLE
実況ルームの連打による重複投稿を防止し、投稿反映を高速化

### DIFF
--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -17,6 +17,7 @@ type PostOrder = "oldest" | "newest";
 let now = $state(Date.now());
 let intervalId: ReturnType<typeof setInterval>;
 let postContent = $state("");
+let isPosting = $state(false);
 let textareaEl: HTMLTextAreaElement | null = $state(null);
 let composerEl: HTMLDivElement | null = $state(null);
 let keepComposerFocused = $state(true);
@@ -279,11 +280,24 @@ function handleWindowPointerDown(event: PointerEvent) {
 	keepComposerFocused = false;
 }
 
-const handleCreatePost: SubmitFunction = () => {
+const handleCreatePost: SubmitFunction = ({ cancel }) => {
+	if (isPosting) {
+		cancel();
+		return;
+	}
+	isPosting = true;
 	keepComposerFocused = true;
 	return async ({ result, update }) => {
-		await update({ reset: false });
-		if (result.type === "success") localSurveyPostCount += 1;
+		try {
+			// invalidateAll は load 全体の再実行で重いため、自分の投稿はライブ更新と同じ差分APIで反映する
+			await update({ reset: false, invalidateAll: false });
+			if (result.type === "success") {
+				localSurveyPostCount += 1;
+				await fetchNewPosts();
+			}
+		} finally {
+			isPosting = false;
+		}
 		await focusComposerTextarea({ preventScroll: true });
 	};
 };
@@ -525,7 +539,7 @@ function formatCompactDate(iso: string) {
 							onkeydown={(e) => {
 								if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
 									e.preventDefault();
-									if (!overLimit && postContent.trim()) {
+									if (!isPosting && !overLimit && postContent.trim()) {
 										e.currentTarget.closest('form')?.requestSubmit();
 									}
 								}
@@ -536,9 +550,9 @@ function formatCompactDate(iso: string) {
 							<button
 								type="submit"
 								class="btn btn-primary btn-sm"
-								disabled={overLimit || !postContent.trim()}
+								disabled={isPosting || overLimit || !postContent.trim()}
 							>
-								投稿
+								{isPosting ? "投稿中..." : "投稿"}
 							</button>
 						</div>
 					</div>


### PR DESCRIPTION
Closes #135

## 問題

1. **二重投稿**: 実況ルームのコンポーザーには送信中ガードがなく、投稿ボタンの `disabled` は文字数チェックのみ、Enterキーの `requestSubmit()` も無防備だったため、サーバー応答前に連打するとその回数だけPOSTされすべてDBに保存されていた（通常投稿の PostComposer には `submitting` フラグがあるため発生しない）。
2. **反映が遅い**: 投稿成功後の `update()` が `invalidateAll` でページのload関数全体（アニメ情報＋投稿100件のenrich＋トレンドRPC＋実験状態＋アンケート状態）を再取得しており、これが反映遅延の正体。遅延中もテキストが残りボタンも押せるため、連打を誘発する構造だった。

## 修正内容

- `isPosting` フラグを追加:
  - enhance のsubmitハンドラで送信中の再送信を `cancel()`
  - 送信中はボタンを `disabled` にし表示を「投稿中...」へ
  - Enterキーによる `requestSubmit()` も送信中は無視
- 投稿成功後の `invalidateAll` を廃止（`update({ reset: false, invalidateAll: false })`）し、ライブ更新と同じ差分API `fetchNewPosts()` で自分の投稿を反映。新着分のみの取得になり反映が大幅に高速化

## 検証

- 実ブラウザ（鬼の花嫁の受付中ルーム）で Enter 5連打・投稿ボタン5連打をそれぞれ実施し、いずれもPOSTが1回・投稿1件のみであることをネットワークログとUIで確認
- テキストエリアのクリア、差分APIのみでの即時反映（load再実行なし）を確認
- テスト投稿は削除済み
- `pnpm check`（Biome + svelte-check + tsc）エラー0

なお、イベントルーム（`src/routes/events/[id]/+page.svelte`）にも同種のガード欠如があるが、#132 のUI統合で置き換え予定のため本PRの対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)