### PR TITLE
ルームリンク付き投稿をトレンド計算に反映

### DIFF
--- a/src/lib/server/actions.test.ts
+++ b/src/lib/server/actions.test.ts
@@ -1,0 +1,99 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import type { Database } from "$lib/supabase/database.types";
+import { insertPostWithHashtags } from "./actions";
+
+type TableChain = Record<string, unknown>;
+
+function maybeSingleChain(response: unknown): TableChain {
+	const chain = {
+		select: vi.fn(() => chain),
+		eq: vi.fn(() => chain),
+		maybeSingle: vi.fn(async () => response),
+	};
+	return chain;
+}
+
+function createInsertPostClient(roomAnime: { title: string | null; official_hashtag: string[] | null } | null) {
+	const insertedPosts: unknown[] = [];
+	const hashtagUpsert = vi.fn(async () => ({ error: null }));
+	const postHashtagUpsert = vi.fn(async () => ({ error: null }));
+	const hashtagSelect = vi.fn(() => ({
+		in: vi.fn(async (_column: string, names: string[]) => ({
+			data: names.map((_name, index) => ({ id: index + 1 })),
+			error: null,
+		})),
+	}));
+
+	const client = {
+		from: vi.fn((table: string) => {
+			if (table === "account_moderation") {
+				return maybeSingleChain({ data: null, error: null });
+			}
+			if (table === "broadcast_room_sessions") {
+				return maybeSingleChain({ data: { anime: roomAnime }, error: null });
+			}
+			if (table === "posts") {
+				return {
+					insert: vi.fn((payload: unknown) => {
+						insertedPosts.push(payload);
+						return {
+							select: vi.fn(() => ({
+								single: vi.fn(async () => ({ data: { id: "post-1" }, error: null })),
+							})),
+						};
+					}),
+				};
+			}
+			if (table === "hashtags") {
+				return {
+					upsert: hashtagUpsert,
+					select: hashtagSelect,
+				};
+			}
+			if (table === "post_hashtags") {
+				return { upsert: postHashtagUpsert };
+			}
+			throw new Error(`unexpected table: ${table}`);
+		}),
+	};
+
+	return {
+		client: client as unknown as SupabaseClient<Database>,
+		hashtagUpsert,
+		postHashtagUpsert,
+		insertedPosts,
+	};
+}
+
+describe("insertPostWithHashtags", () => {
+	it("adds the room-link anime hashtag to trend metadata", async () => {
+		const { client, hashtagUpsert, postHashtagUpsert, insertedPosts } = createInsertPostClient({
+			title: "Room Anime",
+			official_hashtag: ["#OfficialTag"],
+		});
+
+		const result = await insertPostWithHashtags(
+			client,
+			"user-1",
+			"plain room post",
+			null,
+			[],
+			"123",
+			null,
+			null,
+			"session-1",
+		);
+
+		expect(result).toEqual({ success: true, postId: "post-1" });
+		expect(insertedPosts).toContainEqual(expect.objectContaining({ broadcast_room_session_id: "session-1" }));
+		expect(hashtagUpsert).toHaveBeenCalledWith([{ name: "officialtag" }], {
+			onConflict: "name",
+			ignoreDuplicates: true,
+		});
+		expect(postHashtagUpsert).toHaveBeenCalledWith([{ post_id: "post-1", hashtag_id: 1 }], {
+			onConflict: "post_id,hashtag_id",
+			ignoreDuplicates: true,
+		});
+	});
+});

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -28,6 +28,54 @@ type ModerationProfile = {
 	moderation_until: string | null;
 };
 
+type RoomLinkTrendAnime = {
+	title: string | null;
+	official_hashtag: string[] | null;
+};
+
+type RoomLinkTrendSession = {
+	anime: RoomLinkTrendAnime | RoomLinkTrendAnime[] | null;
+};
+
+function fallbackRoomHashtag(title: string) {
+	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
+}
+
+function normalizeHashtagMetadata(value: string) {
+	return value.trim().replace(/^#+/, "").toLowerCase();
+}
+
+function firstRelatedRow<T>(value: T | T[] | null | undefined): T | null {
+	return Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
+}
+
+async function getRoomLinkTrendHashtag(
+	supabase: SupabaseClient<Database>,
+	broadcastRoomSessionId: string | null,
+): Promise<string | null> {
+	if (!broadcastRoomSessionId) return null;
+
+	const { data, error } = await supabase
+		.from("broadcast_room_sessions")
+		.select("anime:anime!broadcast_room_sessions_anime_id_fkey ( title, official_hashtag )")
+		.eq("id", broadcastRoomSessionId)
+		.maybeSingle();
+
+	if (error || !data) {
+		if (error) console.error("room link trend hashtag lookup error:", error);
+		return null;
+	}
+
+	const anime = firstRelatedRow((data as unknown as RoomLinkTrendSession).anime);
+	if (!anime) return null;
+
+	const officialHashtag = anime.official_hashtag?.map(normalizeHashtagMetadata).find((tag) => tag.length > 0);
+	if (officialHashtag) return officialHashtag;
+
+	const fallback = fallbackRoomHashtag(anime.title ?? "");
+	return fallback ? normalizeHashtagMetadata(fallback) : null;
+}
+
 export function getAnimeExchangeErrorDetail(error: {
 	details?: unknown;
 }): keyof typeof animeExchangeErrorMessages | null {
@@ -132,10 +180,11 @@ export async function insertPostWithHashtags(
 	// ハッシュタグを一括登録（既存タグは ON CONFLICT DO NOTHING）。
 	// タグごとの insert+select ループは実況時の余分な往復になるため一括化している。
 	// メンション通知は DB トリガー notify_on_mention（migration 026）が生成する。
-	const additionalTags = additionalHashtags
-		.map((tag) => tag.trim().replace(/^#+/, "").toLowerCase())
-		.filter((tag) => tag.length > 0);
-	const tags = [...new Set([...extractHashtags(postContent), ...additionalTags])];
+	const additionalTags = additionalHashtags.map(normalizeHashtagMetadata).filter((tag) => tag.length > 0);
+	const roomLinkTrendHashtag =
+		additionalTags.length === 0 ? await getRoomLinkTrendHashtag(supabase, broadcastRoomSessionId) : null;
+	const roomLinkTags = roomLinkTrendHashtag ? [roomLinkTrendHashtag] : [];
+	const tags = [...new Set([...extractHashtags(postContent), ...additionalTags, ...roomLinkTags])];
 	if (tags.length > 0) {
 		await supabase.from("hashtags").upsert(
 			tags.map((name) => ({ name })),

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -156,7 +156,9 @@ export const actions: Actions = {
 		const content = stripTrailingRoomHashtag(rawContent, hashtag);
 		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
-		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, []);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
+			hashtag,
+		]);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/src/routes/rooms/anime/[id]/lobby/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/lobby/+page.server.ts
@@ -102,7 +102,9 @@ export const actions: Actions = {
 		const content = stripTrailingRoomHashtag(rawContent, hashtag);
 		if (!content) return fail(400, { message: "投稿内容を入力してください" });
 
-		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, []);
+		return insertPostWithHashtags(supabase, user.id, content, null, [], anime.id, null, null, session.id, null, [
+			hashtag,
+		]);
 	},
 
 	deletePost: async ({ request, locals: { supabase, safeGetSession } }) => {

--- a/supabase/migrations/091_room_links_trending_hashtags.sql
+++ b/supabase/migrations/091_room_links_trending_hashtags.sql
@@ -1,0 +1,52 @@
+-- Count room links as their anime room hashtag in the trending hashtag RPC.
+
+CREATE OR REPLACE FUNCTION public.get_trending_hashtags(limit_count integer DEFAULT 10)
+RETURNS TABLE(name text, post_count bigint)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH tagged_posts AS (
+        SELECT lower(h.name) AS name, ph.post_id
+        FROM   public.hashtags h
+        JOIN   public.post_hashtags ph ON ph.hashtag_id = h.id
+        JOIN   public.posts p          ON p.id = ph.post_id
+        WHERE  p.created_at > now() - interval '24 hours'
+
+        UNION
+
+        SELECT room_tag.name, p.id AS post_id
+        FROM   public.posts p
+        JOIN   public.broadcast_room_sessions brs ON brs.id = p.broadcast_room_session_id
+        JOIN   public.anime a                     ON a.id = brs.anime_id
+        LEFT JOIN LATERAL (
+            SELECT lower(regexp_replace(btrim(official_tags.tag), '^#+', '')) AS name
+            FROM   unnest(coalesce(a.official_hashtag, ARRAY[]::text[])) AS official_tags(tag)
+            WHERE  length(regexp_replace(btrim(official_tags.tag), '^#+', '')) > 0
+            LIMIT  1
+        ) official ON true
+        CROSS JOIN LATERAL (
+            SELECT lower(
+                regexp_replace(
+                    regexp_replace(a.title, '[[:space:]]+', '', 'g'),
+                    '[^[:alnum:]_]',
+                    '',
+                    'g'
+                )
+            ) AS name
+        ) fallback
+        CROSS JOIN LATERAL (
+            SELECT coalesce(nullif(official.name, ''), nullif(fallback.name, '')) AS name
+        ) room_tag
+        WHERE  p.created_at > now() - interval '24 hours'
+          AND  p.broadcast_room_session_id IS NOT NULL
+          AND  room_tag.name IS NOT NULL
+          AND  (NOT a.hidden_by_admin OR public.is_current_user_admin())
+    )
+    SELECT tagged_posts.name, COUNT(DISTINCT tagged_posts.post_id) AS post_count
+    FROM   tagged_posts
+    GROUP  BY tagged_posts.name
+    ORDER  BY post_count DESC, tagged_posts.name ASC
+    LIMIT  limit_count;
+$$;


### PR DESCRIPTION
## Summary
- ハッシュタグとの二重表示を解消してルームリンク表示に統一した際、トレンド計算がルームリンク付き投稿を拾えなくなっていた問題を修正
- `insertPostWithHashtags` にルームリンク投稿用のハッシュタグ解決処理を追加し、アニメの公式ハッシュタグ（なければタイトルのフォールバック）を投稿のメタデータとして登録
- `get_trending_hashtags` RPC を更新し、`broadcast_room_sessions` 経由でルームリンク投稿を直接トレンド集計に含めるよう修正（migration 091）

## Test plan
- [x] `pnpm test:unit` — 44 tests pass
- [x] `pnpm check:types` — no errors
- [x] `pnpm lint` — clean
- [ ] Supabase migration 091 をステージング環境に適用してトレンド表示を目視確認

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)