### PR TITLE
[codex] Show event room links in hashtag timelines

### DIFF
--- a/src/lib/server/actions.test.ts
+++ b/src/lib/server/actions.test.ts
@@ -14,7 +14,10 @@ function maybeSingleChain(response: unknown): TableChain {
 	return chain;
 }
 
-function createInsertPostClient(roomAnime: { title: string | null; official_hashtag: string[] | null } | null) {
+function createInsertPostClient(
+	roomAnime: { title: string | null; official_hashtag: string[] | null } | null,
+	eventHashtag: string | null = null,
+) {
 	const insertedPosts: unknown[] = [];
 	const hashtagUpsert = vi.fn(async () => ({ error: null }));
 	const postHashtagUpsert = vi.fn(async () => ({ error: null }));
@@ -32,6 +35,9 @@ function createInsertPostClient(roomAnime: { title: string | null; official_hash
 			}
 			if (table === "broadcast_room_sessions") {
 				return maybeSingleChain({ data: { anime: roomAnime }, error: null });
+			}
+			if (table === "events") {
+				return maybeSingleChain({ data: eventHashtag ? { hashtag: eventHashtag } : null, error: null });
 			}
 			if (table === "posts") {
 				return {
@@ -88,6 +94,36 @@ describe("insertPostWithHashtags", () => {
 		expect(result).toEqual({ success: true, postId: "post-1" });
 		expect(insertedPosts).toContainEqual(expect.objectContaining({ broadcast_room_session_id: "session-1" }));
 		expect(hashtagUpsert).toHaveBeenCalledWith([{ name: "officialtag" }], {
+			onConflict: "name",
+			ignoreDuplicates: true,
+		});
+		expect(postHashtagUpsert).toHaveBeenCalledWith([{ post_id: "post-1", hashtag_id: 1 }], {
+			onConflict: "post_id,hashtag_id",
+			ignoreDuplicates: true,
+		});
+	});
+
+	it("adds the event room-link hashtag to trend metadata", async () => {
+		const { client, hashtagUpsert, postHashtagUpsert, insertedPosts } = createInsertPostClient(null, "#EventRoom");
+
+		const result = await insertPostWithHashtags(
+			client,
+			"user-1",
+			"plain event post",
+			null,
+			[],
+			"123",
+			null,
+			null,
+			null,
+			null,
+			[],
+			"event-1",
+		);
+
+		expect(result).toEqual({ success: true, postId: "post-1" });
+		expect(insertedPosts).toContainEqual(expect.objectContaining({ event_id: "event-1" }));
+		expect(hashtagUpsert).toHaveBeenCalledWith([{ name: "eventroom" }], {
 			onConflict: "name",
 			ignoreDuplicates: true,
 		});

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -38,6 +38,10 @@ type RoomLinkTrendSession = {
 	anime: RoomLinkTrendAnime | RoomLinkTrendAnime[] | null;
 };
 
+type EventLinkTrendRow = {
+	hashtag: string | null;
+};
+
 function fallbackRoomHashtag(title: string) {
 	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
 }
@@ -75,6 +79,22 @@ async function getRoomLinkTrendHashtag(
 
 	const fallback = fallbackRoomHashtag(anime.title ?? "");
 	return fallback ? normalizeHashtagMetadata(fallback) : null;
+}
+
+async function getEventLinkTrendHashtag(
+	supabase: SupabaseClient<Database>,
+	eventId: string | null,
+): Promise<string | null> {
+	if (!eventId) return null;
+
+	const { data, error } = await supabase.from("events").select("hashtag").eq("id", eventId).maybeSingle();
+	if (error || !data) {
+		if (error) console.error("event room link trend hashtag lookup error:", error);
+		return null;
+	}
+
+	const tag = normalizeHashtagMetadata((data as EventLinkTrendRow).hashtag ?? "");
+	return tag.length > 0 ? tag : null;
 }
 
 export function getAnimeExchangeErrorDetail(error: {
@@ -186,7 +206,9 @@ export async function insertPostWithHashtags(
 	const additionalTags = additionalHashtags.map(normalizeHashtagMetadata).filter((tag) => tag.length > 0);
 	const roomLinkTrendHashtag =
 		additionalTags.length === 0 ? await getRoomLinkTrendHashtag(supabase, broadcastRoomSessionId) : null;
-	const roomLinkTags = roomLinkTrendHashtag ? [roomLinkTrendHashtag] : [];
+	const eventLinkTrendHashtag =
+		additionalTags.length === 0 ? await getEventLinkTrendHashtag(supabase, eventId) : null;
+	const roomLinkTags = [roomLinkTrendHashtag, eventLinkTrendHashtag].filter((tag): tag is string => Boolean(tag));
 	const tags = [...new Set([...extractHashtags(postContent), ...additionalTags, ...roomLinkTags])];
 	if (tags.length > 0) {
 		await supabase.from("hashtags").upsert(

--- a/src/routes/events/[id]/+page.server.ts
+++ b/src/routes/events/[id]/+page.server.ts
@@ -106,7 +106,7 @@ export const actions: Actions = {
 			null,
 			null,
 			null,
-			[],
+			[event.hashtag],
 			event.id,
 		);
 	},

--- a/src/routes/hashtag/[tag]/+page.server.ts
+++ b/src/routes/hashtag/[tag]/+page.server.ts
@@ -15,19 +15,51 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 
 	const [postsResult, trendingResult, animeTrending] = await Promise.all([
 		(async () => {
-			if (!hashtag) return { data: [] };
-
-			const { data: links } = await supabase.from("post_hashtags").select("post_id").eq("hashtag_id", hashtag.id);
+			const { data: links } = hashtag
+				? await supabase.from("post_hashtags").select("post_id").eq("hashtag_id", hashtag.id)
+				: { data: [] };
+			const { data: events } = await supabase
+				.from("events")
+				.select("id")
+				.eq("hashtag", tag)
+				.eq("is_cancelled", false);
 
 			const postIds = (links ?? []).map((l) => l.post_id);
-			if (postIds.length === 0) return { data: [] };
+			const eventIds = (events ?? []).map((event) => event.id);
+			if (postIds.length === 0 && eventIds.length === 0) return { data: [] };
 
-			return supabase
-				.from("posts")
-				.select(POSTS_SELECT)
-				.in("id", postIds)
-				.order("created_at", { ascending: false })
-				.limit(50);
+			const [taggedPosts, eventPosts] = await Promise.all([
+				postIds.length > 0
+					? supabase
+							.from("posts")
+							.select(POSTS_SELECT)
+							.in("id", postIds)
+							.order("created_at", { ascending: false })
+							.limit(50)
+					: Promise.resolve({ data: [] }),
+				eventIds.length > 0
+					? supabase
+							.from("posts")
+							.select(POSTS_SELECT)
+							.in("event_id", eventIds)
+							.order("created_at", { ascending: false })
+							.limit(50)
+					: Promise.resolve({ data: [] }),
+			]);
+
+			const postsById = new Map<string, RawPost>();
+			for (const post of [
+				...((taggedPosts.data ?? []) as unknown as RawPost[]),
+				...((eventPosts.data ?? []) as unknown as RawPost[]),
+			]) {
+				postsById.set(post.id, post);
+			}
+
+			return {
+				data: [...postsById.values()]
+					.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+					.slice(0, 50),
+			};
 		})(),
 
 		supabase.rpc("get_trending_hashtags", { limit_count: 10 }),


### PR DESCRIPTION
## Summary
- store event room link hashtags as post hashtag metadata when creating event room posts
- include event room posts matched by `events.hashtag` on hashtag timelines, covering existing posts without metadata backfill
- add a regression test for event room-link hashtag metadata

## Root cause
Trending counts already included event room-link posts through `posts.event_id -> events.hashtag`, but `/hashtag/[tag]` only queried `post_hashtags`, so clicking the trending tag could omit event room posts.

## Validation
- `pnpm.cmd exec biome check src\lib\server\actions.ts src\lib\server\actions.test.ts src\routes\events\[id\]\+page.server.ts src\routes\hashtag\[tag\]\+page.server.ts`
- `pnpm.cmd exec vitest --run src\lib\server\actions.test.ts`
- `pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json`
- `git diff --check -- src\lib\server\actions.ts src\lib\server\actions.test.ts src\routes\events\[id\]\+page.server.ts src\routes\hashtag\[tag\]\+page.server.ts`