### PR TITLE
Fix live room entry modal behavior

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -121,9 +121,17 @@ body {
 
 :where(html.room-scroll-lock) .app-layout,
 :where(html.room-scroll-lock) .app-main {
-	height: 100dvh;
-	min-height: 100dvh;
+	height: 100vh;
+	min-height: 100vh;
 	overflow: hidden;
+}
+
+@supports (height: 100svh) {
+	:where(html.room-scroll-lock) .app-layout,
+	:where(html.room-scroll-lock) .app-main {
+		height: 100svh;
+		min-height: 100svh;
+	}
 }
 
 .scrollbar-thin-muted {
@@ -584,8 +592,7 @@ textarea {
 }
 
 .composer-textarea:focus-visible {
-	outline: 2px solid var(--color-accent);
-	outline-offset: 2px;
+	outline: none;
 }
 
 .composer-footer {

--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -24,7 +24,7 @@ $effect(() => {
 {#if open}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<div
-		class="anime-search-overlay"
+		class="anime-search-overlay live-room-picker-overlay"
 		onclick={(e) => {
 			if (e.target === e.currentTarget) onclose();
 		}}
@@ -50,7 +50,11 @@ $effect(() => {
 					<p class="anime-search-empty">現在ライブ中の実況ルームはありません</p>
 				{:else}
 					{#each rooms as room (room.id)}
-						<a href="/rooms/anime/{room.anime_id}/{room.room_date}" class="anime-search-item">
+						<a
+							href="/rooms/anime/{room.anime_id}/{room.room_date}"
+							class="anime-search-item"
+							onclick={onclose}
+						>
 							{#if room.anime?.cover_url}
 								<img src={room.anime.cover_url} alt={room.anime.title} class="anime-search-thumb">
 							{:else}
@@ -67,3 +71,11 @@ $effect(() => {
 		</div>
 	</div>
 {/if}
+
+<style>
+.anime-search-overlay.live-room-picker-overlay {
+	z-index: 1200;
+	background: rgba(0, 0, 0, 0.72);
+	pointer-events: auto;
+}
+</style>

--- a/src/lib/components/LiveRoomsPanel.svelte
+++ b/src/lib/components/LiveRoomsPanel.svelte
@@ -57,6 +57,7 @@ function closePicker() {
 
 .live-room-entry {
 	width: 100%;
+	gap: 12px;
 	border: none;
 	background: none;
 	cursor: pointer;

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -59,12 +59,6 @@ async function openLiveRoomPicker() {
 			return;
 		}
 		const rooms: OpenBroadcastRoomSummary[] = await res.json();
-		const onlyRoom = rooms.length === 1 ? rooms[0] : undefined;
-		if (onlyRoom) {
-			liveRoomModalOpen = false;
-			await goto(`/rooms/anime/${onlyRoom.anime_id}/${onlyRoom.room_date}`);
-			return;
-		}
 		liveRooms = rooms;
 	} catch {
 		liveRoomsError = true;

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -34,6 +34,8 @@ let surveyHandled = $state(false);
 let surveySubmitting = $state(false);
 let surveyErrorMessage: string | null = $state(null);
 let programmaticScrollTimer: ReturnType<typeof setTimeout> | undefined;
+let previousVirtualKeyboardOverlaysContent: boolean | undefined;
+let removeRoomKeyboardListeners: (() => void) | undefined;
 
 const maxLen = 280;
 const latestEdgeThreshold = 80;
@@ -321,6 +323,12 @@ onMount(() => {
 	mobileViewportQuery = window.matchMedia("(max-width: 960px)");
 	isMobileViewport = mobileViewportQuery.matches;
 	mobileViewportQuery.addEventListener("change", handleMobileViewportChange);
+	const virtualKeyboard = getVirtualKeyboard();
+	if (virtualKeyboard) {
+		previousVirtualKeyboardOverlaysContent = virtualKeyboard.overlaysContent;
+		virtualKeyboard.overlaysContent = true;
+	}
+	removeRoomKeyboardListeners = installRoomKeyboardOffsetTracking();
 	mounted = true;
 	lastPostCount = data.posts.length;
 	intervalId = setInterval(() => {
@@ -339,6 +347,11 @@ onMount(() => {
 
 onDestroy(() => {
 	mobileViewportQuery?.removeEventListener("change", handleMobileViewportChange);
+	removeRoomKeyboardListeners?.();
+	const virtualKeyboard = getVirtualKeyboard();
+	if (virtualKeyboard && previousVirtualKeyboardOverlaysContent !== undefined) {
+		virtualKeyboard.overlaysContent = previousVirtualKeyboardOverlaysContent;
+	}
 	clearInterval(intervalId);
 	if (programmaticScrollTimer) clearTimeout(programmaticScrollTimer);
 	clearRoomExperimentHeartbeatTimer();
@@ -352,6 +365,29 @@ onDestroy(() => {
 
 function handleMobileViewportChange(event: MediaQueryListEvent) {
 	isMobileViewport = event.matches;
+}
+
+function getVirtualKeyboard() {
+	return (navigator as Navigator & { virtualKeyboard?: { overlaysContent: boolean } }).virtualKeyboard;
+}
+
+function updateRoomKeyboardOffset() {
+	const viewport = window.visualViewport;
+	const offset = viewport ? Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop) : 0;
+	document.documentElement.style.setProperty("--room-keyboard-offset", `${Math.round(offset)}px`);
+}
+
+function installRoomKeyboardOffsetTracking() {
+	updateRoomKeyboardOffset();
+	window.addEventListener("resize", updateRoomKeyboardOffset);
+	window.visualViewport?.addEventListener("resize", updateRoomKeyboardOffset);
+	window.visualViewport?.addEventListener("scroll", updateRoomKeyboardOffset);
+	return () => {
+		window.removeEventListener("resize", updateRoomKeyboardOffset);
+		window.visualViewport?.removeEventListener("resize", updateRoomKeyboardOffset);
+		window.visualViewport?.removeEventListener("scroll", updateRoomKeyboardOffset);
+		document.documentElement.style.removeProperty("--room-keyboard-offset");
+	};
 }
 
 $effect(() => {
@@ -761,7 +797,7 @@ function formatCompactDate(iso: string) {
 
 .room-page-container {
 	max-width: none;
-	height: 100dvh;
+	height: 100vh;
 	margin: 0;
 	align-items: stretch;
 	overflow: hidden;
@@ -973,7 +1009,7 @@ function formatCompactDate(iso: string) {
 
 @media (max-width: 960px) {
 	.room-page-container {
-		height: calc(100dvh - 52px);
+		height: calc(100vh - 52px);
 		padding-right: 12px;
 		padding-bottom: calc(80px + env(safe-area-inset-bottom));
 		padding-left: 12px;
@@ -1000,6 +1036,15 @@ function formatCompactDate(iso: string) {
 		margin-bottom: 0;
 		padding: 8px 10px;
 		border-radius: 14px;
+		transform: translateY(calc(0px - max(env(keyboard-inset-height, 0px), var(--room-keyboard-offset, 0px))));
+		transition: transform 160ms ease;
+		will-change: transform;
+	}
+
+	:global(html.room-scroll-lock .mobile-bottom-nav) {
+		transform: translateY(max(env(keyboard-inset-height, 0px), var(--room-keyboard-offset, 0px)));
+		transition: transform 160ms ease;
+		will-change: transform;
 	}
 
 	.room-page-container .composer form,
@@ -1039,6 +1084,18 @@ function formatCompactDate(iso: string) {
 		min-height: 32px;
 		padding: 6px 12px;
 		white-space: nowrap;
+	}
+}
+
+@supports (height: 100svh) {
+	.room-page-container {
+		height: 100svh;
+	}
+
+	@media (max-width: 960px) {
+		.room-page-container {
+			height: calc(100svh - 52px);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- strengthen the live room picker modal so the backdrop blocks timeline interaction and closes cleanly after room navigation
- keep mobile live-room entry behind the picker modal even when there is only one live room
- tune the home live-room panel spacing and remove the composer focus ring
- keep the mobile live-room layout stable when the keyboard opens, raising only the room composer

## Root Cause
The live room picker reused a lower modal layer and some entry paths bypassed the modal entirely. The mobile room shell also depended on dynamic viewport height, so opening the soft keyboard resized the whole room layout instead of just moving the composer.

## Validation
- `pnpm.cmd exec biome check src/routes/rooms/anime/[id]/[date]/+page.svelte src/app.css`
- `pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json`
- `git diff --check`
- local dev server returned `200` at `http://localhost:5175/`