### PR TITLE
Fix live room picker modal stacking

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -283,6 +283,10 @@ textarea {
 	top: calc(var(--nav-height) + 24px);
 }
 
+.sidebar-column:has(.live-room-picker-overlay) {
+	z-index: 10000;
+}
+
 .page-container:not(.room-page-container):has(> .sidebar-column) > .sidebar-column {
 	flex: 1 1 var(--sidebar-width);
 }

--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -81,9 +81,13 @@ $effect(() => {
 	align-items: center;
 	justify-content: center;
 	padding: 24px;
-	background: rgba(0, 0, 0, 0.88);
+	background: rgba(0, 0, 0, 0.58);
 	pointer-events: auto;
 	isolation: isolate;
+}
+
+:global(.sidebar-column:has(.live-room-picker-overlay)) {
+	z-index: 6000;
 }
 
 .live-room-picker-modal {

--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -76,7 +76,7 @@ $effect(() => {
 .anime-search-overlay.live-room-picker-overlay {
 	position: fixed;
 	inset: 0;
-	z-index: 5000;
+	z-index: 10000;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -84,10 +84,6 @@ $effect(() => {
 	background: rgba(0, 0, 0, 0.58);
 	pointer-events: auto;
 	isolation: isolate;
-}
-
-:global(.sidebar-column:has(.live-room-picker-overlay)) {
-	z-index: 6000;
 }
 
 .live-room-picker-modal {


### PR DESCRIPTION
## Summary
- keep the live room picker backdrop translucent instead of covering the page with an opaque theme background
- raise the desktop sidebar stacking context while the picker is open so timeline post text and icons cannot render above the modal

## Root cause
The picker is rendered from the desktop sidebar. The sidebar is sticky, so the modal stayed inside that stacking context while timeline post children had their own z-index. That made timeline content appear above the modal and look like background transparency.

## Validation
- pnpm.cmd exec biome check src/lib/components/LiveRoomPickerModal.svelte
- pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json
- Chrome check confirmed the :has() sidebar z-index rule is active and the overlay is the top element in the stacking test