### PR TITLE
セキュリティ監査対応: オープンリダイレクト・レート制限・アップロードDoS等

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { type Handle, json, redirect } from "@sveltejs/kit";
 import { env as publicEnv } from "$env/dynamic/public";
-import { isBetaMember } from "$lib/server/discord";
+import { isBetaGateEnabled, isBetaMember } from "$lib/server/discord";
 import { isApiRateLimited } from "$lib/server/rate-limit";
 
 // クローズドβ：これらのプレフィックス配下は未資格ユーザーでもアクセス可
@@ -65,7 +65,8 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	// クローズドβ：所属検証済み（app_metadata.beta_member）でないログインユーザーを遮断する。
 	// 未ログインユーザーや公開パス（/auth 配下）は対象外。検証は /auth/callback で1度だけ行う。
-	if (event.route.id && !isPublicPath(event.url.pathname)) {
+	// PUBLIC_CLOSED_BETA を無効にするとこのゲートごと外れる（β終了時の締め出し防止）。
+	if (isBetaGateEnabled() && event.route.id && !isPublicPath(event.url.pathname)) {
 		const { user } = await event.locals.safeGetSession();
 		if (user && !isBetaMember(user)) {
 			redirect(303, "/auth?error=not_member");

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -7,7 +7,12 @@ import {
 } from "$lib/exchange-tags";
 import { getEvent, isAdminUser } from "$lib/server/queries";
 import { createServiceRoleClient } from "$lib/server/supabase-admin";
-import { publicUrlToStoragePath, validateImageBuffer } from "$lib/server/upload";
+import {
+	MULTIPART_OVERHEAD_BYTES,
+	publicUrlToStoragePath,
+	readFormDataWithLimit,
+	validateImageBuffer,
+} from "$lib/server/upload";
 import type { Database, Json } from "$lib/supabase/database.types";
 import type { AnimeExchangeShare, AnimeStatus, BroadcastRoomMuteDuration } from "$lib/types";
 import { extractHashtags } from "$lib/utils/hashtag";
@@ -1112,7 +1117,27 @@ export async function completeProfileSetupAction(
 	userId: string,
 	options: ProfileSetupOptions = {},
 ): Promise<ProfileSetupResult> {
-	const form = requestOrForm instanceof FormData ? requestOrForm : await requestOrForm.formData();
+	// アバターファイルを含むフォームのため、サイズ検証前の全量バッファを避けて上限付きで読む
+	const parsedForm =
+		requestOrForm instanceof FormData
+			? requestOrForm
+			: await readFormDataWithLimit(requestOrForm, ONBOARDING_MAX_AVATAR_SIZE + MULTIPART_OVERHEAD_BYTES);
+	if (parsedForm === "too_large") {
+		return {
+			error: "画像は2MB以内にしてください",
+			status: 413,
+			field: "avatar",
+			values: { username: "", display_name: "" },
+		};
+	}
+	if (parsedForm === "invalid") {
+		return {
+			error: "フォームの送信内容を読み取れませんでした",
+			status: 400,
+			values: { username: "", display_name: "" },
+		};
+	}
+	const form = parsedForm;
 	const usernameEntry = form.get("username");
 	const displayNameEntry = form.get("display_name");
 	const avatarChoiceEntry = form.get("avatar_choice");

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -23,6 +23,15 @@ function getJwtPayload(session: AuthSession | null) {
 	}
 }
 
+/**
+ * ユーザーがパスワード（email プロバイダー）を持つかを判定する。
+ *
+ * セキュリティ上の注意: `user_metadata.has_password` はクライアントが
+ * `supabase.auth.updateUser({ data })` で自由に書き換えられる値である。
+ * この関数の OR 条件では「パスワード確認を追加で要求する」フェイルセーフ方向にしか
+ * 働かないため問題ないが、**この判定を「検証をスキップしてよい」方向の分岐に
+ * 流用してはならない**。信頼できる信号は identities / app_metadata / amr のみ。
+ */
 export function hasPasswordProvider(user: AuthUser, session: AuthSession | null = null) {
 	const providers = user.app_metadata.providers;
 	const providerList = typeof providers === "string" ? [providers] : Array.isArray(providers) ? providers : [];

--- a/src/lib/server/discord.ts
+++ b/src/lib/server/discord.ts
@@ -1,5 +1,15 @@
 import type { User } from "@supabase/supabase-js";
+import { env as publicEnv } from "$env/dynamic/public";
 import { DISCORD_BOT_TOKEN, DISCORD_GUILD_ID } from "$env/static/private";
+
+/**
+ * クローズドβのアクセスゲートが有効かどうか。
+ * hooks の全ルート遮断・/auth のログイン手段制限・/auth/callback のセッション破棄は
+ * すべてこの判定を共有する（フラグを消せば β ゲート全体が無効になる）。
+ */
+export function isBetaGateEnabled(): boolean {
+	return publicEnv["PUBLIC_CLOSED_BETA"] === "true";
+}
 
 /**
  * Discord Bot トークンを使って、指定 Guild にユーザーが在籍しているか照会する。

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -1365,12 +1365,17 @@ export async function getTimelinePostsWithReposts(
 					profile: ProfileRepostContext;
 				} => item !== null,
 			),
-	]
-		.sort((a, b) => new Date(b.sortAt).getTime() - new Date(a.sortAt).getTime())
-		.filter((item, index, items) => items.findIndex((candidate) => candidate.post.id === item.post.id) === index)
-		.slice(0, limit);
+	].sort((a, b) => new Date(b.sortAt).getTime() - new Date(a.sortAt).getTime());
 
-	const rawTimelinePosts = timelineItems.map((item) => ({
+	// 同一投稿の重複（自分の投稿 + 他プロフィールによるリポスト等）は先勝ちで除外する
+	const seenPostIds = new Set<string>();
+	const dedupedItems = timelineItems.filter((item) => {
+		if (seenPostIds.has(item.post.id)) return false;
+		seenPostIds.add(item.post.id);
+		return true;
+	});
+
+	const rawTimelinePosts = dedupedItems.slice(0, limit).map((item) => ({
 		...item.post,
 		repost_context:
 			item.kind === "repost"

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -32,6 +32,18 @@ export function isRateLimited(key: string, limit: number, windowMs: number): boo
 	return bucket.count > limit;
 }
 
+/**
+ * RequestEvent からレート制限キー用のクライアントアドレスを安全に取得する。
+ * アドレスを取得できないアダプターでは共有バケット "unknown" にフォールバックする。
+ */
+export function getClientKey(event: { getClientAddress: () => string }): string {
+	try {
+		return event.getClientAddress();
+	} catch {
+		return "unknown";
+	}
+}
+
 export interface RateRule {
 	/** ルール名（バケットキーの一部になる） */
 	name: string;

--- a/src/lib/server/upload.test.ts
+++ b/src/lib/server/upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { publicUrlToStoragePath, sniffImageMime, validateImageBuffer } from "./upload";
+import { publicUrlToStoragePath, readFormDataWithLimit, sniffImageMime, validateImageBuffer } from "./upload";
 
 function bytesFrom(head: number[], length = 16): Uint8Array {
 	const bytes = new Uint8Array(length);
@@ -68,5 +68,76 @@ describe("publicUrlToStoragePath", () => {
 
 	it("ストレージ URL でなければ null", () => {
 		expect(publicUrlToStoragePath("https://example.com/a.jpg", "post-images")).toBe(null);
+	});
+});
+
+describe("readFormDataWithLimit", () => {
+	/** 実際の multipart ボディを持つ Request（FormData の往復検証用） */
+	function multipartRequest(fileBytes: Uint8Array): Request {
+		const form = new FormData();
+		form.set("file", new Blob([fileBytes as BlobPart], { type: "application/octet-stream" }), "a.bin");
+		return new Request("http://localhost/api/upload", { method: "POST", body: form });
+	}
+
+	/**
+	 * 指定バイト数を複数チャンクに分けて流し、cancel を素直に受け付ける Request。
+	 * multipart として妥当である必要はない（上限超過テストはパース前に打ち切られる）。
+	 */
+	function chunkedByteRequest(totalBytes: number, contentLength?: string): Request {
+		const chunkSize = 16 * 1024;
+		let remaining = totalBytes;
+		const stream = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (remaining <= 0) {
+					controller.close();
+					return;
+				}
+				const size = Math.min(chunkSize, remaining);
+				remaining -= size;
+				controller.enqueue(new Uint8Array(size));
+			},
+		});
+		return new Request("http://localhost/api/upload", {
+			method: "POST",
+			body: stream,
+			// @ts-expect-error duplex is required by the runtime when body is a stream
+			duplex: "half",
+			headers: {
+				"content-type": "multipart/form-data; boundary=x",
+				...(contentLength ? { "content-length": contentLength } : {}),
+			},
+		});
+	}
+
+	it("上限内のボディは FormData として返す", async () => {
+		const request = multipartRequest(new Uint8Array(1024));
+		const result = await readFormDataWithLimit(request, 64 * 1024);
+		expect(result).toBeInstanceOf(FormData);
+		const file = (result as FormData).get("file") as File;
+		expect(file.size).toBe(1024);
+	});
+
+	it("ボディが上限を超えたら too_large（全量バッファせず中断）", async () => {
+		const request = chunkedByteRequest(256 * 1024);
+		expect(await readFormDataWithLimit(request, 64 * 1024)).toBe("too_large");
+	});
+
+	it("Content-Length 申告が上限超過なら読み込む前に too_large", async () => {
+		const request = chunkedByteRequest(16, String(100 * 1024 * 1024));
+		expect(await readFormDataWithLimit(request, 64 * 1024)).toBe("too_large");
+	});
+
+	it("ボディなしは invalid", async () => {
+		const request = new Request("http://localhost/api/upload", { method: "POST" });
+		expect(await readFormDataWithLimit(request, 64 * 1024)).toBe("invalid");
+	});
+
+	it("multipart として解釈できないボディは invalid", async () => {
+		const request = new Request("http://localhost/api/upload", {
+			method: "POST",
+			body: "not-multipart",
+			headers: { "content-type": "multipart/form-data; boundary=none" },
+		});
+		expect(await readFormDataWithLimit(request, 64 * 1024)).toBe("invalid");
 	});
 });

--- a/src/lib/server/upload.ts
+++ b/src/lib/server/upload.ts
@@ -62,6 +62,55 @@ export function validateImageBuffer(
 	return ext ? { mime, ext } : null;
 }
 
+/** multipart 境界・付随フィールド分の余裕。ファイル上限ちょうどのアップロードを弾かないために加算する */
+export const MULTIPART_OVERHEAD_BYTES = 64 * 1024;
+
+/**
+ * リクエストボディを上限付きでストリーミング読みして FormData として返す。
+ *
+ * `request.formData()` を直接呼ぶとサイズ検証前にボディ全量がメモリへバッファされるため、
+ * 巨大ボディの送りつけ（メモリ DoS）を上限到達時点の読み込み中断で防ぐ。
+ * 上限超過なら "too_large"、ボディなし・multipart として解釈不能なら "invalid" を返す。
+ */
+export async function readFormDataWithLimit(
+	request: Request,
+	maxBytes: number,
+): Promise<FormData | "too_large" | "invalid"> {
+	// Content-Length 申告による早期拒否（偽装可能だが正直なクライアントを速く弾ける）
+	const contentLength = Number(request.headers.get("content-length") ?? 0);
+	if (contentLength > maxBytes) return "too_large";
+
+	if (!request.body) return "invalid";
+
+	const reader = request.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let totalBytes = 0;
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		totalBytes += value.byteLength;
+		if (totalBytes > maxBytes) {
+			await reader.cancel();
+			return "too_large";
+		}
+		chunks.push(value);
+	}
+
+	const body = new Uint8Array(totalBytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+
+	const contentType = request.headers.get("content-type") ?? "";
+	try {
+		return await new Response(body, { headers: { "content-type": contentType } }).formData();
+	} catch {
+		return "invalid";
+	}
+}
+
 /** Supabase Storage の public URL からバケット内パスを取り出す（不一致なら null） */
 export function publicUrlToStoragePath(url: string, bucket: string): string | null {
 	const marker = `/storage/v1/object/public/${bucket}/`;

--- a/src/lib/utils/url.test.ts
+++ b/src/lib/utils/url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeInternalRedirect } from "./url";
+
+describe("sanitizeInternalRedirect", () => {
+	it("サイト内パスはそのまま返す", () => {
+		expect(sanitizeInternalRedirect("/")).toBe("/");
+		expect(sanitizeInternalRedirect("/anime/123")).toBe("/anime/123");
+		expect(sanitizeInternalRedirect("/search?q=%E3%83%86%E3%82%B9%E3%83%88")).toBe(
+			"/search?q=%E3%83%86%E3%82%B9%E3%83%88",
+		);
+	});
+
+	it("null / undefined / 空文字は / にフォールバックする", () => {
+		expect(sanitizeInternalRedirect(null)).toBe("/");
+		expect(sanitizeInternalRedirect(undefined)).toBe("/");
+		expect(sanitizeInternalRedirect("")).toBe("/");
+	});
+
+	it("絶対 URL・プロトコル相対 URL を拒否する", () => {
+		expect(sanitizeInternalRedirect("https://evil.com")).toBe("/");
+		expect(sanitizeInternalRedirect("http://evil.com")).toBe("/");
+		expect(sanitizeInternalRedirect("//evil.com")).toBe("/");
+		expect(sanitizeInternalRedirect("/redirect?to=https://evil.com")).toBe("/");
+	});
+
+	it("スキーム付きの値を拒否する", () => {
+		expect(sanitizeInternalRedirect("javascript:/alert(1)")).toBe("/");
+		expect(sanitizeInternalRedirect("mailto:/a@b.c")).toBe("/");
+	});
+
+	it("バックスラッシュによるプロトコル相対バイパスを拒否する", () => {
+		// ブラウザは Location ヘッダーの \ を / に正規化するため
+		// /\evil.com は //evil.com として外部へリダイレクトされる
+		expect(sanitizeInternalRedirect("/\\evil.com")).toBe("/");
+		expect(sanitizeInternalRedirect("/\\/evil.com")).toBe("/");
+		expect(sanitizeInternalRedirect("\\/evil.com")).toBe("/");
+		expect(sanitizeInternalRedirect("/path\\..\\evil")).toBe("/");
+	});
+});

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -7,3 +7,14 @@ export function isMalUrl(value: string | null | undefined): value is string {
 	if (!value) return false;
 	return value.includes("myanimelist.net") || value.includes("mal.");
 }
+
+/**
+ * リダイレクト先として受け取った値をサイト内パスに限定する。
+ * 外部 URL・プロトコル相対（//）・スキーム付き（:/）に加え、
+ * ブラウザが / へ正規化するバックスラッシュ（`/\evil.com` → `//evil.com`）も拒否し、
+ * 安全でない値は "/" にフォールバックする。
+ */
+export function sanitizeInternalRedirect(raw: string | null | undefined): string {
+	if (!raw) return "/";
+	return raw.startsWith("/") && !raw.startsWith("//") && !raw.includes(":/") && !raw.includes("\\") ? raw : "/";
+}

--- a/src/routes/api/upload/+server.ts
+++ b/src/routes/api/upload/+server.ts
@@ -1,5 +1,5 @@
 import { error, json } from "@sveltejs/kit";
-import { validateImageBuffer } from "$lib/server/upload";
+import { MULTIPART_OVERHEAD_BYTES, readFormDataWithLimit, validateImageBuffer } from "$lib/server/upload";
 import type { RequestHandler } from "./$types";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
@@ -9,37 +9,10 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 	const { user } = await safeGetSession();
 	if (!user) error(401, "ログインが必要です");
 
-	// Fast rejection for clients that send Content-Length (they can lie, but worth the early check)
-	const contentLength = Number(request.headers.get("content-length") ?? 0);
-	if (contentLength > MAX_FILE_SIZE) error(413, "ファイルサイズが大きすぎます（最大5MB）");
+	const form = await readFormDataWithLimit(request, MAX_FILE_SIZE + MULTIPART_OVERHEAD_BYTES);
+	if (form === "too_large") error(413, "ファイルサイズが大きすぎます（最大5MB）");
+	if (form === "invalid") error(400, "ファイルが指定されていません");
 
-	// Stream body with a hard size cap before any parsing
-	const contentType = request.headers.get("content-type") ?? "";
-	if (!request.body) error(400, "ファイルが指定されていません");
-
-	const reader = request.body.getReader();
-	const chunks: Uint8Array[] = [];
-	let totalBytes = 0;
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) break;
-		totalBytes += value.byteLength;
-		if (totalBytes > MAX_FILE_SIZE) {
-			await reader.cancel();
-			error(413, "ファイルサイズが大きすぎます（最大5MB）");
-		}
-		chunks.push(value);
-	}
-
-	// Reassemble and delegate multipart parsing to the native API
-	const body = new Uint8Array(totalBytes);
-	let offset = 0;
-	for (const chunk of chunks) {
-		body.set(chunk, offset);
-		offset += chunk.byteLength;
-	}
-
-	const form = await new Response(body, { headers: { "content-type": contentType } }).formData();
 	const file = form.get("file") as File | null;
 
 	if (!file || file.size === 0) error(400, "ファイルが指定されていません");

--- a/src/routes/api/upload/anime-cover/+server.ts
+++ b/src/routes/api/upload/anime-cover/+server.ts
@@ -3,7 +3,7 @@ import { error, json } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
 import { PUBLIC_SUPABASE_URL } from "$env/static/public";
 import { isAdminUser } from "$lib/server/queries";
-import { validateImageBuffer } from "$lib/server/upload";
+import { MULTIPART_OVERHEAD_BYTES, readFormDataWithLimit, validateImageBuffer } from "$lib/server/upload";
 import type { RequestHandler } from "./$types";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -14,7 +14,10 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 	if (!user) error(401, "ログインが必要です");
 	if (!(await isAdminUser(supabase, user.id))) error(403, "権限がありません");
 
-	const form = await request.formData();
+	const form = await readFormDataWithLimit(request, MAX_FILE_SIZE + MULTIPART_OVERHEAD_BYTES);
+	if (form === "too_large") error(413, "ファイルサイズが大きすぎます（最大10MB）");
+	if (form === "invalid") error(400, "ファイルが指定されていません");
+
 	const fileEntry = form.get("file");
 	const animeIdEntry = form.get("anime_id");
 

--- a/src/routes/api/upload/avatar/+server.ts
+++ b/src/routes/api/upload/avatar/+server.ts
@@ -1,5 +1,5 @@
 import { error, json } from "@sveltejs/kit";
-import { validateImageBuffer } from "$lib/server/upload";
+import { MULTIPART_OVERHEAD_BYTES, readFormDataWithLimit, validateImageBuffer } from "$lib/server/upload";
 import type { RequestHandler } from "./$types";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -9,7 +9,10 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 	const { user } = await safeGetSession();
 	if (!user) error(401, "ログインが必要です");
 
-	const form = await request.formData();
+	const form = await readFormDataWithLimit(request, MAX_FILE_SIZE + MULTIPART_OVERHEAD_BYTES);
+	if (form === "too_large") error(413, "ファイルサイズが大きすぎます（最大2MB）");
+	if (form === "invalid") error(400, "ファイルが指定されていません");
+
 	const file = form.get("file") as File | null;
 
 	if (!file || file.size === 0) error(400, "ファイルが指定されていません");

--- a/src/routes/api/upload/profile-header/+server.ts
+++ b/src/routes/api/upload/profile-header/+server.ts
@@ -1,5 +1,10 @@
 import { error, json } from "@sveltejs/kit";
-import { publicUrlToStoragePath, validateImageBuffer } from "$lib/server/upload";
+import {
+	MULTIPART_OVERHEAD_BYTES,
+	publicUrlToStoragePath,
+	readFormDataWithLimit,
+	validateImageBuffer,
+} from "$lib/server/upload";
 import type { RequestHandler } from "./$types";
 
 const BUCKET = "profile-headers";
@@ -10,7 +15,10 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 	const { user } = await safeGetSession();
 	if (!user) error(401, "ログインが必要です");
 
-	const form = await request.formData();
+	const form = await readFormDataWithLimit(request, MAX_FILE_SIZE + MULTIPART_OVERHEAD_BYTES);
+	if (form === "too_large") error(413, "ファイルサイズが大きすぎます（最大5MB）");
+	if (form === "invalid") error(400, "ファイルが指定されていません");
+
 	const file = form.get("file") as File | null;
 	if (!file || file.size === 0) error(400, "ファイルが指定されていません");
 	if (!ALLOWED_TYPES.includes(file.type)) error(400, "対応していないファイル形式です（JPEG/PNG/WebP）");

--- a/src/routes/auth/+page.server.ts
+++ b/src/routes/auth/+page.server.ts
@@ -1,9 +1,10 @@
 import { fail, redirect } from "@sveltejs/kit";
-import { env as publicEnv } from "$env/dynamic/public";
 import { linkAccounts } from "$lib/server/actions";
-import { isBetaMember } from "$lib/server/discord";
+import { isBetaGateEnabled, isBetaMember } from "$lib/server/discord";
 import { getExtraAccounts, setExtraAccounts } from "$lib/server/multi-account";
+import { getClientKey, isRateLimited } from "$lib/server/rate-limit";
 import { createServiceRoleClient } from "$lib/server/supabase-admin";
+import { sanitizeInternalRedirect } from "$lib/utils/url";
 import type { Actions, PageServerLoad } from "./$types";
 
 const MIN_PASSWORD_LENGTH = 6;
@@ -11,12 +12,11 @@ const MIN_PASSWORD_LENGTH = 6;
 // クローズドβ中は Discord ログインのみ許可する。
 // UI は非表示だがアクションエンドポイントは直接 POST 可能なため、サーバー側でも遮断する。
 function isClosedBeta(): boolean {
-	return publicEnv["PUBLIC_CLOSED_BETA"] === "true";
+	return isBetaGateEnabled();
 }
 
 function getSafeNext(raw: FormDataEntryValue | string | null): string {
-	const next = typeof raw === "string" ? raw : "/";
-	return next.startsWith("/") && !next.startsWith("//") && !next.includes(":/") ? next : "/";
+	return sanitizeInternalRedirect(typeof raw === "string" ? raw : "/");
 }
 
 function normalizeUsername(value: FormDataEntryValue | null): string {
@@ -45,7 +45,11 @@ export const load: PageServerLoad = async ({ url, locals: { safeGetSession } }) 
 };
 
 export const actions: Actions = {
-	login: async ({ request, locals: { supabase } }) => {
+	login: async (event) => {
+		const {
+			request,
+			locals: { supabase },
+		} = event;
 		if (isClosedBeta()) {
 			return fail(403, { mode: "login", email: "", message: "現在はDiscordログインのみご利用いただけます" });
 		}
@@ -56,6 +60,15 @@ export const actions: Actions = {
 
 		if (!email || !password) {
 			return fail(400, { mode: "login", email, message: "メールアドレスとパスワードを入力してください" });
+		}
+
+		// パスワード総当たり対策（IP 単位）。form action は hooks の /api/* リミッターの対象外のためここで制限する
+		if (isRateLimited(`auth-login:${getClientKey(event)}`, 10, 5 * 60_000)) {
+			return fail(429, {
+				mode: "login",
+				email,
+				message: "試行回数が多すぎます。しばらく待ってからお試しください",
+			});
 		}
 
 		const { error } = await supabase.auth.signInWithPassword({ email, password });
@@ -71,7 +84,11 @@ export const actions: Actions = {
 		redirect(303, next);
 	},
 
-	register: async ({ request, locals: { supabase } }) => {
+	register: async (event) => {
+		const {
+			request,
+			locals: { supabase },
+		} = event;
 		if (isClosedBeta()) {
 			return fail(403, {
 				mode: "register",
@@ -131,6 +148,15 @@ export const actions: Actions = {
 			});
 		}
 
+		// アカウント大量作成対策（IP 単位）
+		if (isRateLimited(`auth-register:${getClientKey(event)}`, 5, 10 * 60_000)) {
+			return fail(429, {
+				mode: "register",
+				...values,
+				message: "試行回数が多すぎます。しばらく待ってからお試しください",
+			});
+		}
+
 		const { data, error } = await supabase.auth.signUp({
 			email,
 			password,
@@ -175,6 +201,14 @@ export const actions: Actions = {
 			return fail(400, {
 				mode: "add_account",
 				message: "メールアドレスとパスワードを入力してください",
+			});
+		}
+
+		// 他人アカウントのパスワード総当たり対策（ログイン中ユーザー単位）
+		if (isRateLimited(`auth-add-account:${ownerUser.id}`, 5, 10 * 60_000)) {
+			return fail(429, {
+				mode: "add_account",
+				message: "試行回数が多すぎます。しばらく待ってからお試しください",
 			});
 		}
 

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,8 +1,8 @@
 import { redirect } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
-import { env as publicEnv } from "$env/dynamic/public";
-import { isBetaMember, verifyGuildMembership } from "$lib/server/discord";
+import { isBetaGateEnabled, isBetaMember, verifyGuildMembership } from "$lib/server/discord";
 import { createServiceRoleClient } from "$lib/server/supabase-admin";
+import { sanitizeInternalRedirect } from "$lib/utils/url";
 import type { RequestHandler } from "./$types";
 
 /**
@@ -17,8 +17,7 @@ import type { RequestHandler } from "./$types";
  */
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 	const code = url.searchParams.get("code");
-	const raw = url.searchParams.get("next") ?? "/";
-	const safeNext = raw.startsWith("/") && !raw.startsWith("//") && !raw.includes(":/") ? raw : "/";
+	const safeNext = sanitizeInternalRedirect(url.searchParams.get("next"));
 
 	if (!code) redirect(303, "/");
 
@@ -75,7 +74,7 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 
 	// クローズドβ：所属検証を通っていないユーザー（Google / メール等）は
 	// セッションを破棄してログインを成立させない。
-	if (publicEnv["PUBLIC_CLOSED_BETA"] === "true" && !betaGranted) {
+	if (isBetaGateEnabled() && !betaGranted) {
 		await supabase.auth.signOut();
 		redirect(303, "/auth?error=not_member");
 	}

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -1,13 +1,13 @@
 import { fail, redirect } from "@sveltejs/kit";
 import { completeProfileSetupAction } from "$lib/server/actions";
 import { getProfileIdByUsername } from "$lib/server/queries";
+import { sanitizeInternalRedirect } from "$lib/utils/url";
 import type { Actions, PageServerLoad } from "./$types";
 
 const USERNAME_PATTERN = /^[a-zA-Z0-9_]{3,20}$/;
 
 function getSafeNext(raw: FormDataEntryValue | string | null): string {
-	const next = typeof raw === "string" ? raw : "/";
-	return next.startsWith("/") && !next.startsWith("//") && !next.includes(":/") ? next : "/";
+	return sanitizeInternalRedirect(typeof raw === "string" ? raw : "/");
 }
 
 function getMetadataString(metadata: Record<string, unknown>, key: string): string | null {

--- a/src/routes/settings/account/password/+page.server.ts
+++ b/src/routes/settings/account/password/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail, redirect } from "@sveltejs/kit";
 import { hasPasswordProvider } from "$lib/server/auth";
+import { isRateLimited } from "$lib/server/rate-limit";
 import type { Actions, PageServerLoad } from "./$types";
 
 const MIN_PASSWORD_LENGTH = 6;
@@ -29,6 +30,15 @@ export const actions: Actions = {
 				return fail(400, {
 					field: "current_password",
 					message: "現在のパスワードを入力してください",
+				});
+			}
+
+			// セッションを奪われた場合の現在パスワード総当たり対策（ユーザー単位）。
+			// form action は hooks の /api/* リミッターの対象外のためここで制限する
+			if (isRateLimited(`set-password:${user.id}`, 5, 15 * 60_000)) {
+				return fail(429, {
+					field: "current_password",
+					message: "試行回数が多すぎます。しばらく待ってからお試しください",
 				});
 			}
 


### PR DESCRIPTION
@
## 概要
コードベースのセキュリティ・パフォーマンス横断監査で見つけた項目のうち、コードで修正可能なものを対応。

## セキュリティ
- **S1 オープンリダイレクト（バックスラッシュ・バイパス）**: `next=/\evil.com` がブラウザの正規化で `//evil.com` になり外部誘導される穴を修正。判定を `sanitizeInternalRedirect()` に純粋関数化し、同じ脆弱パターンがあった `auth/callback`・`auth/+page.server.ts`・`onboarding` の3箇所を統一。ユニットテスト付き。
- **S2 認証系 form action のレート制限**: hooks のリミッターは `/api/*` のみで form action は無防備だった。`login`/`register`/`addAccount`/`setPassword`（現在パスワード検証）に総当たり対策を追加。
- **S3 アップロードのメモリ DoS**: `avatar`/`profile-header`/`anime-cover`/オンボーディングは `request.formData()` を先に呼びサイズ検証前に全量バッファしていた。`readFormDataWithLimit()` に抽出しストリーミング上限打ち切りで4経路共用。
- **S4 β ゲートとフラグの不整合**: hooks のゲートがフラグ非依存で常時作動し β 終了時に全員締め出される問題。`isBetaGateEnabled()` に集約。
- **S5**: `hasPasswordProvider` に user_metadata の信頼性に関する警告コメント追加。

## パフォーマンス
- **P5**: タイムライン重複排除を O(n²) `findIndex` から `Set` ベースへ。

## 検証
- `pnpm check`（Biome + svelte-check + tsc）通過
- 全59テスト合格（アップロード・URL サニタイズのテスト新規追加）

## 未対応（別タスク）
- P1/P2（`/anime` の limit:1000 全件取得とソート正しさ）は別ブランチで対応予定
- S2 の本質（Cloudflare インメモリ制限の限界）・P3（毎リクエスト getUser）は WAF / JWKS 等インフラ側対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@