### PR TITLE
Use list icon for my list navigation

### DIFF
--- a/src/lib/components/MobileBottomNav.svelte
+++ b/src/lib/components/MobileBottomNav.svelte
@@ -139,7 +139,12 @@ function isActive(path: string): boolean {
 				stroke-linejoin="round"
 				aria-hidden="true"
 			>
-				<path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+				<path d="M4 6h.01" />
+				<path d="M4 12h.01" />
+				<path d="M4 18h.01" />
+				<path d="M8 6h12" />
+				<path d="M8 12h12" />
+				<path d="M8 18h12" />
 			</svg>
 			<span class="mobile-tab-label">マイリスト</span>
 		</a>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -584,9 +584,12 @@ function isActive(path: string): boolean {
 					stroke-linejoin="round"
 					aria-hidden="true"
 				>
-					<path
-						d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
-					/>
+					<path d="M4 6h.01" />
+					<path d="M4 12h.01" />
+					<path d="M4 18h.01" />
+					<path d="M8 6h12" />
+					<path d="M8 12h12" />
+					<path d="M8 18h12" />
 				</svg>
 				<span class="sidebar-btn-label">マイリスト</span>
 			</a>


### PR DESCRIPTION
## Summary
- Change the mobile bottom navigation my list icon from the bookmark glyph to a three-line list glyph.
- Change the desktop sidebar my list icon to the same list glyph for visual parity.
- Keep bookmark navigation icons unchanged.

## Validation
- `pnpm.cmd exec biome check src/lib/components/MobileBottomNav.svelte src/lib/components/Sidebar.svelte`
- `git diff --check -- src/lib/components/MobileBottomNav.svelte src/lib/components/Sidebar.svelte`

Note: full `svelte-check` was attempted before publishing, but it is currently blocked by existing unrelated `defaultEventDate` / `defaultEventTime` type errors in `src/routes/schedule/+page.svelte`.