### PR TITLE
fix: 実況ルーム検証の再入場処理を明示退出と一時離席で分離

### DIFF
--- a/src/lib/components/room/LiveRoomView.svelte
+++ b/src/lib/components/room/LiveRoomView.svelte
@@ -192,16 +192,25 @@ async function sendRoomExperimentHeartbeat() {
 	}
 }
 
+// 退出ビーコンの送信のみを担う。sessionStorage のキー削除はここでは行わない:
+// アプリ内遷移(onDestroy)や一時的な pagehide でも呼ばれるため、キーを残しておき、
+// 同一タブで戻ってきたときに同じ visit 行を再利用できるようにする。
+// 明示的な退出(退出ボタン→leaveRoom)でのみ clearRoomExperimentVisitKey() でキーを破棄する。
 function sendRoomExperimentExit() {
 	if (!roomExperimentVisitId || roomExperimentExitSent) return;
 	roomExperimentExitSent = true;
 	clearRoomExperimentHeartbeatTimer();
 	const url = `/api/room-experiment-visits/${roomExperimentVisitId}/exit`;
-	const sessionId = data.roomExperiment?.sessionId;
-	if (sessionId) sessionStorage.removeItem(getRoomExperimentVisitStorageKey(sessionId));
 	if (typeof navigator === "undefined") return;
 	if (navigator.sendBeacon?.(url)) return;
 	void fetch(url, { method: "POST", keepalive: true }).catch(() => undefined);
+}
+
+// 明示退出時のみ visit キーを破棄する。次回入場は新しい visit として扱われる。
+// 一時離席(アプリ内遷移)ではキーを残すため、再入場は同じ visit 行に集約される。
+function clearRoomExperimentVisitKey() {
+	const sessionId = data.roomExperiment?.sessionId;
+	if (sessionId) sessionStorage.removeItem(getRoomExperimentVisitStorageKey(sessionId));
 }
 
 function getStayedSeconds() {
@@ -217,6 +226,7 @@ function shouldShowExitSurvey() {
 }
 
 async function leaveRoom() {
+	clearRoomExperimentVisitKey();
 	sendRoomExperimentExit();
 	await goto("/");
 }

--- a/src/lib/server/room-experiment-metrics.test.ts
+++ b/src/lib/server/room-experiment-metrics.test.ts
@@ -102,6 +102,43 @@ describe("calculateRoomExperimentMetrics", () => {
 		expect(room.average_stay_seconds).toBe(20 * 60);
 	});
 
+	it("caps stay by heartbeat count so re-entry away-gaps are excluded", () => {
+		// u1 は約5分(=10ハートビート)滞在 → 一時離席(アプリ内遷移) → 10分後に再入場。
+		// 再入場時の upsert で exited_at が消えるため entered→last_seen のスパンは20分に伸びるが、
+		// heartbeat_count は離席中増えず 10 のまま。離席分を除いた実滞在は約5分。
+		const metrics = calculateRoomExperimentMetrics(
+			{
+				id: "run-1",
+				started_at: runStartedAt,
+				ended_at: null,
+				rooms: [
+					{
+						broadcast_room_session_id: "session-1",
+						room_title: "2026-06-27",
+						scheduled_at: runStartedAt,
+						posting_closes_at: roomClosesAt,
+						visits: [
+							{
+								user_id: "u1",
+								entered_at: "2026-06-27T10:00:00.000Z",
+								last_seen_at: "2026-06-27T10:20:00.000Z",
+								exited_at: "2026-06-27T10:20:00.000Z",
+								heartbeat_count: 10,
+							},
+						],
+						posts: [],
+					},
+				],
+			},
+			new Date("2026-06-27T10:30:00.000Z"),
+			90_000,
+		);
+
+		const room = firstRoom(metrics);
+		// スパンは20分(1200秒)だが、上限 (10 + 1) * 30 = 330秒 が採用され離席10分が除外される。
+		expect(room.average_stay_seconds).toBe(330);
+	});
+
 	it("uses last_seen without early-exit rate when posting close is missing", () => {
 		const metrics = calculateRoomExperimentMetrics({
 			id: "run-1",

--- a/src/lib/server/room-experiment-metrics.ts
+++ b/src/lib/server/room-experiment-metrics.ts
@@ -1,12 +1,15 @@
 export const ROOM_EXPERIMENT_HEARTBEAT_INTERVAL_MS = 30_000;
 export const ROOM_EXPERIMENT_STALE_AFTER_MS = 90_000;
 export const ROOM_EXPERIMENT_BOUNCE_SECONDS = 60;
+export const ROOM_EXPERIMENT_HEARTBEAT_INTERVAL_SECONDS = ROOM_EXPERIMENT_HEARTBEAT_INTERVAL_MS / 1000;
 
 export type ExperimentVisitInput = {
 	user_id: string;
 	entered_at: string;
 	last_seen_at: string;
 	exited_at: string | null;
+	// 実アクティブ秒数の見積もりに使う。未指定なら滞在時間に上限をかけない(従来動作)。
+	heartbeat_count?: number;
 };
 
 export type ExperimentPostCandidate = {
@@ -107,7 +110,15 @@ function visitStaySeconds(visit: ExperimentVisitInput, runEndedMs: number | null
 	if (enteredMs == null) return null;
 	if (!isStayEligible(visit, postingClosesMs)) return null;
 	const endMs = boundedEndMs(visit, runEndedMs, postingClosesMs);
-	return Math.max(0, Math.floor((endMs - enteredMs) / 1000));
+	const spanSeconds = Math.max(0, Math.floor((endMs - enteredMs) / 1000));
+	// 一時離席→再入場では entered→last_seen のスパンに離席時間が混ざる。
+	// ハートビートは離席中は止まり再入場(upsert)でも増えないため、その回数から
+	// 見積もった実アクティブ秒数を上限にして離席分を除外する。
+	// (heartbeat_count + 1) で最後のハートビート以降の端数区間まで含める。
+	// 離席が無い通常の訪問では上限がスパン以上になり、従来どおりスパン値になる。
+	if (visit.heartbeat_count == null) return spanSeconds;
+	const activeCapSeconds = (visit.heartbeat_count + 1) * ROOM_EXPERIMENT_HEARTBEAT_INTERVAL_SECONDS;
+	return Math.min(spanSeconds, activeCapSeconds);
 }
 
 function calculateVisitStats(

--- a/src/lib/server/room-experiments.ts
+++ b/src/lib/server/room-experiments.ts
@@ -40,6 +40,7 @@ type VisitRow = {
 	entered_at: string;
 	last_seen_at: string;
 	exited_at: string | null;
+	heartbeat_count: number;
 	session:
 		| {
 				id: string;
@@ -787,6 +788,7 @@ type EventVisitRow = {
 	entered_at: string;
 	last_seen_at: string;
 	exited_at: string | null;
+	heartbeat_count: number;
 };
 
 type EventPostRow = ExperimentPostCandidate & { event_id: string | null };
@@ -869,7 +871,7 @@ async function getEventRoomExperimentDashboardRuns(
 		supabase.from("events").select("id, title, scheduled_at, duration_minutes, is_cancelled").in("id", eventIds),
 		supabase
 			.from("room_experiment_visits")
-			.select("id, run_id, event_id, user_id, entered_at, last_seen_at, exited_at")
+			.select("id, run_id, event_id, user_id, entered_at, last_seen_at, exited_at, heartbeat_count")
 			.eq("room_kind", "event")
 			.in("run_id", eventRunIds),
 		supabase
@@ -921,6 +923,7 @@ async function getEventRoomExperimentDashboardRuns(
 					entered_at: visit.entered_at,
 					last_seen_at: visit.last_seen_at,
 					exited_at: visit.exited_at,
+					heartbeat_count: visit.heartbeat_count ?? 0,
 				}));
 
 			// filterRoomExperimentPosts はセッションID一致で絞り込むため、イベント投稿では
@@ -1014,7 +1017,7 @@ export async function getRoomExperimentDashboardData(
 		supabase
 			.from("room_experiment_visits")
 			.select(
-				"id, run_id, anime_id, broadcast_room_session_id, user_id, entered_at, last_seen_at, exited_at, session:broadcast_room_sessions!room_experiment_visits_broadcast_room_session_id_fkey ( id, room_date, room_kind, room_key, scheduled_at, posting_closes_at )",
+				"id, run_id, anime_id, broadcast_room_session_id, user_id, entered_at, last_seen_at, exited_at, heartbeat_count, session:broadcast_room_sessions!room_experiment_visits_broadcast_room_session_id_fkey ( id, room_date, room_kind, room_key, scheduled_at, posting_closes_at )",
 			)
 			.in("run_id", runIds),
 		supabase
@@ -1086,6 +1089,7 @@ export async function getRoomExperimentDashboardData(
 				entered_at: visit.entered_at,
 				last_seen_at: visit.last_seen_at,
 				exited_at: visit.exited_at,
+				heartbeat_count: visit.heartbeat_count ?? 0,
 			});
 			visitsBySession.set(session.id, group);
 		}


### PR DESCRIPTION
## 背景

実況ルーム検証(`room_experiment_visits`)で、**アプリ内タブ遷移でも「退出」扱いになり、戻ってくると別 visit として記録される**問題があった。`sendRoomExperimentExit()` が退出ビーコン送信と同時に `sessionStorage` の `client_visit_key` を削除しており、これがSvelteKitのSPA遷移(`onDestroy`)でも発火していたため。

実況中に他ページをちょっと見て戻る、というよくある操作で以下が壊れていた:

- `visit_count` の水増し
- `average_stay_seconds` の分断（1本の滞在が短い前後に割れる）
- `bounce_rate_under_60s` の誤発火（数分いた人の60秒未満の断片が「直帰」に計上）

※ `user_id` は不変のため `unique_visitor_count`(ユニーク人数)は影響なし。

## 変更内容

### 1. 明示退出と一時離席の分離
- `sendRoomExperimentExit()` からキー削除を除去 → 一時離席(`onDestroy`/pagehide)では**キーを残す**
- `clearRoomExperimentVisitKey()` を新設し、明示退出の集約点 `leaveRoom()`（退出ボタン／サーベイ送信・スキップの3経路が通る）でのみキーを破棄
- キーが残るため、同一タブでの再入場は unique index `(run_id, user_id, broadcast_room_session_id, client_visit_key)` に当たり、既存 visit 行を upsert で復活（`exited_at → null`）→ **1訪問に集約**
- ブラウザ戻る/進む(bfcache)は従来どおり `pageshow`/`pagehide` の persisted 分岐で処理（変更なし）

### 2. 離席時間を滞在から除外
再入場で `exited_at` が消え、`entered→last_seen` スパンに離席時間が混ざる問題に対応:
- これまで**未使用**だった `heartbeat_count`（離席中は止まり再入場でも増えない）を実アクティブ秒数の見積もりに利用
- `stay = min(スパン, (heartbeat_count + 1) × 30秒)`
  - 離席なしの通常訪問: 上限がスパン以上 → **従来どおり正確**
  - 再入場した訪問: 離席分を除外
- `ExperimentVisitInput.heartbeat_count` は**任意**。未指定なら上限なし（従来動作）にフォールバック
- ダッシュボードの episode/event 両クエリで `heartbeat_count` を取得しメトリクスへ受け渡し

## テスト
- `pnpm exec svelte-check`: 0 エラー
- 全ユニットテスト: 50 件パス（再入場ギャップ除外の新規テスト追加。1200秒スパン → 上限330秒を検証）
- Biome: 変更ファイル問題なし（`schedule/+page.svelte:534` の警告は本PRと無関係の既存分）

## マイグレーション
不要（`heartbeat_count` カラムは既存。既存の蓄積データにもそのまま効く）。

## 補足（範囲外）
- 精度はハートビート間隔(30秒)粒度。離席なしの一般ケースは正確なので実害なし。
- サーベイ側 `stayed_seconds`（`enteredAt` のリマウントリセット）は本PRでは未対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
