### PR TITLE
アニメ一覧のサーバー側ページネーション化とソート正しさ修正 (P1/P2)

### DIFF
--- a/src/lib/server/anime-ranking.test.ts
+++ b/src/lib/server/anime-ranking.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { type AnimeCandidate, rankAnimeCandidateIds } from "./queries";
+
+// created_at DESC 済みで DB から来る前提（配列インデックス = 新着順）
+const candidates: AnimeCandidate[] = [
+	{ id: 1, created_at: "2026-01-05T00:00:00Z", genre: ["アクション"], genre_en: ["Action"] },
+	{ id: 2, created_at: "2026-01-04T00:00:00Z", genre: ["コメディ"], genre_en: ["Comedy"] },
+	{ id: 3, created_at: "2026-01-03T00:00:00Z", genre: ["アクション", "コメディ"], genre_en: null },
+	{ id: 4, created_at: "2026-01-02T00:00:00Z", genre: null, genre_en: null },
+];
+
+describe("rankAnimeCandidateIds", () => {
+	it("created 順は新着（配列順）を保つ", () => {
+		expect(rankAnimeCandidateIds(candidates, new Map(), "created", [])).toEqual(["1", "2", "3", "4"]);
+	});
+
+	it("popular 順はメトリクス降順、欠損は0扱いで新着タイブレーク", () => {
+		const metrics = new Map([
+			["1", { primary: 5, secondary: 0 }],
+			["3", { primary: 20, secondary: 0 }],
+			["2", { primary: 20, secondary: 0 }],
+			// id 4 はメトリクスなし → 0
+		]);
+		// primary: 3,2 が20で同率 → 新着順(2が先) → 次に1(5) → 最後に4(0)
+		expect(rankAnimeCandidateIds(candidates, metrics, "popular", [])).toEqual(["2", "3", "1", "4"]);
+	});
+
+	it("top_rated は primary 同率のとき secondary（件数）で決める", () => {
+		const metrics = new Map([
+			["1", { primary: 8, secondary: 3 }],
+			["2", { primary: 8, secondary: 50 }],
+			["3", { primary: 9, secondary: 1 }],
+			["4", { primary: 1, secondary: 999 }],
+		]);
+		// primary: 3(9) → 1と2は8で同率 → secondary降順(2=50 > 1=3) → 4(1)
+		expect(rankAnimeCandidateIds(candidates, metrics, "top_rated", [])).toEqual(["3", "2", "1", "4"]);
+	});
+
+	it("ジャンル選択時は一致数がメトリクス同率のタイブレークになる", () => {
+		const metrics = new Map([
+			["1", { primary: 10, secondary: 0 }],
+			["2", { primary: 10, secondary: 0 }],
+			["3", { primary: 10, secondary: 0 }],
+			["4", { primary: 10, secondary: 0 }],
+		]);
+		// 全員 primary 10 同率。「アクション」「コメディ」両方選択 → id3 が2一致で最上位、
+		// id1(アクション)・id2(コメディ)が1一致 → 新着順(1が先)、id4は0一致で最後
+		expect(rankAnimeCandidateIds(candidates, metrics, "popular", ["アクション", "コメディ"])).toEqual([
+			"3",
+			"1",
+			"2",
+			"4",
+		]);
+	});
+
+	it("created 順 + ジャンル選択はジャンル一致優先、その中で新着順", () => {
+		// id3(2一致) → id1,id2(1一致, 新着順) → id4(0)
+		expect(rankAnimeCandidateIds(candidates, new Map(), "created", ["アクション", "コメディ"])).toEqual([
+			"3",
+			"1",
+			"2",
+			"4",
+		]);
+	});
+});

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -1503,6 +1503,65 @@ const ANIME_LIST_BASE_COLUMN_NAMES = [
 const ANIME_LIST_BASE_COLUMNS = ANIME_LIST_BASE_COLUMN_NAMES.join(", ");
 const ANIME_LIST_COLUMNS = [...ANIME_LIST_BASE_COLUMN_NAMES, "computed_broadcast_status"].join(", ");
 
+/** applyAnimeListFilters が扱う共有フィルター条件 */
+interface AnimeFilterInput {
+	season?: string | undefined;
+	broadcastYear?: string | undefined;
+	broadcastSeason?: string | undefined;
+	broadcastSeasons?: string[] | undefined;
+	scheduleRange?: { start: string; end: string } | undefined;
+	genre?: string | undefined;
+	genres?: string[] | undefined;
+	studio?: string | undefined;
+	producer?: string | undefined;
+	source?: string | undefined;
+	broadcastStatus?: string | undefined;
+	query?: string | undefined;
+	listedAnimeIds?: number[] | null | undefined;
+}
+
+/** PostgREST クエリビルダーが持つ、フィルター適用に必要なメソッド群 */
+interface AnimeFilterQuery<T> {
+	eq(column: string, value: string): T;
+	or(filters: string): T;
+	in(column: string, values: (string | number)[]): T;
+	not(column: string, operator: string, value: null): T;
+	contains(column: string, value: string[]): T;
+	gte(column: string, value: string): T;
+	lt(column: string, value: string): T;
+}
+
+/**
+ * アニメ一覧系クエリ（一覧・件数・候補ID取得）で共通のフィルター適用。
+ * getAnimeList / getAnimeListPage / getAnimeCount で同じ条件を重複記述していたのを一元化する。
+ * computed_broadcast_status で絞る broadcastStatus はビュー専用列なのでベーステーブルには渡さないこと。
+ */
+function applyAnimeListFilters<T extends AnimeFilterQuery<T>>(
+	query: T,
+	filters: AnimeFilterInput,
+	seasonFilter: string | null,
+): T {
+	const selectedGenres = normalizeGenreFilters(filters.genres ?? filters.genre);
+	let q = query;
+	if (filters.listedAnimeIds) q = q.in("id", filters.listedAnimeIds);
+	if (filters.season) q = q.eq("season", filters.season);
+	if (seasonFilter) q = q.or(seasonFilter);
+	if (filters.broadcastYear) q = applyAiredYearFilter(q, filters.broadcastYear);
+	if (filters.scheduleRange) {
+		q = q
+			.not("broadcast_day", "is", null)
+			.or(`aired_from.is.null,aired_from.lte.${filters.scheduleRange.end}`)
+			.or(`aired_to.is.null,aired_to.gte.${filters.scheduleRange.start}`);
+	}
+	if (selectedGenres.length) q = q.or(buildGenreFilter(selectedGenres));
+	if (filters.studio) q = q.or(arrayContainsAny(["studio", "studio_en"], filters.studio));
+	if (filters.producer) q = q.contains("producer", [filters.producer]);
+	if (filters.source) q = q.eq("source", filters.source);
+	if (filters.broadcastStatus) q = q.eq("computed_broadcast_status", filters.broadcastStatus);
+	if (filters.query) q = q.or(buildTitleSearchFilter(filters.query));
+	return q;
+}
+
 /**
  * アニメ一覧を取得する（season / status フィルター対応）
  */
@@ -1532,29 +1591,30 @@ export async function getAnimeList(
 	const listedAnimeIds = listedByUserId ? await getListedAnimeIds(supabase, listedByUserId) : null;
 	if (listedAnimeIds && listedAnimeIds.length === 0) return [];
 
-	let query = supabase
-		.from("anime_with_computed_broadcast_status")
-		.select(ANIME_LIST_COLUMNS)
-		.order("created_at", { ascending: false })
-		.limit(limit);
-
-	if (listedAnimeIds) query = query.in("id", listedAnimeIds);
-	if (season) query = query.eq("season", season);
 	const seasonFilter = buildSeasonFilter(undefined, broadcastSeasons?.length ? broadcastSeasons : broadcastSeason);
-	if (seasonFilter) query = query.or(seasonFilter);
-	if (broadcastYear) query = applyAiredYearFilter(query, broadcastYear);
-	if (scheduleRange) {
-		query = query
-			.not("broadcast_day", "is", null)
-			.or(`aired_from.is.null,aired_from.lte.${scheduleRange.end}`)
-			.or(`aired_to.is.null,aired_to.gte.${scheduleRange.start}`);
-	}
-	if (selectedGenres.length) query = query.or(buildGenreFilter(selectedGenres));
-	if (studio) query = query.or(arrayContainsAny(["studio", "studio_en"], studio));
-	if (producer) query = query.contains("producer", [producer]);
-	if (source) query = query.eq("source", source);
-	if (broadcastStatus) query = query.eq("computed_broadcast_status", broadcastStatus);
-	if (searchQuery) query = query.or(buildTitleSearchFilter(searchQuery));
+	const query = applyAnimeListFilters(
+		supabase
+			.from("anime_with_computed_broadcast_status")
+			.select(ANIME_LIST_COLUMNS)
+			.order("created_at", { ascending: false })
+			.limit(limit),
+		{
+			season,
+			broadcastYear,
+			broadcastSeason,
+			broadcastSeasons,
+			scheduleRange,
+			genre,
+			genres,
+			studio,
+			producer,
+			source,
+			broadcastStatus,
+			query: searchQuery,
+			listedAnimeIds,
+		},
+		seasonFilter,
+	);
 
 	const { data, error } = await query;
 	const rows =
@@ -1568,6 +1628,162 @@ export async function getAnimeList(
 	const animes: Anime[] = mappedAnimes.map(({ anime }) => anime);
 	if (userId) return enrichAnimeWithUserEntries(supabase, animes, userId);
 	return animes;
+}
+
+export interface AnimeListPageResult {
+	items: Anime[];
+	total: number;
+}
+
+/** 候補ID並べ替え用の軽量行（重い一覧列は含めない） */
+export type AnimeCandidate = {
+	id: number;
+	created_at: string;
+	genre: string[] | null;
+	genre_en: string[] | null;
+};
+
+/**
+ * 候補配列を sortBy に従って並べ、ページ用に並んだ ID 配列（文字列）を返す純関数。
+ * DB 側で created_at DESC 済みの前提で、配列インデックスを created 順のタイブレークに使う。
+ * 既存の sortAnimeListItems と同じ優先順位（metric → top_rated件数 → ジャンル一致 → 新着）を再現する。
+ */
+export function rankAnimeCandidateIds(
+	candidates: AnimeCandidate[],
+	metrics: Map<string, { primary: number; secondary: number }>,
+	sortBy: NonNullable<AnimeListOptions["sortBy"]>,
+	selectedGenres: string[],
+): string[] {
+	const genreMatch = (c: AnimeCandidate): number => {
+		if (selectedGenres.length === 0) return 0;
+		const set = new Set([...(c.genre ?? []), ...(c.genre_en ?? [])].map((g) => g.toLowerCase()));
+		return selectedGenres.reduce((n, g) => n + (set.has(g.toLowerCase()) ? 1 : 0), 0);
+	};
+	const withIndex = candidates.map((c, index) => ({ c, index }));
+
+	if (sortBy === "created") {
+		withIndex.sort((a, b) => (selectedGenres.length ? genreMatch(b.c) - genreMatch(a.c) : 0) || a.index - b.index);
+		return withIndex.map(({ c }) => String(c.id));
+	}
+
+	withIndex.sort((a, b) => {
+		const am = metrics.get(String(a.c.id));
+		const bm = metrics.get(String(b.c.id));
+		const primaryDelta = (bm?.primary ?? 0) - (am?.primary ?? 0);
+		if (primaryDelta !== 0) return primaryDelta;
+		if (sortBy === "top_rated") {
+			const secondaryDelta = (bm?.secondary ?? 0) - (am?.secondary ?? 0);
+			if (secondaryDelta !== 0) return secondaryDelta;
+		}
+		if (selectedGenres.length) {
+			const genreDelta = genreMatch(b.c) - genreMatch(a.c);
+			if (genreDelta !== 0) return genreDelta;
+		}
+		return a.index - b.index;
+	});
+	return withIndex.map(({ c }) => String(c.id));
+}
+
+const ANIME_CANDIDATE_COLUMNS = "id, created_at, genre, genre_en";
+
+/** フィルター済みの候補行（軽量列）を created_at DESC で取得する。ビュー失敗時はベーステーブルへ */
+async function fetchAnimeCandidates(
+	supabase: SupabaseClient<Database>,
+	filters: AnimeFilterInput,
+	seasonFilter: string | null,
+): Promise<AnimeCandidate[]> {
+	const viewRes = await applyAnimeListFilters(
+		supabase
+			.from("anime_with_computed_broadcast_status")
+			.select(ANIME_CANDIDATE_COLUMNS)
+			.order("created_at", { ascending: false })
+			.limit(2000),
+		filters,
+		seasonFilter,
+	);
+	if (!viewRes.error && viewRes.data) return viewRes.data as unknown as AnimeCandidate[];
+
+	// broadcastStatus はビュー専用列なのでベーステーブルには渡さない
+	const { broadcastStatus: _broadcastStatus, ...baseFilters } = filters;
+	const baseRes = await applyAnimeListFilters(
+		supabase.from("anime").select(ANIME_CANDIDATE_COLUMNS).order("created_at", { ascending: false }).limit(2000),
+		baseFilters,
+		seasonFilter,
+	);
+	return (baseRes.data ?? []) as unknown as AnimeCandidate[];
+}
+
+/**
+ * アニメ一覧を1ページ分だけ取得する（P1: SSR ペイロード削減 / P2: DB 相当のグローバル順を保証）。
+ *
+ * まず軽量な候補行（id/created_at/ジャンル）を取得して total と正しい並び順を確定し、
+ * 重い一覧列は現在ページの ID 群（最大 pageSize 件）だけ後段でまとめて取得する。
+ * これにより「最新N件を取ってからJSで人気順に並べ替える」既存の不整合（P2）も解消する。
+ */
+export async function getAnimeListPage(
+	supabase: SupabaseClient<Database>,
+	options: AnimeListOptions & { page?: number; pageSize?: number },
+): Promise<AnimeListPageResult> {
+	const { page = 1, pageSize = 50, sortBy = "created", userId, listedByUserId } = options;
+	const selectedGenres = normalizeGenreFilters(options.genres ?? options.genre);
+
+	const listedAnimeIds = listedByUserId ? await getListedAnimeIds(supabase, listedByUserId) : null;
+	if (listedAnimeIds && listedAnimeIds.length === 0) return { items: [], total: 0 };
+
+	const seasonFilter = buildSeasonFilter(
+		undefined,
+		options.broadcastSeasons?.length ? options.broadcastSeasons : options.broadcastSeason,
+	);
+	const filters: AnimeFilterInput = {
+		season: options.season,
+		broadcastYear: options.broadcastYear,
+		broadcastSeason: options.broadcastSeason,
+		broadcastSeasons: options.broadcastSeasons,
+		scheduleRange: options.scheduleRange,
+		genre: options.genre,
+		genres: options.genres,
+		studio: options.studio,
+		producer: options.producer,
+		source: options.source,
+		broadcastStatus: options.broadcastStatus,
+		query: options.query,
+		listedAnimeIds,
+	};
+
+	const candidates = await fetchAnimeCandidates(supabase, filters, seasonFilter);
+	const total = candidates.length;
+	if (total === 0) return { items: [], total: 0 };
+
+	const metrics =
+		sortBy === "created"
+			? new Map<string, { primary: number; secondary: number }>()
+			: await getAnimeRankingMetrics(
+					supabase,
+					candidates.map((c) => String(c.id)),
+					sortBy,
+				);
+
+	const orderedIds = rankAnimeCandidateIds(candidates, metrics, sortBy, selectedGenres);
+	const start = Math.max(0, (page - 1) * pageSize);
+	const pageIds = orderedIds.slice(start, start + pageSize);
+	if (pageIds.length === 0) return { items: [], total };
+
+	const animes = await fetchAnimesByIds(supabase, pageIds);
+
+	// メトリクス値を一覧カード表示用に反映（sortAnimeListItems と同じ規則）
+	for (const anime of animes) {
+		const metric = metrics.get(anime.id);
+		if (!metric) continue;
+		if (sortBy === "popular") anime.list_count = metric.primary;
+		if (sortBy === "trending") anime.recent_count = metric.primary;
+		if (sortBy === "top_rated") {
+			anime.avg_score = normalizeAverageScore(metric.primary, metric.secondary);
+			anime.score_count = metric.secondary;
+		}
+	}
+
+	if (userId) return { items: await enrichAnimeWithUserEntries(supabase, animes, userId), total };
+	return { items: animes, total };
 }
 
 export async function getAnimeCount(
@@ -1962,13 +2178,34 @@ export async function getAnimeRelations(
 /**
  * 人気ランキング（総マイリスト登録数順）
  */
-export async function getAnimeRankingPopularity(supabase: SupabaseClient<Database>, limit = 20): Promise<Anime[]> {
+/** ランキングビューの総件数（ページャの総ページ算出用） */
+export async function countAnimeRanking(
+	supabase: SupabaseClient<Database>,
+	kind: "popular" | "trending" | "top_rated",
+): Promise<number> {
+	if (kind === "top_rated") {
+		const { count } = await supabase
+			.from("anime_top_rated")
+			.select("anime_id", { count: "exact", head: true })
+			.gt("score_count", 0);
+		return count ?? 0;
+	}
+	const view = kind === "popular" ? "anime_popularity" : "anime_trending";
+	const { count } = await supabase.from(view).select("anime_id", { count: "exact", head: true });
+	return count ?? 0;
+}
+
+export async function getAnimeRankingPopularity(
+	supabase: SupabaseClient<Database>,
+	limit = 20,
+	offset = 0,
+): Promise<Anime[]> {
 	const { data, error } = await supabase
 		.from("anime_popularity")
 		.select("anime_id, list_count")
 		.order("list_count", { ascending: false })
 		.order("anime_id", { ascending: true })
-		.limit(limit);
+		.range(offset, offset + limit - 1);
 	if (error || !data || data.length === 0) return [];
 
 	const rankedIds = data.map((row) => String(row.anime_id));
@@ -1980,13 +2217,17 @@ export async function getAnimeRankingPopularity(supabase: SupabaseClient<Databas
 /**
  * トレンドランキング（直近7日間のアクティビティ順）
  */
-export async function getAnimeRankingTrending(supabase: SupabaseClient<Database>, limit = 20): Promise<Anime[]> {
+export async function getAnimeRankingTrending(
+	supabase: SupabaseClient<Database>,
+	limit = 20,
+	offset = 0,
+): Promise<Anime[]> {
 	const { data, error } = await supabase
 		.from("anime_trending")
 		.select("anime_id, recent_count")
 		.order("recent_count", { ascending: false })
 		.order("anime_id", { ascending: true })
-		.limit(limit);
+		.range(offset, offset + limit - 1);
 	if (error || !data || data.length === 0) return [];
 
 	const rankedIds = data.map((row) => String(row.anime_id));
@@ -2007,7 +2248,11 @@ export async function getTrendingHashtags(supabase: SupabaseClient<Database>, li
 /**
  * 高評価ランキング（平均スコア順）
  */
-export async function getAnimeRankingTopRated(supabase: SupabaseClient<Database>, limit = 20): Promise<Anime[]> {
+export async function getAnimeRankingTopRated(
+	supabase: SupabaseClient<Database>,
+	limit = 20,
+	offset = 0,
+): Promise<Anime[]> {
 	const { data, error } = await supabase
 		.from("anime_top_rated")
 		.select("anime_id, avg_score, score_count")
@@ -2015,7 +2260,7 @@ export async function getAnimeRankingTopRated(supabase: SupabaseClient<Database>
 		.order("avg_score", { ascending: false })
 		.order("score_count", { ascending: false })
 		.order("anime_id", { ascending: true })
-		.limit(limit);
+		.range(offset, offset + limit - 1);
 	if (error || !data || data.length === 0) return [];
 
 	const rankedIds = data.map((row) => String(row.anime_id));
@@ -2037,10 +2282,26 @@ export async function getAnimeRankingTopRated(supabase: SupabaseClient<Database>
 /**
  * ユーザーのマイリストを取得する
  */
+/** マイリストの総件数（ページャの総ページ算出用） */
+export async function countUserAnimeList(
+	supabase: SupabaseClient<Database>,
+	userId: string,
+	status?: AnimeStatus,
+): Promise<number> {
+	let query = supabase
+		.from("user_anime_list")
+		.select("anime_id", { count: "exact", head: true })
+		.eq("user_id", userId);
+	if (status) query = query.eq("status", status);
+	const { count } = await query;
+	return count ?? 0;
+}
+
 export async function getUserAnimeList(
 	supabase: SupabaseClient<Database>,
 	userId: string,
 	status?: AnimeStatus,
+	range?: { limit: number; offset: number },
 ): Promise<Anime[]> {
 	let query = supabase
 		.from("user_anime_list")
@@ -2049,6 +2310,7 @@ export async function getUserAnimeList(
 		.order("updated_at", { ascending: false });
 
 	if (status) query = query.eq("status", status);
+	if (range) query = query.range(range.offset, range.offset + range.limit - 1);
 
 	const { data, error } = await query;
 	if (error || !data) return [];

--- a/src/routes/anime/+page.server.ts
+++ b/src/routes/anime/+page.server.ts
@@ -2,7 +2,10 @@
 import { registerAnimeAction } from "$lib/server/anime-admin";
 import { buildAnimeListOptions, parseAnimeListFilters } from "$lib/server/anime-list-filters";
 import {
-	getAnimeList,
+	type AnimeListPageResult,
+	countAnimeRanking,
+	countUserAnimeList,
+	getAnimeListPage,
 	getAnimeRankingPopularity,
 	getAnimeRankingTopRated,
 	getAnimeRankingTrending,
@@ -45,60 +48,63 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		source,
 	} = filters;
 
-	let animes: Anime[];
+	// ── ページネーション ─────────────────────────────────────────
+	// 従来は最大1000件を毎回SSRペイロードに載せていた（P1）。1ページ分だけ返す。
+	const PAGE_SIZE = 50;
+	const pageParam = Number(url.searchParams.get("page") ?? "1");
+	const page = Number.isFinite(pageParam) && pageParam >= 1 ? Math.floor(pageParam) : 1;
+	const offset = (page - 1) * PAGE_SIZE;
+	const userId = user?.id ?? null;
+
+	/** ランキングビュー系タブ：件数0なら通常一覧にフォールバック（既存挙動を維持） */
+	const rankingTab = async (
+		kind: "popular" | "trending" | "top_rated",
+		fetchPage: (limit: number, off: number) => Promise<Anime[]>,
+	): Promise<AnimeListPageResult> => {
+		const total = await countAnimeRanking(supabase, kind);
+		if (total === 0) return getAnimeListPage(supabase, { page, pageSize: PAGE_SIZE, userId });
+		return { items: await fetchPage(PAGE_SIZE, offset), total };
+	};
+
+	let result: AnimeListPageResult;
 
 	if (filters.hasSearchFilters) {
-		if (tab === "mylist") {
-			if (!user) {
-				animes = [];
-				return {
-					animes: [],
-					tab,
-					search,
-					genre,
-					genres,
-					season,
-					broadcastYear,
-					broadcastSeason,
-					broadcastSeasons,
-					studio,
-					producer,
-					source,
-					user,
-					isAdmin,
-				};
-			}
-		}
-		animes = await getAnimeList(supabase, buildAnimeListOptions(filters, user?.id ?? null));
+		result =
+			tab === "mylist" && !user
+				? { items: [], total: 0 }
+				: await getAnimeListPage(supabase, {
+						...buildAnimeListOptions(filters, userId),
+						page,
+						pageSize: PAGE_SIZE,
+					});
 	} else if (tab === "mylist") {
-		animes = user ? await getUserAnimeList(supabase, user.id) : [];
+		result = user
+			? {
+					items: await getUserAnimeList(supabase, user.id, undefined, { limit: PAGE_SIZE, offset }),
+					total: await countUserAnimeList(supabase, user.id),
+				}
+			: { items: [], total: 0 };
 	} else if (tab === "trending") {
-		animes = await getAnimeRankingTrending(supabase, 1000);
-		if (animes.length === 0) {
-			animes = await getAnimeList(supabase, { limit: 1000, userId: user?.id ?? null });
-		}
+		result = await rankingTab("trending", (limit, off) => getAnimeRankingTrending(supabase, limit, off));
 	} else if (tab === "top_rated") {
-		animes = await getAnimeRankingTopRated(supabase, 1000);
-		if (animes.length === 0) {
-			animes = await getAnimeList(supabase, { limit: 1000, userId: user?.id ?? null });
-		}
+		result = await rankingTab("top_rated", (limit, off) => getAnimeRankingTopRated(supabase, limit, off));
 	} else if (tab === "airing") {
-		animes = await getAnimeList(supabase, { broadcastStatus: "airing", limit: 1000, userId: user?.id ?? null });
+		result = await getAnimeListPage(supabase, { broadcastStatus: "airing", userId, page, pageSize: PAGE_SIZE });
 	} else if (tab === "upcoming") {
-		animes = await getAnimeList(supabase, { broadcastStatus: "upcoming", limit: 1000, userId: user?.id ?? null });
+		result = await getAnimeListPage(supabase, { broadcastStatus: "upcoming", userId, page, pageSize: PAGE_SIZE });
 	} else if (tab === "all") {
-		animes = await getAnimeList(supabase, { limit: 1000, userId: user?.id ?? null });
+		result = await getAnimeListPage(supabase, { userId, page, pageSize: PAGE_SIZE });
 	} else if (tab === "register") {
-		animes = [];
+		result = { items: [], total: 0 };
 	} else {
-		animes = await getAnimeRankingPopularity(supabase, 1000);
-		if (animes.length === 0) {
-			animes = await getAnimeList(supabase, { limit: 1000, userId: user?.id ?? null });
-		}
+		result = await rankingTab("popular", (limit, off) => getAnimeRankingPopularity(supabase, limit, off));
 	}
 
 	return {
-		animes: animes.map(toAnimeListItem),
+		animes: result.items.map(toAnimeListItem),
+		total: result.total,
+		page,
+		pageSize: PAGE_SIZE,
 		tab,
 		search,
 		genre,

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -99,26 +99,13 @@ let hasActiveFilters = $derived(
 			data.source,
 	),
 );
-let currentAnimeSectionIndex = $state(0);
-let animeSections = $derived(chunkAnimes(data.animes));
-let currentAnimeSection = $derived(animeSections[currentAnimeSectionIndex] ?? { start: 0, end: 0, items: [] });
-let visibleAnimeSectionPages = $derived(getVisibleAnimeSectionPages(animeSections, currentAnimeSectionIndex, 7));
-let visibleMobileAnimeSectionPages = $derived(getVisibleAnimeSectionPages(animeSections, currentAnimeSectionIndex, 5));
-let animeListContextKey = $derived(
-	[
-		data.tab,
-		data.search,
-		data.genre,
-		data.season,
-		data.broadcastYear,
-		data.broadcastSeason,
-		data.broadcastSeasons?.join(","),
-		data.studio,
-		data.producer,
-		data.source,
-	].join("\u0000"),
-);
-let previousAnimeListContextKey = $state<string | null>(null);
+// ページネーションはサーバー駆動（data.page / data.total）。表示は data.animes（現在ページ分）を直接使う。
+let pageSize = $derived(data.pageSize || ANIME_SECTION_SIZE);
+let totalPages = $derived(Math.max(1, Math.ceil((data.total ?? data.animes.length) / pageSize)));
+let currentAnimeSectionIndex = $derived(Math.min(Math.max((data.page ?? 1) - 1, 0), totalPages - 1));
+let pageStartRank = $derived(currentAnimeSectionIndex * pageSize);
+let visibleAnimeSectionPages = $derived(getVisibleAnimeSectionPages(totalPages, currentAnimeSectionIndex, 7));
+let visibleMobileAnimeSectionPages = $derived(getVisibleAnimeSectionPages(totalPages, currentAnimeSectionIndex, 5));
 let previousDataFilterKey = $state("");
 
 function toFilterState(): AnimeFilterState {
@@ -226,48 +213,36 @@ $effect(() => {
 	}
 });
 
-function chunkAnimes(animes: AnimeListItem[]) {
-	const sections: { start: number; end: number; items: AnimeListItem[] }[] = [];
-	for (let start = 0; start < animes.length; start += ANIME_SECTION_SIZE) {
-		const items = animes.slice(start, start + ANIME_SECTION_SIZE);
-		sections.push({ start, end: start + items.length, items });
-	}
-	return sections;
+/** 現在のフィルター/タブを保ったまま page=N を付けた一覧URLを組み立てる（page 1 は付けない） */
+function buildAnimePageUrl(pageIndex: number): string {
+	const base = buildCurrentAnimeListUrl();
+	if (pageIndex <= 0) return base;
+	const sep = base.includes("?") ? "&" : "?";
+	return `${base}${sep}page=${pageIndex + 1}`;
 }
 
-function setAnimeSectionIndex(index: number) {
-	currentAnimeSectionIndex = Math.min(Math.max(index, 0), Math.max(animeSections.length - 1, 0));
+function goToAnimePage(pageIndex: number) {
+	const clamped = Math.min(Math.max(pageIndex, 0), Math.max(totalPages - 1, 0));
+	if (clamped === currentAnimeSectionIndex) return;
+	goto(buildAnimePageUrl(clamped));
 }
 
-function getVisibleAnimeSectionPages(
-	sections: { start: number; end: number; items: AnimeListItem[] }[],
-	currentIndex: number,
-	visibleCount: number,
-) {
-	const maxStart = Math.max(sections.length - visibleCount, 0);
+/** ページャに表示するページ番号（0基点）とその件数レンジを返す */
+function getVisibleAnimeSectionPages(pageCount: number, currentIndex: number, visibleCount: number) {
+	const maxStart = Math.max(pageCount - visibleCount, 0);
 	const sideCount = Math.floor(visibleCount / 2);
 	const start = Math.min(Math.max(currentIndex - sideCount, 0), maxStart);
-	return sections.slice(start, start + visibleCount).map((section, offset) => ({
-		section,
-		index: start + offset,
-	}));
+	const end = Math.min(start + visibleCount, pageCount);
+	const pages: { index: number; rangeStart: number; rangeEnd: number }[] = [];
+	for (let index = start; index < end; index += 1) {
+		pages.push({
+			index,
+			rangeStart: index * pageSize,
+			rangeEnd: Math.min((index + 1) * pageSize, data.total ?? data.animes.length),
+		});
+	}
+	return pages;
 }
-
-$effect(() => {
-	if (previousAnimeListContextKey === null) {
-		previousAnimeListContextKey = animeListContextKey;
-		return;
-	}
-	if (animeListContextKey !== previousAnimeListContextKey) {
-		previousAnimeListContextKey = animeListContextKey;
-		currentAnimeSectionIndex = 0;
-	}
-});
-
-$effect(() => {
-	const maxIndex = Math.max(animeSections.length - 1, 0);
-	if (currentAnimeSectionIndex > maxIndex) currentAnimeSectionIndex = maxIndex;
-});
 
 function openQuickAdd(e: MouseEvent, anime: AnimeListItem) {
 	e.preventDefault();
@@ -647,38 +622,38 @@ function isAiringToday(anime: AnimeListItem): boolean {
 		</nav>
 
 		{#if data.search}
-			<p class="search-label">「{data.search}」の検索結果 — {data.animes.length}件</p>
+			<p class="search-label">「{data.search}」の検索結果 — {data.total ?? data.animes.length}件</p>
 		{:else if data.genre}
 			<p class="search-label">
 				ジャンル：<strong>{data.genre}</strong>
-				— {data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
+				— {data.total ?? data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
 			</p>
 		{:else if data.season}
 			<p class="search-label">
 				シーズン：<strong>{data.season}</strong>
-				— {data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
+				— {data.total ?? data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
 			</p>
 		{:else if data.broadcastYear || data.broadcastSeason || data.broadcastSeasons?.length}
 			<p class="search-label">
 				放送時期：<strong
 					>{[data.broadcastYear, ...(data.broadcastSeasons?.length ? data.broadcastSeasons : [data.broadcastSeason])].filter(Boolean).join(' ')}</strong
 				>
-				／ {data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
+				／ {data.total ?? data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
 			</p>
 		{:else if data.studio}
 			<p class="search-label">
 				スタジオ：<strong>{data.studio}</strong>
-				— {data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
+				— {data.total ?? data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
 			</p>
 		{:else if data.producer}
 			<p class="search-label">
 				制作：<strong>{data.producer}</strong>
-				— {data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
+				— {data.total ?? data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
 			</p>
 		{:else if data.source}
 			<p class="search-label">
 				原作：<strong>{data.source}</strong>
-				— {data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
+				— {data.total ?? data.animes.length}件 <a href="/anime" class="filter-clear">✕</a>
 			</p>
 		{/if}
 
@@ -705,8 +680,8 @@ function isAiringToday(anime: AnimeListItem): boolean {
 		{:else}
 			<div class="anime-list-surface">
 				<div class="anime-grid">
-					{#each currentAnimeSection.items as anime, sectionItemIndex}
-						{@const rankIndex = currentAnimeSection.start + sectionItemIndex}
+					{#each data.animes as anime, sectionItemIndex}
+						{@const rankIndex = pageStartRank + sectionItemIndex}
 						<a href={buildAnimeDetailUrl(anime.id)} class="anime-card">
 							<div class="anime-cover">
 								{#if anime.cover_url}
@@ -803,12 +778,12 @@ function isAiringToday(anime: AnimeListItem): boolean {
 					{/each}
 				</div>
 
-				{#if animeSections.length > 1}
+				{#if totalPages > 1}
 					<nav class="anime-section-bar" aria-label="50件ごとの表示切り替え">
 						<button
 							type="button"
 							class="anime-section-control"
-							onclick={() => setAnimeSectionIndex(0)}
+							onclick={() => goToAnimePage(0)}
 							disabled={currentAnimeSectionIndex === 0}
 							aria-label="最初の50件"
 						>
@@ -817,7 +792,7 @@ function isAiringToday(anime: AnimeListItem): boolean {
 						<button
 							type="button"
 							class="anime-section-control"
-							onclick={() => setAnimeSectionIndex(currentAnimeSectionIndex - 1)}
+							onclick={() => goToAnimePage(currentAnimeSectionIndex - 1)}
 							disabled={currentAnimeSectionIndex === 0}
 							aria-label="前の50件"
 						>
@@ -828,8 +803,8 @@ function isAiringToday(anime: AnimeListItem): boolean {
 								type="button"
 								class="anime-section-page anime-section-page--desktop"
 								class:active={currentAnimeSectionIndex === page.index}
-								onclick={() => setAnimeSectionIndex(page.index)}
-								aria-label={`${page.section.start + 1}-${page.section.end}件を表示`}
+								onclick={() => goToAnimePage(page.index)}
+								aria-label={`${page.rangeStart + 1}-${page.rangeEnd}件を表示`}
 								aria-current={currentAnimeSectionIndex === page.index ? 'page' : undefined}
 							>
 								{page.index + 1}
@@ -840,8 +815,8 @@ function isAiringToday(anime: AnimeListItem): boolean {
 								type="button"
 								class="anime-section-page anime-section-page--mobile"
 								class:active={currentAnimeSectionIndex === page.index}
-								onclick={() => setAnimeSectionIndex(page.index)}
-								aria-label={`${page.section.start + 1}-${page.section.end}件を表示`}
+								onclick={() => goToAnimePage(page.index)}
+								aria-label={`${page.rangeStart + 1}-${page.rangeEnd}件を表示`}
 								aria-current={currentAnimeSectionIndex === page.index ? 'page' : undefined}
 							>
 								{page.index + 1}
@@ -850,8 +825,8 @@ function isAiringToday(anime: AnimeListItem): boolean {
 						<button
 							type="button"
 							class="anime-section-control"
-							onclick={() => setAnimeSectionIndex(currentAnimeSectionIndex + 1)}
-							disabled={currentAnimeSectionIndex === animeSections.length - 1}
+							onclick={() => goToAnimePage(currentAnimeSectionIndex + 1)}
+							disabled={currentAnimeSectionIndex === totalPages - 1}
 							aria-label="次の50件"
 						>
 							<span aria-hidden="true">›</span>
@@ -859,8 +834,8 @@ function isAiringToday(anime: AnimeListItem): boolean {
 						<button
 							type="button"
 							class="anime-section-control"
-							onclick={() => setAnimeSectionIndex(animeSections.length - 1)}
-							disabled={currentAnimeSectionIndex === animeSections.length - 1}
+							onclick={() => goToAnimePage(totalPages - 1)}
+							disabled={currentAnimeSectionIndex === totalPages - 1}
 							aria-label="最後の50件"
 						>
 							<span aria-hidden="true">»</span>


### PR DESCRIPTION
@
## 概要
監査で最重要ボトルネックだった `/anime` の「毎リクエスト最大1000件をSSRペイロードに載せる」問題（P1）と、それに付随するソート不整合（P2）を修正。

## P1: サーバー側ページネーション
`/anime` は全タブで最大1000件をビューから取得し、9フィールドに射影して丸ごとSSRペイロードに載せていた（クライアントで50件ずつセクション表示）。カタログが育つほど転送・シリアライズ・ビュー評価が線形に悪化。
- **1ページ50件**のサーバー側ページネーションに変更（`?page=N`）。
- `getAnimeListPage` を新設：軽量な候補行（`id/created_at/genre`）で `total` と並び順を確定し、重い一覧列は現在ページ分（~50件）だけ取得。
- ランキング関数（popular/trending/top_rated）に `offset` を追加し `range()` 化、`countAnimeRanking` を追加。
- `getUserAnimeList` にページング引数と `countUserAnimeList` を追加。
- クライアントのセクションページャを**URL駆動**に変更（in-memory スライスを廃止）。

## P2: ソート正しさ
`getAnimeList` は「`created_at DESC LIMIT n` で取得 → JSで人気/急上昇/評価順に並べ替え」だったため、`limit < 総件数` になった瞬間「最新n件の中での人気順」という誤った結果になる潜在バグがあった（従来は limit:1000 が全件を覆い露見せず）。
- 候補ID全件をメトリクス順に並べてからページスライスすることで、DB相当のグローバル順を保証。
- 並べ替えを純関数 `rankAnimeCandidateIds` に切り出し、created/popular/top_rated/ジャンルタイブレークをユニットテスト。
- フィルター適用を `applyAnimeListFilters` に集約（`getAnimeList` の重複を解消）。

## 検証
- `pnpm check`（Biome + svelte-check + tsc）通過
- 全54テスト合格（`rankAnimeCandidateIds` の5ケース新規）
- dev サーバーで実DBに対し確認：
  - 各タブ（all/trending/top_rated/airing/mylist）で 1ページ=50件に削減（従来 最大1000）
  - `?page=2` が次の50件を返し先頭アイテムが変わる、フィルター検索の総件数表示が全一致数（例: 80件）で正しい
  - 範囲外ページ（`page=9999`）は空表示でグレースフル、home/schedule も回帰なし

## 備考
- 候補ID取得は `.limit(2000)` を上限にしており、カタログが2000件を超えた場合の総件数・並び順は将来的にDB側RPC化が必要（現行規模では十分）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@