### PR TITLE
fix: admin総ユーザー数からトレードプール用ダミーアカウントを除外

### DIFF
--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -975,9 +975,9 @@ export async function getAdminDashboardData(supabase: SupabaseClient<Database>):
 		countRows(supabase, "reports", (query) => query.eq("status", "reviewing")),
 		countRows(supabase, "reports", (query) => query.gte("created_at", today.toISOString())),
 		countRows(supabase, "reports", (query) => query.gte("created_at", weekAgo.toISOString())),
-		countRows(supabase, "profiles", (query) => query.gte("created_at", today.toISOString())),
+		countRealUsers(supabase, (query) => query.gte("created_at", today.toISOString())),
 		countRows(supabase, "posts", (query) => query.gte("created_at", today.toISOString())),
-		countRows(supabase, "profiles"),
+		countRealUsers(supabase),
 		countRows(supabase, "posts"),
 		countRows(supabase, "account_moderation", (query) => query.eq("status", "restricted")),
 		countRows(supabase, "account_moderation", (query) => query.eq("status", "banned")),
@@ -1155,8 +1155,24 @@ async function countRows(
 type CountQuery = {
 	eq: (column: string, value: string) => CountQuery;
 	gte: (column: string, value: string) => CountQuery;
+	not: (column: string, operator: string, value: string) => CountQuery;
 	then: Promise<{ count: number | null }>["then"];
 };
+
+// アニメトレードのプール在庫用に SQL で直接投入されたダミーアカウント
+// （pool_dummy_01〜50）が profiles に存在するため、ユーザー数の集計から
+// username パターンで除外する。
+const DUMMY_USERNAME_PATTERN = "pool_dummy_%";
+
+function countRealUsers(
+	supabase: SupabaseClient<Database>,
+	apply?: (query: CountQuery) => CountQuery,
+): Promise<number> {
+	return countRows(supabase, "profiles", (query) => {
+		const filtered = query.not("username", "like", DUMMY_USERNAME_PATTERN);
+		return apply ? apply(filtered) : filtered;
+	});
+}
 
 function toAdminReport(
 	row: AdminReportRow,


### PR DESCRIPTION
## 概要

adminダッシュボードの総ユーザー数が67人と表示され、実ユーザー数と大きく乖離していた問題の修正です。

## 原因

アニメトレードのプール在庫用にSQLで直接投入されたダミーアカウント `pool_dummy_01`〜`pool_dummy_50` が `profiles` に存在し、実ユーザーと一緒にカウントされていました（ダミーは `anime_exchange_entries` 62件中50件の在庫を保有しているため削除は不可）。

## 変更内容

- `queries.ts` に `countRealUsers()` を追加し、「総ユーザー数」「今日の新規ユーザー」の集計から `username LIKE 'pool_dummy_%'` を除外
- `CountQuery` 型に `not` フィルタを追加

## 変更後の表示

総ユーザー数: 67 → **14**（実ユーザー13 + devアカウント）

## あわせて実施したDB側の作業（コード外・実施済み）

- 旧デモseedアカウント3件（animetaro / jikkyohanako / kamianime_jiro、`demo_data.sql` 由来）を `auth.users` から削除
- SQL直接INSERT由来でGoTrueが読めなかった pool_dummy 50行のNULLカラム（confirmation_token 等4カラム）を空文字に修復し、`auth.admin.listUsers` の500エラーを解消

## 検証

- `pnpm check`（Biome + svelte-check + tsc）エラーなし
- 本番DBに対して除外後カウントが14になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)