### PR TITLE
Support late-night event room times

### DIFF
--- a/src/lib/components/EventSettingsModal.svelte
+++ b/src/lib/components/EventSettingsModal.svelte
@@ -124,6 +124,7 @@ const handleCancelSubmit: SubmitFunction = () => {
 										type="date"
 										name="scheduled_date"
 										required
+										aria-label="開始日"
 										value={eventBroadcastDateInputValue(event.scheduled_at)}
 									>
 									<input
@@ -132,11 +133,12 @@ const handleCancelSubmit: SubmitFunction = () => {
 										name="scheduled_time"
 										required
 										inputmode="numeric"
-										pattern="([01]?[0-9]|2[0-7]):[0-5][0-9]|28:00"
+										pattern="([01]?[0-9]|2[0-7]):[0-5][0-9]"
+										aria-label="開始時刻"
 										value={eventBroadcastTimeInputValue(event.scheduled_at)}
 									>
 								</div>
-								<span class="field-hint">深夜枠は 24:00〜28:00 の形式で入力できます</span>
+								<span class="field-hint">深夜枠は 24:00〜27:59 の形式で入力できます</span>
 							</label>
 							<label>
 								<span>ルームリンク</span>

--- a/src/lib/components/EventSettingsModal.svelte
+++ b/src/lib/components/EventSettingsModal.svelte
@@ -3,6 +3,7 @@ import type { SubmitFunction } from "@sveltejs/kit";
 import { enhance } from "$app/forms";
 import { trapFocus } from "$lib/actions/trapFocus";
 import type { Event } from "$lib/types";
+import { eventBroadcastDateInputValue, eventBroadcastTimeInputValue } from "$lib/utils/event-time";
 
 type EventSettingsEventData = Pick<
 	Event,
@@ -23,22 +24,6 @@ let editError = $state("");
 let confirmingCancel = $state(false);
 let cancelSubmitting = $state(false);
 let cancelError = $state("");
-
-function toDateTimeLocalValue(iso: string): string {
-	// サーバー側は datetime-local を JST として解釈するため、表示も Asia/Tokyo に固定する
-	// (ja-JP + hour12:false は "YYYY/MM/DD HH:mm" 形式を返す)
-	const formatted = new Date(iso).toLocaleString("ja-JP", {
-		timeZone: "Asia/Tokyo",
-		year: "numeric",
-		month: "2-digit",
-		day: "2-digit",
-		hour: "2-digit",
-		minute: "2-digit",
-		hour12: false,
-	});
-	const [datePart, timePart] = formatted.split(" ");
-	return `${datePart?.replaceAll("/", "-")}T${timePart}`;
-}
 
 $effect(() => {
 	if (open) return;
@@ -133,13 +118,25 @@ const handleCancelSubmit: SubmitFunction = () => {
 							</label>
 							<label>
 								<span>開始日時</span>
-								<input
-									class="input"
-									type="datetime-local"
-									name="scheduled_at"
-									required
-									value={toDateTimeLocalValue(event.scheduled_at)}
-								>
+								<div class="event-date-time-row">
+									<input
+										class="input"
+										type="date"
+										name="scheduled_date"
+										required
+										value={eventBroadcastDateInputValue(event.scheduled_at)}
+									>
+									<input
+										class="input"
+										type="text"
+										name="scheduled_time"
+										required
+										inputmode="numeric"
+										pattern="([01]?[0-9]|2[0-7]):[0-5][0-9]|28:00"
+										value={eventBroadcastTimeInputValue(event.scheduled_at)}
+									>
+								</div>
+								<span class="field-hint">深夜枠は 24:00〜28:00 の形式で入力できます</span>
 							</label>
 							<label>
 								<span>ルームリンク</span>
@@ -324,6 +321,11 @@ const handleCancelSubmit: SubmitFunction = () => {
 	font-size: 0.76rem;
 	color: var(--color-text-muted);
 	opacity: 0.8;
+}
+.event-date-time-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 120px;
+	gap: 8px;
 }
 .form-error {
 	margin: 10px 0 0;

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -585,7 +585,7 @@ async function parseEventForm(
 		}
 		scheduledAtIso = eventScheduledAtIsoFromBroadcastInput(scheduledDateRaw, scheduledTimeRaw);
 		if (!scheduledAtIso) {
-			return { ok: false, failure: fail(400, { message: "開始時刻は 00:00〜28:00 の形式で入力してください" }) };
+			return { ok: false, failure: fail(400, { message: "開始時刻は 00:00〜27:59 の形式で入力してください" }) };
 		}
 	}
 	if (!scheduledAtIso) {

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -10,6 +10,7 @@ import { createServiceRoleClient } from "$lib/server/supabase-admin";
 import { publicUrlToStoragePath, validateImageBuffer } from "$lib/server/upload";
 import type { Database, Json } from "$lib/supabase/database.types";
 import type { AnimeExchangeShare, AnimeStatus, BroadcastRoomMuteDuration } from "$lib/types";
+import { eventScheduledAtIsoFromBroadcastInput } from "$lib/utils/event-time";
 import { extractHashtags } from "$lib/utils/hashtag";
 
 const reportStatuses = new Set(["open", "reviewing", "resolved", "rejected"]);
@@ -552,6 +553,8 @@ async function parseEventForm(
 	const description = (form.get("description") as string | null)?.trim() || null;
 	const rawHashtag = (form.get("hashtag") as string | null)?.trim() ?? "";
 	const scheduledAtRaw = (form.get("scheduled_at") as string | null)?.trim() ?? "";
+	const scheduledDateRaw = (form.get("scheduled_date") as string | null)?.trim() ?? "";
+	const scheduledTimeRaw = (form.get("scheduled_time") as string | null)?.trim() ?? "";
 	const durationRaw = (form.get("duration_minutes") as string | null)?.trim() ?? "";
 	const animeIdRaw = (form.get("anime_id") as string | null)?.trim() ?? "";
 	const animeId = animeIdRaw ? parsePositiveInt(animeIdRaw) : null;
@@ -575,14 +578,28 @@ async function parseEventForm(
 		return { ok: false, failure: fail(400, { message: "ルームリンクに使用できない文字が含まれています" }) };
 	}
 
-	if (!scheduledAtRaw) return { ok: false, failure: fail(400, { message: "開始日時を入力してください" }) };
-	// datetime-local はタイムゾーンなしの文字列で届く。サーバーのTZ(本番はUTC)で解釈すると
-	// 9時間ずれるため、オフセットが付いていない場合は JST として明示的にパースする。
-	const hasOffset = /(?:Z|[+-]\d{2}:\d{2})$/.test(scheduledAtRaw);
-	const scheduledAt = new Date(hasOffset ? scheduledAtRaw : `${scheduledAtRaw}+09:00`);
-	if (Number.isNaN(scheduledAt.getTime())) {
-		return { ok: false, failure: fail(400, { message: "開始日時の形式が正しくありません" }) };
+	let scheduledAtIso: string | null = null;
+	if (scheduledDateRaw || scheduledTimeRaw) {
+		if (!scheduledDateRaw || !scheduledTimeRaw) {
+			return { ok: false, failure: fail(400, { message: "開始日と開始時刻を入力してください" }) };
+		}
+		scheduledAtIso = eventScheduledAtIsoFromBroadcastInput(scheduledDateRaw, scheduledTimeRaw);
+		if (!scheduledAtIso) {
+			return { ok: false, failure: fail(400, { message: "開始時刻は 00:00〜28:00 の形式で入力してください" }) };
+		}
 	}
+	if (!scheduledAtIso) {
+		if (!scheduledAtRaw) return { ok: false, failure: fail(400, { message: "開始日時を入力してください" }) };
+		// datetime-local はタイムゾーンなしの文字列で届く。サーバーのTZ(本番はUTC)で解釈すると
+		// 9時間ずれるため、オフセットが付いていない場合は JST として明示的にパースする。
+		const hasOffset = /(?:Z|[+-]\d{2}:\d{2})$/.test(scheduledAtRaw);
+		const scheduledAt = new Date(hasOffset ? scheduledAtRaw : `${scheduledAtRaw}+09:00`);
+		if (Number.isNaN(scheduledAt.getTime())) {
+			return { ok: false, failure: fail(400, { message: "開始日時の形式が正しくありません" }) };
+		}
+		scheduledAtIso = scheduledAt.toISOString();
+	}
+	if (!scheduledAtIso) return { ok: false, failure: fail(400, { message: "開始日時を入力してください" }) };
 
 	const durationMinutes = durationRaw ? parsePositiveInt(durationRaw) : null;
 	if (durationRaw && durationMinutes === null) {
@@ -604,7 +621,7 @@ async function parseEventForm(
 
 	return {
 		ok: true,
-		value: { title, description, hashtag, scheduledAtIso: scheduledAt.toISOString(), durationMinutes, animeId },
+		value: { title, description, hashtag, scheduledAtIso, durationMinutes, animeId },
 	};
 }
 

--- a/src/lib/utils/event-time.ts
+++ b/src/lib/utils/event-time.ts
@@ -21,8 +21,7 @@ export function parseExtendedClockTime(value: string): ExtendedClockTime | null 
 	if (!match) return null;
 	const hour = Number(match[1]);
 	const minute = Number(match[2]);
-	if (hour < 0 || hour > MAX_EXTENDED_HOUR) return null;
-	if (hour === MAX_EXTENDED_HOUR && minute !== 0) return null;
+	if (hour < 0 || hour >= MAX_EXTENDED_HOUR) return null;
 	return { hour, minute };
 }
 

--- a/src/lib/utils/event-time.ts
+++ b/src/lib/utils/event-time.ts
@@ -1,0 +1,70 @@
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const MINUTES_PER_DAY = 24 * 60;
+const LATE_NIGHT_CUTOFF_HOUR = 4;
+const MAX_EXTENDED_HOUR = 28;
+
+export type ExtendedClockTime = {
+	hour: number;
+	minute: number;
+};
+
+function pad2(value: number): string {
+	return String(value).padStart(2, "0");
+}
+
+function utcDateKey(date: Date): string {
+	return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`;
+}
+
+export function parseExtendedClockTime(value: string): ExtendedClockTime | null {
+	const match = value.trim().match(/^(\d{1,2}):([0-5]\d)$/);
+	if (!match) return null;
+	const hour = Number(match[1]);
+	const minute = Number(match[2]);
+	if (hour < 0 || hour > MAX_EXTENDED_HOUR) return null;
+	if (hour === MAX_EXTENDED_HOUR && minute !== 0) return null;
+	return { hour, minute };
+}
+
+export function eventScheduledAtIsoFromBroadcastInput(dateKey: string, timeValue: string): string | null {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) return null;
+	const time = parseExtendedClockTime(timeValue);
+	if (!time) return null;
+
+	const base = new Date(`${dateKey}T00:00:00+09:00`);
+	if (Number.isNaN(base.getTime())) return null;
+	return new Date(base.getTime() + (time.hour * 60 + time.minute) * 60_000).toISOString();
+}
+
+export function eventJstDate(scheduledAtIso: string): Date | null {
+	const date = new Date(scheduledAtIso);
+	if (Number.isNaN(date.getTime())) return null;
+	return new Date(date.getTime() + JST_OFFSET_MS);
+}
+
+export function eventBroadcastDateKey(scheduledAtIso: string): string | null {
+	const jst = eventJstDate(scheduledAtIso);
+	if (!jst) return null;
+	if (jst.getUTCHours() < LATE_NIGHT_CUTOFF_HOUR) jst.setUTCDate(jst.getUTCDate() - 1);
+	return utcDateKey(jst);
+}
+
+export function eventBroadcastMinutes(scheduledAtIso: string): number | null {
+	const jst = eventJstDate(scheduledAtIso);
+	if (!jst) return null;
+	const hour = jst.getUTCHours();
+	const minutes = hour * 60 + jst.getUTCMinutes();
+	return hour < LATE_NIGHT_CUTOFF_HOUR ? minutes + MINUTES_PER_DAY : minutes;
+}
+
+export function eventBroadcastDateInputValue(scheduledAtIso: string): string {
+	return eventBroadcastDateKey(scheduledAtIso) ?? "";
+}
+
+export function eventBroadcastTimeInputValue(scheduledAtIso: string): string {
+	const jst = eventJstDate(scheduledAtIso);
+	if (!jst) return "";
+	const hour = jst.getUTCHours();
+	const displayHour = hour < LATE_NIGHT_CUTOFF_HOUR ? hour + 24 : hour;
+	return `${pad2(displayHour)}:${pad2(jst.getUTCMinutes())}`;
+}

--- a/src/routes/events/[id]/+page.server.ts
+++ b/src/routes/events/[id]/+page.server.ts
@@ -11,6 +11,7 @@ import {
 import { getAnime, getAnimeRankingTrending, getEvent, getEventRoomPosts, isAdminUser } from "$lib/server/queries";
 import { getRoomExitSurveyLoadState, ROOM_EXIT_SURVEY_VERSION } from "$lib/server/room-exit-survey";
 import { createRoomExperimentServiceClient, getActiveRoomExperimentRunForEvent } from "$lib/server/room-experiments";
+import { eventBroadcastDateKey } from "$lib/utils/event-time";
 import type { Actions, PageServerLoad } from "./$types";
 
 const DEFAULT_EVENT_DURATION_MINUTES = 6 * 60;
@@ -40,6 +41,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	const scheduledMs = new Date(event.scheduled_at).getTime();
 	const durationMinutes = event.duration_minutes ?? DEFAULT_EVENT_DURATION_MINUTES;
 	const postingClosesAt = new Date(scheduledMs + durationMinutes * 60 * 1000).toISOString();
+	const roomDate = eventBroadcastDateKey(event.scheduled_at) ?? event.scheduled_at.slice(0, 10);
 
 	return {
 		event,
@@ -47,7 +49,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		anime,
 		room: {
 			session_id: event.id,
-			date: event.scheduled_at.slice(0, 10),
+			date: roomDate,
 			kind: "event" as const,
 			hashtag: event.hashtag,
 			scheduled_at: event.scheduled_at,

--- a/src/routes/schedule/+page.server.ts
+++ b/src/routes/schedule/+page.server.ts
@@ -28,6 +28,7 @@ import {
 	overrideForRoomDate,
 	roomDateKey,
 } from "$lib/utils/broadcast-room";
+import { eventBroadcastDateKey } from "$lib/utils/event-time";
 import type { Actions, PageServerLoad } from "./$types";
 
 interface BroadcastAnnouncement {
@@ -114,6 +115,8 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 	const weekStart = rawWeek < minWeek ? minWeek : rawWeek > maxWeek ? maxWeek : rawWeek;
 	const weekEnd = addDays(weekStart, 7);
 	weekEnd.setMilliseconds(-1);
+	const eventRangeEnd = new Date(weekEnd);
+	eventRangeEnd.setHours(eventRangeEnd.getHours() + 4);
 	const scheduleRange = {
 		start: toDateInputValue(weekStart),
 		end: toDateInputValue(addDays(weekStart, 6)),
@@ -131,7 +134,7 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		eventNotificationSubscriptions,
 	] = await Promise.all([
 		getAnimeList(supabase, { scheduleRange, limit: 1000, userId: user?.id ?? null }),
-		getEventsByRange(supabase, weekStart.toISOString(), weekEnd.toISOString()),
+		getEventsByRange(supabase, weekStart.toISOString(), eventRangeEnd.toISOString()),
 		user ? getBroadcastSubscriptions(supabase, user.id) : Promise.resolve([] as string[]),
 		user
 			? getBroadcastNotificationSettings(supabase, user.id)
@@ -197,8 +200,10 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 	}
 
 	for (const event of events) {
-		const day = new Date(event.scheduled_at).getDay();
-		days[day]?.events.push(event);
+		const date = eventBroadcastDateKey(event.scheduled_at);
+		if (!date || date < scheduleRange.start || date > scheduleRange.end) continue;
+		const day = days.find((candidate) => candidate.date === date);
+		day?.events.push(event);
 	}
 
 	for (const day of days) {
@@ -232,6 +237,8 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		canGoPrev: weekStart > minWeek,
 		canGoNext: weekStart < maxWeek,
 		defaultScheduledAt: `${toDateInputValue(new Date())}T20:00`,
+		defaultEventDate: eventBroadcastDateKey(new Date().toISOString()) ?? toDateInputValue(new Date()),
+		defaultEventTime: "20:00",
 	};
 };
 

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -16,6 +16,7 @@ import {
 	minutesUntilBroadcast as resolveMinutesUntilBroadcast,
 	roomLiveKey,
 } from "$lib/utils/broadcast-room";
+import { eventBroadcastMinutes, eventBroadcastTimeInputValue } from "$lib/utils/event-time";
 import type { ActionData, PageProps } from "./$types";
 
 let { data, form }: PageProps & { form: ActionData } = $props();
@@ -120,20 +121,12 @@ function formatShortDate(value: string): string {
 }
 
 function formatTime(iso: string) {
-	// 放送スケジュールはJST基準のため、閲覧ブラウザのTZに依存させない
-	return new Date(iso).toLocaleTimeString("ja-JP", {
-		timeZone: "Asia/Tokyo",
-		hour: "2-digit",
-		minute: "2-digit",
-	});
+	return eventBroadcastTimeInputValue(iso);
 }
 
 /** イベント開始時刻の JST での「0時からの経過分」。アニメの broadcast_time との時刻順ソートに使う */
 function eventMinutesInJst(iso: string): number {
-	const [hour, minute] = new Date(iso)
-		.toLocaleTimeString("ja-JP", { timeZone: "Asia/Tokyo", hour12: false, hour: "2-digit", minute: "2-digit" })
-		.split(":");
-	return Number(hour) * 60 + Number(minute);
+	return eventBroadcastMinutes(iso) ?? Number.MAX_SAFE_INTEGER;
 }
 
 function openEventDialog() {
@@ -1073,13 +1066,20 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 				</label>
 				<label>
 					<span>開始日時</span>
-					<input
-						class="input"
-						type="datetime-local"
-						name="scheduled_at"
-						required
-						value={data.defaultScheduledAt}
-					>
+					<div class="event-date-time-row">
+						<input class="input" type="date" name="scheduled_date" required value={data.defaultEventDate}>
+						<input
+							class="input"
+							type="text"
+							name="scheduled_time"
+							required
+							inputmode="numeric"
+							pattern="([01]?[0-9]|2[0-7]):[0-5][0-9]|28:00"
+							placeholder="26:00"
+							value={data.defaultEventTime}
+						>
+					</div>
+					<span class="event-field-hint">深夜枠は 24:00〜28:00 の形式で入力できます</span>
 				</label>
 				<label>
 					<span>ルームリンク</span>
@@ -1795,6 +1795,11 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 	font-weight: 400;
 	color: var(--color-text-muted);
 	opacity: 0.8;
+}
+.event-date-time-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 120px;
+	gap: 8px;
 }
 .event-anime-selected,
 .event-anime-result {

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -60,7 +60,7 @@ function getDisplayDayOrder(): number[] {
 
 function getCurrentBroadcastDate(now = new Date()): Date {
 	const date = new Date(now);
-	// Late-night broadcasts through 28:00 (04:00 next day) belong to the previous broadcast date.
+	// Late-night broadcasts before 28:00 (04:00 next day) belong to the previous broadcast date.
 	if (date.getHours() < 4) date.setDate(date.getDate() - 1);
 	return date;
 }
@@ -1067,19 +1067,27 @@ function formatEpisodeBadge(ep: BroadcastEpisodeSlot, total: string | null): str
 				<label>
 					<span>開始日時</span>
 					<div class="event-date-time-row">
-						<input class="input" type="date" name="scheduled_date" required value={data.defaultEventDate}>
+						<input
+							class="input"
+							type="date"
+							name="scheduled_date"
+							required
+							aria-label="開始日"
+							value={data.defaultEventDate}
+						>
 						<input
 							class="input"
 							type="text"
 							name="scheduled_time"
 							required
 							inputmode="numeric"
-							pattern="([01]?[0-9]|2[0-7]):[0-5][0-9]|28:00"
+							pattern="([01]?[0-9]|2[0-7]):[0-5][0-9]"
 							placeholder="26:00"
+							aria-label="開始時刻"
 							value={data.defaultEventTime}
 						>
 					</div>
-					<span class="event-field-hint">深夜枠は 24:00〜28:00 の形式で入力できます</span>
+					<span class="event-field-hint">深夜枠は 24:00〜27:59 の形式で入力できます</span>
 				</label>
 				<label>
 					<span>ルームリンク</span>


### PR DESCRIPTION
## Summary
- allow event creation and editing with broadcast-style late-night times from 24:00 through 28:00
- keep stored event times as real JST instants while deriving the schedule room date from the broadcast date
- show late-night event slots with 24+ time notation and keep event room metadata aligned

## Root cause
The event form used datetime-local, which cannot represent values like 26:00. Entering the real clock time, such as 02:00 the next day, caused the schedule to group the event under the wrong broadcast date.

## Validation
- pnpm.cmd exec svelte-check --tsconfig ./tsconfig.json
- pnpm.cmd exec biome format --write src/lib/utils/event-time.ts src/lib/server/actions.ts src/routes/schedule/+page.server.ts src/routes/schedule/+page.svelte src/lib/components/EventSettingsModal.svelte src/routes/events
- pnpm.cmd exec biome check src/lib/utils/event-time.ts src/lib/server/actions.ts src/routes/schedule/+page.server.ts src/routes/schedule/+page.svelte src/lib/components/EventSettingsModal.svelte src/routes/events