### PR TITLE
マルチアカウントCookieをHMAC-SHA256で署名 (S6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ PUBLIC_SUPABASE_URL=your-supabase-url
 PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-supabase-publishable-key
 SUPABASE_SECRET_KEY=your-supabase-secret-key
 
+# 任意: マルチアカウント Cookie の HMAC 署名鍵。未設定なら SUPABASE_SECRET_KEY を流用する。
+# 専用のランダム文字列（例: openssl rand -base64 32）を設定するのが望ましい。
+# 変更すると既存の追加アカウント Cookie は失効し、ユーザーは再連携が必要になる。
+MULTI_ACCOUNT_COOKIE_SECRET=
+
 # 管理者メールアドレス（アニメカバー画像アップロード権限）
 ADMIN_EMAIL=your-admin@example.com
 

--- a/src/lib/server/multi-account-no-secret.test.ts
+++ b/src/lib/server/multi-account-no-secret.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+// 署名鍵がどれも設定されていない環境を再現する
+vi.mock("$app/environment", () => ({ dev: true }));
+vi.mock("$env/dynamic/private", () => ({ env: {} }));
+
+import type { Cookies } from "@sveltejs/kit";
+import type { StoredAccount } from "$lib/types";
+import { getExtraAccounts, setExtraAccounts } from "./multi-account";
+
+const COOKIE_NAME = "anipolis_extra_accounts";
+
+function makeCookies(initial?: Record<string, string>): Cookies & { store: Map<string, string> } {
+	const store = new Map<string, string>(Object.entries(initial ?? {}));
+	return {
+		store,
+		get: (name: string) => store.get(name),
+		set: (name: string, value: string) => store.set(name, value),
+		delete: (name: string) => store.delete(name),
+		getAll: () => [...store.entries()].map(([name, value]) => ({ name, value })),
+		serialize: () => "",
+	} as unknown as Cookies & { store: Map<string, string> };
+}
+
+const account: StoredAccount = {
+	userId: "u1",
+	refreshToken: "refresh.u1.token",
+	profile: { username: "alice", display_name: null, avatar_url: null },
+};
+
+describe("multi-account signed cookie（署名鍵なし環境）", () => {
+	it("鍵が無ければ未署名で保存せず Cookie を残さない", () => {
+		const cookies = makeCookies();
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		setExtraAccounts(cookies, [account]);
+		expect(cookies.store.has(COOKIE_NAME)).toBe(false);
+		expect(errSpy).toHaveBeenCalledOnce();
+		errSpy.mockRestore();
+	});
+
+	it("鍵が無ければ既存 Cookie も信用せず空配列を返す", () => {
+		// 有効そうに見える値が入っていても、鍵が無い限り検証不能なので空
+		const cookies = makeCookies({ [COOKIE_NAME]: "cGF5bG9hZA.signature" });
+		expect(getExtraAccounts(cookies)).toEqual([]);
+	});
+});

--- a/src/lib/server/multi-account.test.ts
+++ b/src/lib/server/multi-account.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("$app/environment", () => ({ dev: true }));
+vi.mock("$env/dynamic/private", () => ({ env: { MULTI_ACCOUNT_COOKIE_SECRET: "unit-test-secret-value" } }));
+
+import type { Cookies } from "@sveltejs/kit";
+import type { StoredAccount } from "$lib/types";
+import { getExtraAccounts, setExtraAccounts } from "./multi-account";
+
+const COOKIE_NAME = "anipolis_extra_accounts";
+
+function makeCookies(initial?: Record<string, string>): Cookies & { store: Map<string, string> } {
+	const store = new Map<string, string>(Object.entries(initial ?? {}));
+	return {
+		store,
+		get: (name: string) => store.get(name),
+		set: (name: string, value: string) => store.set(name, value),
+		delete: (name: string) => store.delete(name),
+		getAll: () => [...store.entries()].map(([name, value]) => ({ name, value })),
+		serialize: () => "",
+	} as unknown as Cookies & { store: Map<string, string> };
+}
+
+const account = (userId: string, username: string): StoredAccount => ({
+	userId,
+	refreshToken: `refresh.${userId}.token`,
+	profile: { username, display_name: null, avatar_url: null },
+});
+
+describe("multi-account signed cookie", () => {
+	it("署名して書き込み、検証して読み戻せる（ラウンドトリップ）", () => {
+		const cookies = makeCookies();
+		const accounts = [account("u1", "alice")];
+		setExtraAccounts(cookies, accounts);
+
+		const raw = cookies.store.get(COOKIE_NAME);
+		expect(raw).toBeDefined();
+		expect(raw).toContain("."); // <payload>.<signature>
+		expect(getExtraAccounts(cookies)).toEqual(accounts);
+	});
+
+	it("ペイロード改ざんは検出して空配列を返す", () => {
+		const cookies = makeCookies();
+		setExtraAccounts(cookies, [account("u1", "alice")]);
+		const raw = cookies.store.get(COOKIE_NAME) ?? "";
+		const [payload, sig] = raw.split(".");
+		// 別ユーザーの payload に差し替えて署名は元のまま
+		const forgedPayload = Buffer.from(JSON.stringify([account("attacker", "attacker")])).toString("base64url");
+		cookies.store.set(COOKIE_NAME, `${forgedPayload}.${sig}`);
+		expect(getExtraAccounts(cookies)).toEqual([]);
+		expect(payload).toBeTruthy();
+	});
+
+	it("署名が壊れていれば空配列を返す", () => {
+		const cookies = makeCookies();
+		setExtraAccounts(cookies, [account("u1", "alice")]);
+		const raw = cookies.store.get(COOKIE_NAME) ?? "";
+		const [payload] = raw.split(".");
+		cookies.store.set(COOKIE_NAME, `${payload}.deadbeef`);
+		expect(getExtraAccounts(cookies)).toEqual([]);
+	});
+
+	it("旧形式（未署名の生JSON）は信用せず空配列を返す", () => {
+		const legacy = JSON.stringify([account("u1", "alice")]);
+		const cookies = makeCookies({ [COOKIE_NAME]: legacy });
+		expect(getExtraAccounts(cookies)).toEqual([]);
+	});
+
+	it("追加アカウントは最大2件に制限される", () => {
+		const cookies = makeCookies();
+		setExtraAccounts(cookies, [account("u1", "a"), account("u2", "b"), account("u3", "c")]);
+		const restored = getExtraAccounts(cookies);
+		expect(restored).toHaveLength(2);
+		expect(restored.map((a) => a.userId)).toEqual(["u1", "u2"]);
+	});
+
+	it("空配列を渡すと Cookie を削除する", () => {
+		const cookies = makeCookies();
+		setExtraAccounts(cookies, [account("u1", "alice")]);
+		expect(cookies.store.has(COOKIE_NAME)).toBe(true);
+		setExtraAccounts(cookies, []);
+		expect(cookies.store.has(COOKIE_NAME)).toBe(false);
+	});
+});

--- a/src/lib/server/multi-account.ts
+++ b/src/lib/server/multi-account.ts
@@ -1,5 +1,7 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import type { Cookies } from "@sveltejs/kit";
 import { dev } from "$app/environment";
+import { env } from "$env/dynamic/private";
 import type { StoredAccount } from "$lib/types";
 
 const COOKIE_NAME = "anipolis_extra_accounts";
@@ -11,11 +13,50 @@ const COOKIE_OPTS = {
 	maxAge: 60 * 60 * 24 * 7,
 };
 
+/**
+ * Cookie 署名鍵。専用の MULTI_ACCOUNT_COOKIE_SECRET を優先し、未設定なら
+ * サーバー専用の Supabase シークレットにフォールバックする（新規の必須環境変数を増やさない）。
+ * どれも無ければ空文字を返し、その場合は署名 Cookie を発行・信用しない。
+ */
+function getSigningSecret(): string {
+	return env["MULTI_ACCOUNT_COOKIE_SECRET"] ?? env["SUPABASE_SECRET_KEY"] ?? env["SUPABASE_SERVICE_ROLE_KEY"] ?? "";
+}
+
+function sign(payloadB64: string, secret: string): string {
+	return createHmac("sha256", secret).update(payloadB64).digest("base64url");
+}
+
+/** 署名を定数時間比較で検証する */
+function verify(payloadB64: string, signature: string, secret: string): boolean {
+	const expected = Buffer.from(sign(payloadB64, secret));
+	const actual = Buffer.from(signature);
+	if (expected.length !== actual.length) return false;
+	return timingSafeEqual(expected, actual);
+}
+
+/**
+ * 署名付き Cookie から追加アカウントを取り出す。
+ *
+ * Cookie 値は `<base64url(JSON)>.<HMAC-SHA256 署名>` 形式。改ざん・偽造された値、
+ * および署名鍵未設定時は空配列を返す（未署名データは信用しない）。
+ * リフレッシュトークンを平文で持つため、Cookie 窃取時の被害面を抑える目的での署名検証。
+ * 呼び出し側（api/account-switch）は DB の linked_accounts でも別途リンクを検証している。
+ */
 export function getExtraAccounts(cookies: Cookies): StoredAccount[] {
 	const raw = cookies.get(COOKIE_NAME);
 	if (!raw) return [];
+
+	const secret = getSigningSecret();
+	if (!secret) return [];
+
+	const dotIndex = raw.lastIndexOf(".");
+	if (dotIndex <= 0) return [];
+	const payloadB64 = raw.slice(0, dotIndex);
+	const signature = raw.slice(dotIndex + 1);
+	if (!verify(payloadB64, signature, secret)) return [];
+
 	try {
-		const parsed = JSON.parse(raw);
+		const parsed = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
 		if (!Array.isArray(parsed)) return [];
 		return parsed.filter(
 			(a): a is StoredAccount =>
@@ -34,5 +75,17 @@ export function setExtraAccounts(cookies: Cookies, accounts: StoredAccount[]): v
 		cookies.delete(COOKIE_NAME, { path: "/" });
 		return;
 	}
-	cookies.set(COOKIE_NAME, JSON.stringify(capped), COOKIE_OPTS);
+
+	const secret = getSigningSecret();
+	if (!secret) {
+		// 署名鍵が無い環境では未署名でトークンを保存しない（多重アカウントが永続化されないだけ）
+		console.error(
+			"MULTI_ACCOUNT_COOKIE_SECRET / SUPABASE_SECRET_KEY is not configured; skipping extra-account cookie",
+		);
+		cookies.delete(COOKIE_NAME, { path: "/" });
+		return;
+	}
+
+	const payloadB64 = Buffer.from(JSON.stringify(capped)).toString("base64url");
+	cookies.set(COOKIE_NAME, `${payloadB64}.${sign(payloadB64, secret)}`, COOKIE_OPTS);
 }

--- a/src/lib/server/multi-account.ts
+++ b/src/lib/server/multi-account.ts
@@ -26,12 +26,15 @@ function sign(payloadB64: string, secret: string): string {
 	return createHmac("sha256", secret).update(payloadB64).digest("base64url");
 }
 
-/** 署名を定数時間比較で検証する */
+/**
+ * 署名を定数時間で検証する。
+ * 入力長に依存する早期 return を避けるため、期待値・入力値をそれぞれ再度 HMAC で
+ * 固定長（32バイト）ダイジェスト化してから timingSafeEqual で比較する。
+ */
 function verify(payloadB64: string, signature: string, secret: string): boolean {
-	const expected = Buffer.from(sign(payloadB64, secret));
-	const actual = Buffer.from(signature);
-	if (expected.length !== actual.length) return false;
-	return timingSafeEqual(expected, actual);
+	const expectedDigest = createHmac("sha256", secret).update(sign(payloadB64, secret)).digest();
+	const actualDigest = createHmac("sha256", secret).update(signature).digest();
+	return timingSafeEqual(expectedDigest, actualDigest);
 }
 
 /**
@@ -80,7 +83,7 @@ export function setExtraAccounts(cookies: Cookies, accounts: StoredAccount[]): v
 	if (!secret) {
 		// 署名鍵が無い環境では未署名でトークンを保存しない（多重アカウントが永続化されないだけ）
 		console.error(
-			"MULTI_ACCOUNT_COOKIE_SECRET / SUPABASE_SECRET_KEY is not configured; skipping extra-account cookie",
+			"No signing secret configured (MULTI_ACCOUNT_COOKIE_SECRET / SUPABASE_SECRET_KEY / SUPABASE_SERVICE_ROLE_KEY); skipping extra-account cookie",
 		);
 		cookies.delete(COOKIE_NAME, { path: "/" });
 		return;


### PR DESCRIPTION
@
## 概要
監査 S6 の対応。追加アカウントのリフレッシュトークンを保持する `anipolis_extra_accounts` Cookie を**HMAC-SHA256署名付き**に変更し、改ざん・偽造された値をサーバー側で拒否する。

これまで httpOnly / secure / SameSite=Lax / 7日で妥当な範囲だったが、Cookie値は平文JSONだった。DB側の `linked_accounts` 照合で偽造アカウントへの切替は既に防げていたが、本PRで**Cookie値そのものの完全性**を保証し、窃取・改ざん時の被害面をさらに絞る。

## 変更点
- `getExtraAccounts` / `setExtraAccounts` の内部に署名・検証を追加（**呼び出し側は変更なし**）。Cookie値は `<base64url(JSON)>.<HMAC-SHA256>` 形式。
- 署名鍵は `MULTI_ACCOUNT_COOKIE_SECRET` を優先し、未設定なら `SUPABASE_SECRET_KEY` にフォールバック（新規の必須環境変数を増やさない）。鍵が無い環境では未署名でトークンを保存しない。
- 検証は `timingSafeEqual` による定数時間比較。
- `nodejs_compat` 有効のため `node:crypto`（同期API）を使用し、関数シグネチャは非同期化せず据え置き。
- `.env.example` に `MULTI_ACCOUNT_COOKIE_SECRET`（任意）を追記。

## 互換性・デプロイ時の注意
- **旧形式（未署名の生JSON）Cookieは失効扱い**になり、既存ユーザーは追加アカウントの再連携が一度だけ必要。DB `linked_accounts` での二重検証があるためデータ整合性への影響はなし。
- 本番で専用鍵を使う場合は `MULTI_ACCOUNT_COOKIE_SECRET`（例: `openssl rand -base64 32`）をCloudflareに設定。設定しなければ `SUPABASE_SECRET_KEY` が流用される。

## 検証
- `pnpm check`（Biome + svelte-check + tsc）通過
- 全55テスト合格（ラウンドトリップ / ペイロード改ざん検出 / 署名破損 / 旧形式拒否 / 上限2件 / 空削除の6ケース新規）
- dev サーバーで全ルート200、偽造Cookie送信時もグレースフルに無視（クラッシュなし）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@