### PR TITLE
[codex] Fix anime detail mobile bottom spacing

### DIFF
--- a/src/routes/anime/[id]/+page.svelte
+++ b/src/routes/anime/[id]/+page.svelte
@@ -1625,6 +1625,12 @@ $effect(() => {
 	color: var(--text);
 }
 
+@media (max-width: 960px) {
+	.detail-page {
+		padding-bottom: calc(80px + env(safe-area-inset-bottom));
+	}
+}
+
 /* Two-column layout */
 .anime-layout {
 	display: grid;


### PR DESCRIPTION
## Summary
- Add mobile-only bottom clearance to the anime detail page wrapper.
- Keep desktop spacing unchanged while accounting for the fixed mobile bottom tab and safe-area inset.

## Root Cause
The anime detail route uses its own `.detail-page` wrapper instead of the shared `.page-container` mobile spacing path, so its existing `48px` bottom padding could leave the room log covered by the fixed mobile bottom navigation.

## Validation
- `pnpm.cmd exec biome check "src/routes/anime/[id]/+page.svelte"`
- `pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json`
- `git diff --check`