### PR TITLE
developをmasterへ反映: タイムライン右コンテナスクロール修正

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -283,6 +283,10 @@ textarea {
 	top: calc(var(--nav-height) + 24px);
 }
 
+.sidebar-column:has(.live-room-picker-overlay) {
+	z-index: 10000;
+}
+
 .page-container:not(.room-page-container):has(> .sidebar-column) > .sidebar-column {
 	flex: 1 1 var(--sidebar-width);
 }

--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -81,9 +81,13 @@ $effect(() => {
 	align-items: center;
 	justify-content: center;
 	padding: 24px;
-	background: rgba(0, 0, 0, 0.88);
+	background: rgba(0, 0, 0, 0.58);
 	pointer-events: auto;
 	isolation: isolate;
+}
+
+:global(.sidebar-column:has(.live-room-picker-overlay)) {
+	z-index: 6000;
 }
 
 .live-room-picker-modal {

--- a/src/lib/components/LiveRoomPickerModal.svelte
+++ b/src/lib/components/LiveRoomPickerModal.svelte
@@ -76,7 +76,7 @@ $effect(() => {
 .anime-search-overlay.live-room-picker-overlay {
 	position: fixed;
 	inset: 0;
-	z-index: 5000;
+	z-index: 10000;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -84,10 +84,6 @@ $effect(() => {
 	background: rgba(0, 0, 0, 0.58);
 	pointer-events: auto;
 	isolation: isolate;
-}
-
-:global(.sidebar-column:has(.live-room-picker-overlay)) {
-	z-index: 6000;
 }
 
 .live-room-picker-modal {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,8 @@ const SKELETON_COUNT = 5;
 let { data }: PageProps = $props();
 
 let onboardingDismissed = $state(true);
+let homeSidebarSlot = $state<HTMLElement | null>(null);
+let homeSidebarReady = $state(false);
 
 $effect(() => {
 	onboardingDismissed = localStorage.getItem("anipolis_onboarding_dismissed") === "1";
@@ -33,6 +35,29 @@ function loadMoreHref(lastCreatedAt: string, lastPostId: string): string {
 	const separator = base.includes("?") ? "&" : "?";
 	return `${base}${separator}before=${encodeURIComponent(lastCreatedAt)}&before_id=${encodeURIComponent(lastPostId)}`;
 }
+
+$effect(() => {
+	if (!homeSidebarSlot) return;
+
+	function updateHomeSidebarMetrics() {
+		if (!homeSidebarSlot) return;
+		const rect = homeSidebarSlot.getBoundingClientRect();
+		homeSidebarSlot.style.setProperty("--home-sidebar-left", `${rect.left}px`);
+		homeSidebarSlot.style.setProperty("--home-sidebar-top", `${rect.top}px`);
+		homeSidebarSlot.style.setProperty("--home-sidebar-width", `${rect.width}px`);
+		homeSidebarReady = true;
+	}
+
+	updateHomeSidebarMetrics();
+	const resizeObserver = new ResizeObserver(updateHomeSidebarMetrics);
+	resizeObserver.observe(homeSidebarSlot);
+	window.addEventListener("resize", updateHomeSidebarMetrics);
+
+	return () => {
+		resizeObserver.disconnect();
+		window.removeEventListener("resize", updateHomeSidebarMetrics);
+	};
+});
 
 $effect(() => {
 	if ((data.initialAnime || data.initialExchangeShare) && data.profile) {
@@ -232,11 +257,13 @@ $effect(() => {
 		{/await}
 	</main>
 
-	<aside class="sidebar-column">
-		{#if data.user}
-			<LiveRoomsPanel rooms={data.liveRooms} />
-		{/if}
-		<TrendingPanel trending={data.trending} animeTrending={data.animeTrending} />
+	<aside class="sidebar-column home-sidebar-column" bind:this={homeSidebarSlot}>
+		<div class="home-sidebar-fixed scrollbar-thin-muted" class:home-sidebar-fixed-ready={homeSidebarReady}>
+			{#if data.user}
+				<LiveRoomsPanel rooms={data.liveRooms} />
+			{/if}
+			<TrendingPanel trending={data.trending} animeTrending={data.animeTrending} />
+		</div>
 	</aside>
 </div>
 
@@ -345,6 +372,26 @@ $effect(() => {
 
 .compose-modal-body {
 	overflow-y: auto;
+}
+
+.home-sidebar-column {
+	position: static;
+}
+
+.home-sidebar-fixed {
+	position: fixed;
+	top: var(--home-sidebar-top, calc(var(--nav-height) + 24px));
+	bottom: 0;
+	left: var(--home-sidebar-left, 0);
+	width: var(--home-sidebar-width, var(--sidebar-width));
+	overflow-x: hidden;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	visibility: hidden;
+}
+
+.home-sidebar-fixed-ready {
+	visibility: visible;
 }
 
 /* Landing hero (unauthenticated) */

--- a/src/routes/anime/[id]/+page.svelte
+++ b/src/routes/anime/[id]/+page.svelte
@@ -1625,6 +1625,12 @@ $effect(() => {
 	color: var(--text);
 }
 
+@media (max-width: 960px) {
+	.detail-page {
+		padding-bottom: calc(80px + env(safe-area-inset-bottom));
+	}
+}
+
 /* Two-column layout */
 .anime-layout {
 	display: grid;


### PR DESCRIPTION
## Summary
- Merge the latest `develop` changes into `master`.
- Includes PR #153: home timeline right container now scrolls independently, stays fixed while the timeline feed scrolls, and extends its scroll area to the viewport bottom.

## Validation
- PR #153 checks passed before merging to `develop`:
  - Cloudflare Pages: success
  - CodeRabbit: success
- Local validation for PR #153:
  - `pnpm.cmd exec biome check src/routes/+page.svelte`
  - `pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json`
  - `git diff --check`