### PR TITLE
Fix live room entry and mobile room UI

### DIFF
--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -34,7 +34,7 @@ $effect(() => {
 		tabindex="-1"
 		use:trapFocus
 	>
-		<div class="anime-search-modal">
+		<div class="anime-search-modal live-room-picker-modal">
 			<div class="anime-search-header">
 				<span class="anime-search-title">ライブ実況ルームを選択</span>
 				<button type="button" class="anime-search-close" onclick={onclose} aria-label="閉じる">
@@ -74,8 +74,47 @@ $effect(() => {
 
 <style>
 .anime-search-overlay.live-room-picker-overlay {
-	z-index: 1200;
-	background: rgba(0, 0, 0, 0.72);
+	position: fixed;
+	inset: 0;
+	z-index: 5000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	background: rgba(0, 0, 0, 0.88);
 	pointer-events: auto;
+	isolation: isolate;
+}
+
+.live-room-picker-modal {
+	width: min(480px, calc(100vw - 32px));
+	max-height: min(76vh, 620px);
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	box-shadow: 0 24px 80px rgba(0, 0, 0, 0.56);
+}
+
+.live-room-picker-modal .anime-search-header,
+.live-room-picker-modal .anime-search-results {
+	background: var(--color-surface);
+}
+
+.live-room-picker-modal .anime-search-item {
+	background: var(--color-surface);
+}
+
+.live-room-picker-modal .anime-search-item:hover,
+.live-room-picker-modal .anime-search-item:focus-visible {
+	background: var(--color-surface-hover);
+}
+
+@media (max-width: 640px) {
+	.anime-search-overlay.live-room-picker-overlay {
+		padding: 16px;
+	}
+
+	.live-room-picker-modal {
+		max-height: min(82vh, 620px);
+	}
 }
 </style>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -959,6 +959,12 @@ function isActive(path: string): boolean {
 	gap: 4px;
 }
 
+.mobile-live-room-btn .i-lucide-radio {
+	width: 20px;
+	height: 20px;
+	font-size: 20px;
+}
+
 .mobile-header-logo {
 	display: flex;
 	align-items: center;

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -2704,6 +2704,7 @@ export async function getOpenBroadcastRoomSessions(
 	const rows = data ?? [];
 	const episodeRows = rows.filter((row) => row.room_kind === "episode");
 	const overrideBySessionKey = new Map<string, { is_cancelled: boolean | null }>();
+	let overrideLookupFailed = false;
 	if (episodeRows.length > 0) {
 		const animeIds = [...new Set(episodeRows.map((row) => row.anime_id))];
 		const roomDates = [...new Set(episodeRows.map((row) => row.room_date))];
@@ -2716,6 +2717,7 @@ export async function getOpenBroadcastRoomSessions(
 			.in("room_date", roomDates);
 		if (overrideError) {
 			console.error("getOpenBroadcastRoomSessions overrides failed:", overrideError);
+			overrideLookupFailed = true;
 		}
 		for (const override of (overrides as
 			| Pick<BroadcastRoomOverride, "anime_id" | "room_date" | "is_cancelled">[]
@@ -2740,6 +2742,7 @@ export async function getOpenBroadcastRoomSessions(
 	return rows
 		.filter((row) => {
 			if (row.room_kind !== "episode") return true;
+			if (overrideLookupFailed) return false;
 			const anime = rawAnimeForRow(row.anime);
 			if (!anime) return false;
 			const override = overrideBySessionKey.get(`${row.anime_id}:${row.room_date.slice(0, 10)}`);

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -24,6 +24,7 @@ import type {
 	UserAnimeEntry,
 } from "$lib/types";
 import { toPost } from "$lib/types";
+import { animeIsScheduledForRoomDate } from "$lib/utils/broadcast-room";
 
 type NotificationActor = {
 	username: string;
@@ -2689,7 +2690,7 @@ export async function getOpenBroadcastRoomSessions(
 	let query = supabase
 		.from("broadcast_room_sessions")
 		.select(
-			"id, anime_id, room_date, room_kind, room_key, scheduled_at, anime:anime!broadcast_room_sessions_anime_id_fkey ( id, title, cover_url )",
+			"id, anime_id, room_date, room_kind, room_key, scheduled_at, anime:anime!broadcast_room_sessions_anime_id_fkey ( id, title, cover_url, aired_from, aired_to, broadcast_day )",
 		)
 		.lte("posting_opens_at", now)
 		.gte("posting_closes_at", now)
@@ -2700,17 +2701,61 @@ export async function getOpenBroadcastRoomSessions(
 		console.error("getOpenBroadcastRoomSessions failed:", error);
 		return [];
 	}
-	type RawAnime = { id: number; title: string; cover_url: string | null };
-	return (data ?? []).map((row) => {
-		const anime = row.anime as unknown as RawAnime | null;
-		return {
-			id: row.id,
-			anime_id: String(row.anime_id),
-			room_date: row.room_date,
-			room_kind: row.room_kind as "episode" | "global",
-			room_key: row.room_key,
-			scheduled_at: row.scheduled_at,
-			anime: anime ? { id: String(anime.id), title: anime.title, cover_url: anime.cover_url ?? null } : null,
-		};
-	});
+	const rows = data ?? [];
+	const episodeRows = rows.filter((row) => row.room_kind === "episode");
+	const overrideBySessionKey = new Map<string, { is_cancelled: boolean | null }>();
+	if (episodeRows.length > 0) {
+		const animeIds = [...new Set(episodeRows.map((row) => row.anime_id))];
+		const roomDates = [...new Set(episodeRows.map((row) => row.room_date))];
+		// biome-ignore lint/suspicious/noExplicitAny: broadcast_room_overrides not yet in generated types
+		const reader = supabase as SupabaseClient<any>;
+		const { data: overrides, error: overrideError } = await reader
+			.from("broadcast_room_overrides")
+			.select("anime_id, room_date, is_cancelled")
+			.in("anime_id", animeIds)
+			.in("room_date", roomDates);
+		if (overrideError) {
+			console.error("getOpenBroadcastRoomSessions overrides failed:", overrideError);
+		}
+		for (const override of (overrides as
+			| Pick<BroadcastRoomOverride, "anime_id" | "room_date" | "is_cancelled">[]
+			| null) ?? []) {
+			overrideBySessionKey.set(`${override.anime_id}:${override.room_date.slice(0, 10)}`, {
+				is_cancelled: override.is_cancelled,
+			});
+		}
+	}
+	type RawAnime = {
+		id: number;
+		title: string;
+		cover_url: string | null;
+		aired_from: string | null;
+		aired_to: string | null;
+		broadcast_day: number | null;
+	};
+	const rawAnimeForRow = (anime: unknown): RawAnime | null => {
+		const raw = Array.isArray(anime) ? anime[0] : anime;
+		return raw ? (raw as RawAnime) : null;
+	};
+	return rows
+		.filter((row) => {
+			if (row.room_kind !== "episode") return true;
+			const anime = rawAnimeForRow(row.anime);
+			if (!anime) return false;
+			const override = overrideBySessionKey.get(`${row.anime_id}:${row.room_date.slice(0, 10)}`);
+			if (override?.is_cancelled) return false;
+			return animeIsScheduledForRoomDate(anime, row.room_date, override != null);
+		})
+		.map((row) => {
+			const anime = rawAnimeForRow(row.anime);
+			return {
+				id: row.id,
+				anime_id: String(row.anime_id),
+				room_date: row.room_date,
+				room_kind: row.room_kind as "episode" | "global",
+				room_key: row.room_key,
+				scheduled_at: row.scheduled_at,
+				anime: anime ? { id: String(anime.id), title: anime.title, cover_url: anime.cover_url ?? null } : null,
+			};
+		});
 }

--- a/src/lib/utils/broadcast-room.test.ts
+++ b/src/lib/utils/broadcast-room.test.ts
@@ -47,4 +47,35 @@ describe("animeIsScheduledForRoomDate", () => {
 			),
 		).toBe(true);
 	});
+
+	it("keeps override dates bounded by the anime airing start", () => {
+		expect.assertions(1);
+
+		expect(
+			animeIsScheduledForRoomDate(
+				{
+					aired_from: "2026-07-12",
+					aired_to: null,
+					broadcast_day: 0,
+				},
+				"2026-07-05",
+				true,
+			),
+		).toBe(false);
+	});
+
+	it("rejects invalid calendar dates", () => {
+		expect.assertions(1);
+
+		expect(
+			animeIsScheduledForRoomDate(
+				{
+					aired_from: "2026-02-01",
+					aired_to: null,
+					broadcast_day: 2,
+				},
+				"2026-02-31",
+			),
+		).toBe(false);
+	});
 });

--- a/src/lib/utils/broadcast-room.test.ts
+++ b/src/lib/utils/broadcast-room.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { animeIsScheduledForRoomDate } from "./broadcast-room";
+
+describe("animeIsScheduledForRoomDate", () => {
+	it("rejects a weekly room date before the anime starts airing", () => {
+		expect.assertions(1);
+
+		expect(
+			animeIsScheduledForRoomDate(
+				{
+					aired_from: "2026-07-12",
+					aired_to: null,
+					broadcast_day: 0,
+				},
+				"2026-07-05",
+			),
+		).toBe(false);
+	});
+
+	it("accepts a regular room date on or after the anime starts airing", () => {
+		expect.assertions(1);
+
+		expect(
+			animeIsScheduledForRoomDate(
+				{
+					aired_from: "2026-07-12",
+					aired_to: null,
+					broadcast_day: 0,
+				},
+				"2026-07-12",
+			),
+		).toBe(true);
+	});
+
+	it("lets override dates bypass the regular weekday check", () => {
+		expect.assertions(1);
+
+		expect(
+			animeIsScheduledForRoomDate(
+				{
+					aired_from: "2026-07-12",
+					aired_to: null,
+					broadcast_day: 0,
+				},
+				"2026-07-13",
+				true,
+			),
+		).toBe(true);
+	});
+});

--- a/src/lib/utils/broadcast-room.ts
+++ b/src/lib/utils/broadcast-room.ts
@@ -2,8 +2,40 @@ import type { Anime, BroadcastRoomOverride } from "$lib/types";
 
 export type BroadcastRoomOverridesByAnimeId = Record<string, BroadcastRoomOverride[]>;
 
+interface BroadcastScheduleBounds {
+	aired_from: string | null;
+	aired_to: string | null;
+	broadcast_day: number | null;
+}
+
 export function roomDateKey(value: string): string {
 	return value.slice(0, 10);
+}
+
+function dateKeyToDate(value: string) {
+	const dateKey = roomDateKey(value);
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) return null;
+	const date = new Date(`${dateKey}T00:00:00`);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function animeIsScheduledForRoomDate(
+	anime: BroadcastScheduleBounds,
+	dateKey: string,
+	hasOverride = false,
+): boolean {
+	const roomDate = roomDateKey(dateKey);
+	const date = dateKeyToDate(roomDate);
+	if (!date) return false;
+	if (!hasOverride && (anime.broadcast_day == null || date.getDay() !== anime.broadcast_day)) return false;
+
+	const airedFrom = anime.aired_from?.slice(0, 10) ?? null;
+	if (airedFrom && roomDate < airedFrom) return false;
+
+	const airedTo = anime.aired_to?.slice(0, 10) ?? null;
+	if (airedTo && roomDate > airedTo) return false;
+
+	return true;
 }
 
 export function roomLiveKey(animeId: string, roomDate: string): string {

--- a/src/lib/utils/broadcast-room.ts
+++ b/src/lib/utils/broadcast-room.ts
@@ -14,9 +14,21 @@ export function roomDateKey(value: string): string {
 
 function dateKeyToDate(value: string) {
 	const dateKey = roomDateKey(value);
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) return null;
-	const date = new Date(`${dateKey}T00:00:00`);
-	return Number.isNaN(date.getTime()) ? null : date;
+	const match = dateKey.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const date = new Date(year, month - 1, day);
+	if (
+		Number.isNaN(date.getTime()) ||
+		date.getFullYear() !== year ||
+		date.getMonth() !== month - 1 ||
+		date.getDate() !== day
+	) {
+		return null;
+	}
+	return date;
 }
 
 export function animeIsScheduledForRoomDate(

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -20,29 +20,8 @@ import {
 } from "$lib/server/room-experiments";
 import type { Anime } from "$lib/types";
 import { calcEpisodeNumberFromDate } from "$lib/types";
+import { animeIsScheduledForRoomDate } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
-
-function dateKeyToDate(value: string) {
-	const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-	if (!match) return null;
-	const date = new Date(`${value}T00:00:00`);
-	if (Number.isNaN(date.getTime())) return null;
-	return date;
-}
-
-function animeIsScheduledForDate(anime: Anime, dateKey: string, hasOverride: boolean) {
-	const date = dateKeyToDate(dateKey);
-	if (!date) return false;
-	if (!hasOverride && (anime.broadcast_day == null || date.getDay() !== anime.broadcast_day)) return false;
-
-	const airedFrom = anime.aired_from?.slice(0, 10) ?? null;
-	if (airedFrom && dateKey < airedFrom) return false;
-
-	const airedTo = anime.aired_to?.slice(0, 10) ?? null;
-	if (airedTo && dateKey > airedTo) return false;
-
-	return true;
-}
 
 function fallbackRoomHashtag(title: string) {
 	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
@@ -78,7 +57,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	if (override?.is_cancelled) {
 		throw error(404, "放送ルームが見つかりません");
 	}
-	if (!animeIsScheduledForDate(anime, params.date, override != null)) {
+	if (!animeIsScheduledForRoomDate(anime, params.date, override != null)) {
 		throw error(404, "放送ルームが見つかりません");
 	}
 
@@ -136,7 +115,7 @@ export const actions: Actions = {
 		if (override?.is_cancelled) {
 			return fail(404, { message: "放送ルームが見つかりません" });
 		}
-		if (!anime || !animeIsScheduledForDate(anime, params.date, override != null)) {
+		if (!anime || !animeIsScheduledForRoomDate(anime, params.date, override != null)) {
 			return fail(404, { message: "放送ルームが見つかりません" });
 		}
 

--- a/src/routes/rooms/anime/[id]/[date]/+page.svelte
+++ b/src/routes/rooms/anime/[id]/[date]/+page.svelte
@@ -536,21 +536,22 @@ function formatCompactDate(iso: string) {
 <div class="page-container room-page-container">
 	<div class="feed-column">
 		<div class="room-mobile-bar">
-			<span class="room-mobile-title"
-				><a href="/anime/{data.anime.id}" class="anime-title-link">{data.anime.title}</a
-				><span class="hierarchy-separator" aria-hidden="true"> ❯ </span
-				><span class="room-name-label">{roomNameLabel}</span></span
-			>
+			<div class="header-top-row">
+				<span class="room-mobile-title"
+					><a href="/anime/{data.anime.id}" class="anime-title-link">{data.anime.title}</a
+					><span class="hierarchy-separator" aria-hidden="true"> ❯ </span
+					><span class="room-name-label">{roomNameLabel}</span></span
+				>
+				<button type="button" class="room-mobile-exit" onclick={handleExitRoom} aria-label="退出する">
+					<span class="i-lucide-log-out" aria-hidden="true"></span>
+					<span>退出</span>
+				</button>
+			</div>
 			{#if !isGlobalLobby && status !== "ended"}
-				<span class="room-mobile-timer event-timer--{status}">{timerLabel}</span>
-				{#if status === "open"}
-					<span class="event-timer-badge">受付中</span>
-				{/if}
+				<div class="header-bottom-row">
+					<span class="room-mobile-timer event-timer--{status}">{timerLabel}</span>
+				</div>
 			{/if}
-			<button type="button" class="room-mobile-exit" onclick={handleExitRoom} aria-label="退出する">
-				<span class="i-lucide-log-out" aria-hidden="true"></span>
-				<span>退出</span>
-			</button>
 		</div>
 
 		{#if data.user && status === "open"}
@@ -950,14 +951,28 @@ function formatCompactDate(iso: string) {
 /* ── モバイル用コンパクトバー (サイドバー非表示時のみ表示) ── */
 .room-mobile-bar {
 	display: none;
-	align-items: center;
-	gap: 8px;
-	padding: 8px 12px;
+	flex-direction: column;
+	gap: 6px;
+	padding: 10px 12px;
 	margin-bottom: 12px;
 	background: var(--color-surface);
 	border: 1px solid var(--color-border);
 	border-radius: var(--radius);
 	overflow: hidden;
+}
+.header-top-row,
+.header-bottom-row {
+	display: flex;
+	width: 100%;
+	min-width: 0;
+}
+.header-top-row {
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+}
+.header-bottom-row {
+	align-items: center;
 }
 .room-mobile-title {
 	display: inline-flex;
@@ -975,7 +990,7 @@ function formatCompactDate(iso: string) {
 	font-variant-numeric: tabular-nums;
 	color: var(--color-text-muted);
 	white-space: nowrap;
-	flex-shrink: 0;
+	line-height: 1.2;
 }
 .room-mobile-exit {
 	display: inline-flex;

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -1644,7 +1644,7 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	.create-event-btn {
 		position: fixed;
 		top: 6px;
-		right: 52px;
+		right: 92px;
 		z-index: 161;
 		width: 40px;
 		height: 40px;


### PR DESCRIPTION
## Summary
- Filter open live-room entry points so episode rooms only show for real broadcast dates
- Share the room-date schedule guard between open-room lists and the room route
- Polish live-room picker and mobile room/schedule header affordances
- Refactor the mobile live-room header into navigation and timer rows

## Root cause
Open-room entry points only checked the broadcast room posting window, so generated sessions for future-starting titles could appear before the anime had actually started airing. The room route already rejected those dates, which produced a visible entry point that led to 404.

## Validation
- pnpm.cmd exec biome check --write on touched files
- pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json
- pnpm.cmd exec vitest --run src/lib/utils/broadcast-room.test.ts
- git diff --check

Closes #142