### PR TITLE
Syobocal as the sole source of truth for calendar and broadcast rooms

### DIFF
--- a/.github/workflows/syobocal-sync.yml
+++ b/.github/workflows/syobocal-sync.yml
@@ -1,15 +1,18 @@
 name: Syobocal sync
 
 # Keeps broadcast rooms and catalog mappings fresh:
-# - daily: program-table sync for the current season (time changes, cancelled
-#   slots and rescheduled episodes are absorbed by the importer's update/delete
+# - daily: program-table sync (catalog-wide mappings, rolling window; time
+#   changes and cancelled slots are absorbed by the importer's update/delete
 #   logic; channel selection sticks to the earliest terrestrial airing).
-# - weekly: full season import + catalog resolve (new titles, new mappings via
-#   the exact/reading matchers, official URLs).
+# - weekly: MAL + Jikan + Syobocal imports and catalog resolve for the current
+#   AND next season, so late-added MAL entries (e.g. announced mid-season) and
+#   their official links are picked up automatically. Jikan runs against the
+#   public API here; persistent 504s can be backfilled manually via the
+#   self-hosted instance (scripts/local/enrich-jikan-links.ts).
 #
 # Requires repository Actions secrets:
-#   PUBLIC_SUPABASE_URL, SUPABASE_SECRET_KEY
-# and migration 114 applied to the database.
+#   PUBLIC_SUPABASE_URL, SUPABASE_SECRET_KEY, MAL_CLIENT_ID
+# and migrations 114 + 115 applied to the database.
 
 on:
   schedule:
@@ -31,10 +34,11 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 75
     env:
       PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
       SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+      MAL_CLIENT_ID: ${{ secrets.MAL_CLIENT_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -44,27 +48,35 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      - name: Determine current season (JST)
+      - name: Determine current and next season (JST)
         id: season
         run: |
           MONTH=$(TZ=Asia/Tokyo date +%-m)
           YEAR=$(TZ=Asia/Tokyo date +%Y)
-          if [ "$MONTH" -le 3 ]; then SEASON=winter
-          elif [ "$MONTH" -le 6 ]; then SEASON=spring
-          elif [ "$MONTH" -le 9 ]; then SEASON=summer
-          else SEASON=fall; fi
+          if [ "$MONTH" -le 3 ]; then SEASON=winter; NEXT=spring; NEXT_YEAR=$YEAR
+          elif [ "$MONTH" -le 6 ]; then SEASON=spring; NEXT=summer; NEXT_YEAR=$YEAR
+          elif [ "$MONTH" -le 9 ]; then SEASON=summer; NEXT=fall; NEXT_YEAR=$YEAR
+          else SEASON=fall; NEXT=winter; NEXT_YEAR=$((YEAR + 1)); fi
           echo "year=$YEAR" >> "$GITHUB_OUTPUT"
           echo "season=$SEASON" >> "$GITHUB_OUTPUT"
-          echo "Current season: $YEAR-$SEASON"
+          echo "next_year=$NEXT_YEAR" >> "$GITHUB_OUTPUT"
+          echo "next_season=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Current season: $YEAR-$SEASON / next: $NEXT_YEAR-$NEXT"
 
       - name: Sync program table (daily)
         if: github.event.schedule == '15 20 * * *' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'sync-programs')
         run: pnpm sync:syobocal-programs -- --year ${{ steps.season.outputs.year }} --season ${{ steps.season.outputs.season }}
 
-      - name: Full season import (weekly)
+      - name: Weekly imports and resolve (current + next season)
         if: github.event.schedule == '15 19 * * 0' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full-import')
-        run: pnpm import:syobocal -- --year ${{ steps.season.outputs.year }} --season ${{ steps.season.outputs.season }}
-
-      - name: Resolve catalog (weekly)
-        if: github.event.schedule == '15 19 * * 0' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full-import')
-        run: pnpm resolve:anime-catalog -- --year ${{ steps.season.outputs.year }} --season ${{ steps.season.outputs.season }}
+        run: |
+          for TARGET in \
+            "${{ steps.season.outputs.year }} ${{ steps.season.outputs.season }}" \
+            "${{ steps.season.outputs.next_year }} ${{ steps.season.outputs.next_season }}"; do
+            set -- $TARGET
+            echo "=== $1-$2 ==="
+            pnpm import:mal -- --year "$1" --season "$2" || echo "MAL import for $1-$2 failed; continuing"
+            pnpm import:jikan -- --year "$1" --season "$2" || echo "Jikan import for $1-$2 failed; continuing"
+            pnpm import:syobocal -- --year "$1" --season "$2"
+            pnpm resolve:anime-catalog -- --year "$1" --season "$2"
+          done

--- a/.github/workflows/syobocal-sync.yml
+++ b/.github/workflows/syobocal-sync.yml
@@ -27,6 +27,9 @@ on:
         required: false
         default: "sync-programs"
 
+permissions:
+  contents: read
+
 concurrency:
   group: syobocal-sync
   cancel-in-progress: false

--- a/.github/workflows/syobocal-sync.yml
+++ b/.github/workflows/syobocal-sync.yml
@@ -38,12 +38,13 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     timeout-minutes: 75
-    env:
-      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
-      SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
-      MAL_CLIENT_ID: ${{ secrets.MAL_CLIENT_ID }}
     steps:
+      # persist-credentials: false — トークンを.git/configに残さない。
+      # Supabase等の資格情報はjobレベルではなく必要なステップにだけ渡す
+      # （pnpm installのpostinstallスクリプト等に秘匿値を見せない）。
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -68,10 +69,17 @@ jobs:
 
       - name: Sync program table (daily)
         if: github.event.schedule == '15 20 * * *' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'sync-programs')
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
         run: pnpm sync:syobocal-programs -- --year ${{ steps.season.outputs.year }} --season ${{ steps.season.outputs.season }}
 
       - name: Weekly imports and resolve (current + next season)
         if: github.event.schedule == '15 19 * * 0' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full-import')
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+          MAL_CLIENT_ID: ${{ secrets.MAL_CLIENT_ID }}
         run: |
           for TARGET in \
             "${{ steps.season.outputs.year }} ${{ steps.season.outputs.season }}" \

--- a/scripts/import-mal-season.ts
+++ b/scripts/import-mal-season.ts
@@ -26,6 +26,7 @@ const MAL_FIELDS = [
 	"media_type",
 	"status",
 	"num_episodes",
+	"average_episode_duration",
 	"start_season",
 	"broadcast",
 	"source",
@@ -66,6 +67,7 @@ type MalAnimeNode = {
 	media_type?: string;
 	status?: string;
 	num_episodes?: number;
+	average_episode_duration?: number;
 	start_season?: { year?: number; season?: string };
 	broadcast?: { day_of_the_week?: string; start_time?: string };
 	source?: string;
@@ -82,6 +84,8 @@ type MalNormalizedData = {
 	title_en?: string;
 	title_romaji?: string;
 	episode_count?: string;
+	/** 1話あたりの実尺（分）。総合ロビー自動判定のソース。 */
+	episode_duration_minutes?: number;
 	type?: string;
 	source?: string;
 	aired_from?: string;
@@ -327,6 +331,9 @@ function mapMalAnime(anime: MalAnimeNode, year: number, season: SeasonName): Mal
 	if (titleEn) normalized.title_en = titleEn;
 	if (titleRomaji) normalized.title_romaji = titleRomaji;
 	if (anime.num_episodes) normalized.episode_count = String(anime.num_episodes);
+	if (anime.average_episode_duration && anime.average_episode_duration > 0) {
+		normalized.episode_duration_minutes = Math.round(anime.average_episode_duration / 60);
+	}
 	const type = MEDIA_TYPE_LABELS[anime.media_type ?? ""];
 	if (type) normalized.type = type;
 	const sourceLabel = humanizeMalSource(anime.source);

--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -597,6 +597,61 @@ async function readManualMappings(): Promise<ManualMapping[]> {
 	});
 }
 
+type ProgramSyncMapping = {
+	malId: number;
+	tid: number;
+	validFrom: string | null;
+	validTo: string | null;
+};
+
+// Every confirmed primary Syobocal mapping in the catalog, regardless of
+// season: the program sync follows these so the calendar and rooms are driven
+// by Syobocal alone.
+async function fetchAllPrimaryMappings(
+	supabase: ReturnType<typeof getSupabaseClient>,
+	dryRun: boolean,
+): Promise<ProgramSyncMapping[]> {
+	const rows: ProgramSyncMapping[] = [];
+	for (let start = 0; ; start += DATABASE_BATCH_SIZE) {
+		const { data, error } = await supabase
+			.from("anime_external_mappings")
+			.select("mal_id,external_key,valid_from,valid_to")
+			.eq("external_source", "syobocal")
+			.eq("is_primary", true)
+			.eq("match_status", "confirmed")
+			.order("mal_id", { ascending: true })
+			.range(start, start + DATABASE_BATCH_SIZE - 1);
+		if (error) {
+			if (dryRun && (error.code === "42P01" || error.code === "PGRST205")) return [];
+			throw new Error(`Could not read catalog-wide Syobocal mappings: ${error.message}`);
+		}
+		for (const row of data ?? []) {
+			const record = row as Record<string, unknown>;
+			const tid = Number.parseInt(String(record["external_key"] ?? ""), 10);
+			if (!Number.isSafeInteger(tid) || tid <= 0) continue;
+			rows.push({
+				malId: Number(record["mal_id"]),
+				tid,
+				validFrom: (record["valid_from"] as string | null) ?? null,
+				validTo: (record["valid_to"] as string | null) ?? null,
+			});
+		}
+		if (!data || data.length < DATABASE_BATCH_SIZE) break;
+	}
+	return rows;
+}
+
+function mergeProgramSyncMappings(
+	selected: readonly ProgramSyncMapping[],
+	catalogWide: readonly ProgramSyncMapping[],
+): ProgramSyncMapping[] {
+	const byMal = new Map<number, ProgramSyncMapping>();
+	for (const mapping of catalogWide) byMal.set(mapping.malId, mapping);
+	// This run's freshly selected mappings supersede stored rows for their MAL ids.
+	for (const mapping of selected) byMal.set(mapping.malId, mapping);
+	return [...byMal.values()];
+}
+
 async function fetchExistingMappings(
 	supabase: ReturnType<typeof getSupabaseClient>,
 	malIds: number[],
@@ -1200,7 +1255,7 @@ async function fetchAnimeRoomRows(supabase: ReturnType<typeof getSupabaseClient>
 
 function buildBroadcastRoomSessionRows(
 	animeRows: AnimeRoomRow[],
-	mappings: MappingProposal[],
+	mappings: readonly ProgramSyncMapping[],
 	titles: SyobocalTitle[],
 	channels: SyobocalChannel[],
 	programs: SyobocalProgram[],
@@ -1402,24 +1457,43 @@ async function main() {
 	);
 	for (const line of mapping.review) console.warn(`REVIEW: ${line}`);
 
+	const titleByTid = new Map(titles.map((title) => [title.tid, title] as const));
 	const selectedTitleByTid = new Map(
 		mapping.selected.flatMap((proposal) => {
-			const title = titles.find((candidate) => candidate.tid === proposal.tid);
+			const title = titleByTid.get(proposal.tid);
 			return title ? [[proposal.tid, title] as const] : [];
 		}),
 	);
+	// Syobocal is the source of truth for the calendar and rooms: program slots
+	// are synced for every confirmed primary mapping in the catalog, not just
+	// the imported season, so continuing shows keep their schedule and shows
+	// without current Syobocal programs disappear naturally.
+	const programMappings: ProgramSyncMapping[] = options.syncPrograms
+		? mergeProgramSyncMappings(mapping.selected, await fetchAllPrimaryMappings(supabase, options.dryRun))
+		: mapping.selected;
+	const programTids = [...new Set(programMappings.map((entry) => entry.tid))].filter((tid) => titleByTid.has(tid));
 	const titlesToStore = [
-		...new Map([...seasonalTitles, ...selectedTitleByTid.values()].map((title) => [title.tid, title])).values(),
+		...new Map(
+			[
+				...seasonalTitles,
+				...selectedTitleByTid.values(),
+				...programTids.flatMap((tid) => {
+					const title = titleByTid.get(tid);
+					return title ? [title] : [];
+				}),
+			].map((title) => [title.tid, title]),
+		).values(),
 	];
 	let programs: SyobocalProgram[] = [];
 	let channels: SyobocalChannel[] = [];
-	const programRange = options.syncPrograms ? rollingSyobocalProgramRange(range.startDate, range.endDate) : null;
-	if (options.syncPrograms && !programRange) {
-		console.log(`${season} is outside the rolling program window; no Syobocal program rows will be fetched.`);
-	}
-	if (programRange && mapping.selected.length > 0) {
-		console.log(`Program sync range: ${programRange.startDate} through ${programRange.endDate} (end exclusive).`);
-		programs = await fetchPrograms([...selectedTitleByTid.keys()], programRange.apiRange);
+	// The program window is purely rolling (yesterday through +91 days): with
+	// catalog-wide mappings the season clamp would wrongly cut continuing shows.
+	const programRange = options.syncPrograms ? rollingSyobocalProgramRange("1900-01-01", "2999-12-31") : null;
+	if (programRange && programMappings.length > 0) {
+		console.log(
+			`Program sync range: ${programRange.startDate} through ${programRange.endDate} (end exclusive) for ${programTids.length} mapped titles.`,
+		);
+		programs = await fetchPrograms(programTids, programRange.apiRange);
 		const allChannels = await fetchChannels();
 		const usedChids = new Set(programs.map((program) => program.chid));
 		channels = allChannels.filter((channel) => usedChids.has(channel.chid));
@@ -1427,15 +1501,15 @@ async function main() {
 		if (missingChids.length > 0) throw new Error(`Missing Syobocal channels: ${missingChids.join(", ")}`);
 	}
 	const animeRoomRows = programRange
-		? await fetchAnimeRoomRows(
-				supabase,
-				mapping.selected.map((proposal) => proposal.malId),
-			)
+		? await fetchAnimeRoomRows(supabase, [...new Set(programMappings.map((proposal) => proposal.malId))])
 		: [];
 	const roomSessionRows = buildBroadcastRoomSessionRows(
 		animeRoomRows,
-		mapping.selected,
-		[...selectedTitleByTid.values()],
+		programMappings,
+		programTids.flatMap((tid) => {
+			const title = titleByTid.get(tid);
+			return title ? [title] : [];
+		}),
 		channels,
 		programs,
 		importedAt,

--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -140,7 +140,9 @@ type MappingProposal = {
 const VALID_SEASONS = new Set<SeasonName>(["winter", "spring", "summer", "fall"]);
 const DATABASE_BATCH_SIZE = 100;
 const WIKIDATA_BATCH_SIZE = 100;
-const PROGRAM_TID_BATCH_SIZE = 10;
+// Catalog-wide program sync queries ~1,800 TIDs; large batches with a gentle
+// interval keep the request count low enough for Syobocal's rate limit.
+const PROGRAM_TID_BATCH_SIZE = 50;
 const SYOBOCAL_ENDPOINT = "https://cal.syoboi.jp/db.php";
 const JAPANESE_WIKIPEDIA_ENDPOINT = "https://ja.wikipedia.org/w/api.php";
 const WIKIDATA_ENDPOINT = "https://query.wikidata.org/sparql";
@@ -318,6 +320,9 @@ function responseItems(payload: unknown, responseKey: string, itemsKey: string, 
 	const response = asRecord(asRecord(payload)[responseKey]);
 	const result = asRecord(response["Result"]);
 	const code = textValue(result, "Code");
+	// 404 means "no rows matched" (e.g. a program lookup for titles with no
+	// slots in the range), which is a normal empty result, not a failure.
+	if (code === "404") return [];
 	if (code && code !== "200") throw new Error(`Syobocal returned ${code}: ${textValue(result, "Message") ?? ""}`);
 	return asArray(asRecord(response[itemsKey])[itemKey]).map(asRecord);
 }
@@ -456,7 +461,7 @@ async function fetchPrograms(tids: number[], range: string): Promise<SyobocalPro
 		console.log(
 			`Syobocal programs fetched for ${Math.min(start + batch.length, tids.length)}/${tids.length} TIDs.`,
 		);
-		await sleep(250);
+		await sleep(1000);
 	}
 	return [...new Map(programs.map((program) => [program.pid, program])).values()];
 }

--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -148,7 +148,7 @@ const DATABASE_BATCH_SIZE = 100;
 const WIKIDATA_BATCH_SIZE = 100;
 // Catalog-wide program sync queries ~1,800 TIDs; large batches with a gentle
 // interval keep the request count low enough for Syobocal's rate limit.
-const PROGRAM_TID_BATCH_SIZE = 50;
+const PROGRAM_TID_BATCH_SIZE = 100;
 const SYOBOCAL_ENDPOINT = "https://cal.syoboi.jp/db.php";
 const JAPANESE_WIKIPEDIA_ENDPOINT = "https://ja.wikipedia.org/w/api.php";
 const WIKIDATA_ENDPOINT = "https://query.wikidata.org/sparql";
@@ -289,6 +289,11 @@ async function fetchWithRetry(url: URL, accept: string): Promise<Response> {
 				throw new Error(`${response.status} ${response.statusText}`);
 			}
 			lastError = new Error(`${response.status} ${response.statusText}`);
+			// Rate limiting needs a real cool-down, not a sub-second retry.
+			if (response.status === 429 && attempt < 4) {
+				await sleep(30_000 * attempt);
+				continue;
+			}
 		} catch (error) {
 			lastError = error;
 		}
@@ -1486,7 +1491,11 @@ async function main() {
 	const programMappings: ProgramSyncMapping[] = options.syncPrograms
 		? mergeProgramSyncMappings(mapping.selected, await fetchAllPrimaryMappings(supabase, options.dryRun))
 		: mapping.selected;
-	const programTids = [...new Set(programMappings.map((entry) => entry.tid))].filter((tid) => titleByTid.has(tid));
+	// Sorted for stable batch composition, so the per-batch response cache hits
+	// across reruns of the same day.
+	const programTids = [...new Set(programMappings.map((entry) => entry.tid))]
+		.filter((tid) => titleByTid.has(tid))
+		.sort((left, right) => left - right);
 	const titlesToStore = [
 		...new Map(
 			[

--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -13,6 +13,8 @@ import {
 	findSyobocalOfficialXUrl,
 	findSyobocalWikipediaArticleLinks,
 	findSyobocalWikipediaKeywordLinks,
+	kanaFoldTitle,
+	latinFoldTitle,
 	matchSyobocalTitlesByReading,
 	matchSyobocalTitlesExactly,
 	normalizeSyobocalTitle,
@@ -1036,21 +1038,36 @@ function buildMappings(
 	});
 
 	// Reading/Latin second-tier matches: only for MAL entries and TIDs that no
-	// higher-confidence proposal already claims.
-	const claimedMalIds = new Set(
-		[...exactProposals, ...wikipediaProposals, ...wikidataProposals, ...existingManual, ...fileManual].map(
-			(proposal) => proposal.malId,
-		),
-	);
-	const claimedTids = new Set(
-		[...exactProposals, ...wikipediaProposals, ...wikidataProposals, ...existingManual, ...fileManual].map(
-			(proposal) => proposal.tid,
-		),
-	);
+	// higher-confidence proposal already claims. Proposals whose TID is missing
+	// from the title snapshot never reach `selected`, so they must not block a
+	// reading match for the same MAL entry.
+	const effectiveSeeds = [
+		...exactProposals,
+		...wikipediaProposals,
+		...wikidataProposals,
+		...existingManual,
+		...fileManual,
+	].filter((proposal) => titlesByTid.has(proposal.tid));
+	const claimedMalIds = new Set(effectiveSeeds.map((proposal) => proposal.malId));
+	const claimedTids = new Set(effectiveSeeds.map((proposal) => proposal.tid));
+	// The evidence must name the candidate title that actually matched; a MAL id
+	// can carry several title candidates (ODbL synonyms), so resolve via the
+	// match key instead of the last-one-wins candidatesByMal map.
+	const candidateMatchKeys = (candidate: CatalogCandidate): Set<string> => {
+		const keys = new Set<string>();
+		const kana = kanaFoldTitle(candidate.title);
+		if (kana.length >= 3) keys.add(`kana:${kana}`);
+		const latin = latinFoldTitle(candidate.title);
+		if (latin) keys.add(`latin:${latin}`);
+		return keys;
+	};
 	const readingProposals: MappingProposal[] = matchSyobocalTitlesByReading(candidates, matchingTitles).flatMap(
 		(match) => {
 			if (claimedMalIds.has(match.malId) || claimedTids.has(match.tid)) return [];
-			const candidate = candidatesByMal.get(match.malId);
+			const candidate =
+				candidates.find(
+					(value) => value.malId === match.malId && candidateMatchKeys(value).has(match.matchKey),
+				) ?? candidatesByMal.get(match.malId);
 			const title = titlesByTid.get(match.tid);
 			return [
 				{

--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -454,7 +454,7 @@ async function fetchPrograms(tids: number[], range: string): Promise<SyobocalPro
 	for (let start = 0; start < tids.length; start += PROGRAM_TID_BATCH_SIZE) {
 		const batch = tids.slice(start, start + PROGRAM_TID_BATCH_SIZE);
 		// A joined TID list exceeds Windows path limits at this batch size; hash it.
-		const batchKey = createHash("sha1").update(batch.join(",")).digest("hex").slice(0, 16);
+		const batchKey = createHash("sha256").update(batch.join(",")).digest("hex").slice(0, 16);
 		const cacheName = `programs/${range}-${batchKey}.xml`;
 		const payload = await readCachedXml(
 			"ProgLookup",

--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createClient } from "@supabase/supabase-js";
@@ -18,7 +19,12 @@ import {
 	parseSyobocalLinks,
 	type SyobocalWikipediaArticleLink,
 } from "../src/lib/syobocal.ts";
-import { jstDate, rollingSyobocalProgramRange, selectPrimarySyobocalPrograms } from "../src/lib/syobocal-schedule.ts";
+import {
+	jstBroadcastDate,
+	jstDate,
+	rollingSyobocalProgramRange,
+	selectPrimarySyobocalPrograms,
+} from "../src/lib/syobocal-schedule.ts";
 
 type SeasonName = "winter" | "spring" | "summer" | "fall";
 type SourceName = AnimeCatalogSeasonSource | "manual" | "wikidata" | "syobocal";
@@ -442,7 +448,9 @@ async function fetchPrograms(tids: number[], range: string): Promise<SyobocalPro
 	const programs: SyobocalProgram[] = [];
 	for (let start = 0; start < tids.length; start += PROGRAM_TID_BATCH_SIZE) {
 		const batch = tids.slice(start, start + PROGRAM_TID_BATCH_SIZE);
-		const cacheName = `programs/${range}-${batch.join("-")}.xml`;
+		// A joined TID list exceeds Windows path limits at this batch size; hash it.
+		const batchKey = createHash("sha1").update(batch.join(",")).digest("hex").slice(0, 16);
+		const cacheName = `programs/${range}-${batchKey}.xml`;
 		const payload = await readCachedXml(
 			"ProgLookup",
 			{ TID: batch.join(","), Range: range, JOIN: "SubTitles" },
@@ -1282,7 +1290,9 @@ function buildBroadcastRoomSessionRows(
 		const postCloseMinutes = anime.broadcast_room_post_close_minutes ?? 30;
 		const postingOpensAt = startsAt - preOpenMinutes * 60_000;
 		if (postingOpensAt <= now) return [];
-		const roomDate = jstDate(program.startsAt);
+		// 深夜アニメ慣習: 4時前の枠は前日の放送日として room_date を振る
+		// （overrides / ensure_broadcast_room_session と同じ基準）
+		const roomDate = jstBroadcastDate(program.startsAt);
 		return [
 			{
 				anime_id: anime.id,

--- a/scripts/resolve-anime-catalog.ts
+++ b/scripts/resolve-anime-catalog.ts
@@ -442,6 +442,55 @@ async function syncResolvedRelations(
 	if (malIds.length > 0) console.log(`Resolved ${relationRows.length} relations for ${malIds.length} anime.`);
 }
 
+// 総合ロビー自動判定: MAL公式APIの1話実尺が15分以下の作品はエピソードルームでは
+// なく総合ロビーを使う。管理者が手動設定した作品（room_type_source='manual'）と、
+// 実尺が取得できていない作品には触れない。
+const SHORT_ANIME_LOBBY_MINUTES = 15;
+
+async function applyShortAnimeLobbyRule(
+	supabase: ReturnType<typeof getSupabaseClient>,
+	resolutions: AnimeCatalogResolution[],
+	recordsByMalId: Map<number, SourceRecordRow[]>,
+) {
+	const malIds = resolutions.map((resolution) => resolution.canonical.mal_id);
+	type RoomTypeRow = { mal_id: number; room_type: string | null; room_type_source: string | null };
+	const rows: RoomTypeRow[] = [];
+	for (let start = 0; start < malIds.length; start += BATCH_SIZE) {
+		const { data, error } = await supabase
+			.from("anime")
+			.select("mal_id,room_type,room_type_source")
+			.in("mal_id", malIds.slice(start, start + BATCH_SIZE));
+		if (error) {
+			// Migration 115 (room_type_source) not applied yet: skip the rule.
+			console.warn(`Short-anime lobby rule skipped (apply migration 115 first): ${error.message}`);
+			return;
+		}
+		rows.push(...((data ?? []) as unknown as RoomTypeRow[]));
+	}
+	const currentByMal = new Map(rows.map((row) => [row.mal_id, row]));
+	let applied = 0;
+	for (const resolution of resolutions) {
+		const malId = resolution.canonical.mal_id;
+		const mal = (recordsByMalId.get(malId) ?? []).find((record) => record.source === "mal");
+		const normalized =
+			mal && mal.normalized_data !== null && typeof mal.normalized_data === "object"
+				? (mal.normalized_data as Record<string, unknown>)
+				: null;
+		const duration = normalized?.["episode_duration_minutes"];
+		if (typeof duration !== "number" || duration <= 0) continue;
+		const current = currentByMal.get(malId);
+		if (current?.room_type_source === "manual") continue;
+		const autoRoomType = duration <= SHORT_ANIME_LOBBY_MINUTES ? "global" : "episode";
+		if (current && current.room_type !== autoRoomType) {
+			const canonical = resolution.canonical as unknown as Record<string, unknown>;
+			canonical["room_type"] = autoRoomType;
+			canonical["room_type_source"] = "auto";
+			applied += 1;
+		}
+	}
+	if (applied > 0) console.log(`Short-anime lobby rule reclassified ${applied} rows.`);
+}
+
 async function main() {
 	const options = parseArgs(process.argv.slice(2));
 	const season = `${options.year}-${options.season}`;
@@ -466,6 +515,7 @@ async function main() {
 			studioMappings.get(normalizeStudioAlias(name)),
 		),
 	);
+	await applyShortAnimeLobbyRule(supabase, resolutions, recordsByMalId);
 	const counts = resolutions.reduce(
 		(result, resolution) => {
 			result[resolution.resolutionStatus] += 1;

--- a/scripts/resolve-anime-catalog.ts
+++ b/scripts/resolve-anime-catalog.ts
@@ -134,6 +134,10 @@ const LEGACY_COLUMNS = [
 	"resources",
 	"cover_url",
 	"metadata_ready",
+	// applyShortAnimeLobbyRuleが全canonical行に注入するため、changedFieldsの
+	// 差分比較でノイズにならないよう既存値も読み込む
+	"room_type",
+	"room_type_source",
 ].join(",");
 
 function parseArgs(argv: string[]): Options {

--- a/scripts/resolve-anime-catalog.ts
+++ b/scripts/resolve-anime-catalog.ts
@@ -469,8 +469,16 @@ async function applyShortAnimeLobbyRule(
 	}
 	const currentByMal = new Map(rows.map((row) => [row.mal_id, row]));
 	let applied = 0;
+	// The batched upsert uses one column set for every row, so room_type must be
+	// present (with its current value) on ALL rows — a partial column would null
+	// out the untouched ones.
 	for (const resolution of resolutions) {
 		const malId = resolution.canonical.mal_id;
+		const current = currentByMal.get(malId);
+		const canonical = resolution.canonical as unknown as Record<string, unknown>;
+		canonical["room_type"] = current?.room_type ?? "episode";
+		canonical["room_type_source"] = current?.room_type_source ?? "default";
+		if (current?.room_type_source === "manual") continue;
 		const mal = (recordsByMalId.get(malId) ?? []).find((record) => record.source === "mal");
 		const normalized =
 			mal && mal.normalized_data !== null && typeof mal.normalized_data === "object"
@@ -478,11 +486,8 @@ async function applyShortAnimeLobbyRule(
 				: null;
 		const duration = normalized?.["episode_duration_minutes"];
 		if (typeof duration !== "number" || duration <= 0) continue;
-		const current = currentByMal.get(malId);
-		if (current?.room_type_source === "manual") continue;
 		const autoRoomType = duration <= SHORT_ANIME_LOBBY_MINUTES ? "global" : "episode";
-		if (current && current.room_type !== autoRoomType) {
-			const canonical = resolution.canonical as unknown as Record<string, unknown>;
+		if ((current?.room_type ?? "episode") !== autoRoomType) {
 			canonical["room_type"] = autoRoomType;
 			canonical["room_type_source"] = "auto";
 			applied += 1;

--- a/src/lib/anime-catalog-resolver.test.ts
+++ b/src/lib/anime-catalog-resolver.test.ts
@@ -122,6 +122,28 @@ describe("resolveAnimeCatalog", () => {
 		expect(resolved.fieldSources["title"]?.source).toBe("manual");
 	});
 
+	it("rejects native-language titles smuggled into MAL's Japanese-title field", () => {
+		// 韓国作品: MALのja欄にハングル題
+		const korean = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "Hello Carbot", status: "finished" }),
+			source("mal", { title_ja: "헬로 카봇 시즌8", type: "TV" }),
+		]);
+		expect(korean.canonical.metadata_ready).toBe(false);
+		// 中国作品: かな無しの中文題・日本側ソースの裏付けなし
+		const donghua = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "Ya She", status: "finished" }),
+			source("mal", { title_ja: "哑舍", type: "ONA" }),
+		]);
+		expect(donghua.canonical.metadata_ready).toBe(false);
+		// 日本放送あり: しょぼいマッピングが裏付けになり、かな無し題でも公開
+		const broadcast = resolveAnimeCatalog([
+			source("mal", { title_ja: "天官賜福", type: "ONA" }),
+			source("syobocal", { official_site_url: "https://example.jp/" }),
+		]);
+		expect(broadcast.canonical.metadata_ready).toBe(true);
+		expect(broadcast.canonical.title).toBe("天官賜福");
+	});
+
 	it("never publishes Music/PV/CM entries even with a verified title", () => {
 		const resolved = resolveAnimeCatalog([
 			source("anime_offline_database", { title: "Example MV", type: "Special", status: "finished" }),

--- a/src/lib/anime-catalog-resolver.test.ts
+++ b/src/lib/anime-catalog-resolver.test.ts
@@ -122,6 +122,16 @@ describe("resolveAnimeCatalog", () => {
 		expect(resolved.fieldSources["title"]?.source).toBe("manual");
 	});
 
+	it("never publishes Music/PV/CM entries even with a verified title", () => {
+		const resolved = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "Example MV", type: "Special", status: "finished" }),
+			source("mal", { title_ja: "検証済みのMVタイトル", type: "Music" }),
+		]);
+		expect(resolved.resolutionStatus).toBe("verified");
+		expect(resolved.canonical.metadata_ready).toBe(false);
+		expect(resolved.resolutionReasons).toContain("Music/PV/CM entries are not published.");
+	});
+
 	it("uses a confirmed Syobocal title and official links ahead of other imported sources", () => {
 		const resolved = resolveAnimeCatalog([
 			source("anime_offline_database", { title: "Example", status: "finished" }),

--- a/src/lib/anime-catalog-resolver.ts
+++ b/src/lib/anime-catalog-resolver.ts
@@ -41,6 +41,8 @@ export type LegacyAnimeCatalogRow = {
 	resources: unknown;
 	cover_url: string | null;
 	metadata_ready?: boolean;
+	room_type?: string | null;
+	room_type_source?: string | null;
 };
 
 export type AnimeCatalogCanonicalRow = Omit<LegacyAnimeCatalogRow, "resources"> & {

--- a/src/lib/anime-catalog-resolver.ts
+++ b/src/lib/anime-catalog-resolver.ts
@@ -424,6 +424,14 @@ export function resolveAnimeCatalog(
 					: "Verified Japanese display title is missing.",
 			];
 
+	// Music videos, PVs and CMs are never published (same policy as the Jikan
+	// importer's BLOCKED_TYPES). The check uses the MAL/Jikan media label
+	// directly: anime-offline-database has no music type and mislabels these
+	// entries as "Special", so the resolved type alone cannot be trusted.
+	const mediaTypeLabel = (stringValue(mal, "type") ?? stringValue(jikan, "type"))?.toLowerCase() ?? null;
+	const blockedMediaType = mediaTypeLabel !== null && ["music", "pv", "cm"].includes(mediaTypeLabel);
+	if (blockedMediaType) resolutionReasons.push("Music/PV/CM entries are not published.");
+
 	const resolvedFields = {
 		title,
 		title_en: titleEnglish,
@@ -475,7 +483,7 @@ export function resolveAnimeCatalog(
 			official_x_url: officialXUrl.value,
 			resources: mergeResources(syobocal),
 			cover_url: coverUrl.value,
-			metadata_ready: resolutionStatus === "verified",
+			metadata_ready: resolutionStatus === "verified" && !blockedMediaType,
 		},
 		fieldSources,
 		resolutionStatus,

--- a/src/lib/anime-catalog-resolver.ts
+++ b/src/lib/anime-catalog-resolver.ts
@@ -232,13 +232,28 @@ export function resolveAnimeCatalog(
 
 	const offlineTitle = stringValue(offline, "title");
 	const syobocalJapaneseTitle = stringValue(syobocal, "title_ja");
-	const wikidataJapaneseTitle = stringValue(wikidata, "title_ja");
-	const malJapaneseTitle =
+	const rejectHangul = (value: string | undefined) =>
+		value && /[\p{Script=Hangul}]/u.test(value) ? undefined : value;
+	const wikidataJapaneseTitle = rejectHangul(stringValue(wikidata, "title_ja"));
+	// MALは韓国・中国作品の「日本語タイトル」欄に現地語題をそのまま入れることが
+	// ある。かなを含まない題は、日本側ソース（しょぼいマッピング / Wikidata日本語
+	// ラベル / manual）の裏付けがない限り検証済みとして扱わない。ハングルは常に拒否。
+	const japaneseSideCorroborated =
+		bySource.has("syobocal") || wikidataJapaneseTitle !== undefined || stringValue(manual, "title") !== undefined;
+	const acceptJapaneseTitle = (value: string | undefined): string | undefined => {
+		if (!value) return undefined;
+		if (/[\p{Script=Hangul}]/u.test(value)) return undefined;
+		if (/[\p{Script=Hiragana}\p{Script=Katakana}]/u.test(value)) return value;
+		return japaneseSideCorroborated ? value : undefined;
+	};
+	const malJapaneseTitle = acceptJapaneseTitle(
 		stringValue(mal, "title_ja") ??
-		(containsJapaneseScript(stringValue(mal, "title") ?? "") ? stringValue(mal, "title") : undefined);
-	const jikanJapaneseTitle =
+			(containsJapaneseScript(stringValue(mal, "title") ?? "") ? stringValue(mal, "title") : undefined),
+	);
+	const jikanJapaneseTitle = acceptJapaneseTitle(
 		stringValue(jikan, "title_ja") ??
-		(containsJapaneseScript(stringValue(jikan, "title") ?? "") ? stringValue(jikan, "title") : undefined);
+			(containsJapaneseScript(stringValue(jikan, "title") ?? "") ? stringValue(jikan, "title") : undefined),
+	);
 	const legacyJapaneseTitle =
 		legacyRow?.title && containsJapaneseScript(legacyRow.title) ? legacyRow.title : undefined;
 	const title = firstDefined([

--- a/src/lib/server/anime-admin.ts
+++ b/src/lib/server/anime-admin.ts
@@ -169,6 +169,8 @@ async function buildAnimePayload(supabase: SupabaseClient<Database>, fd: FormDat
 		broadcast_duration_minutes: broadcastDurationMinutes,
 		broadcast_station: parseBroadcastStations(fd),
 		room_type: parseRoomType(fd),
+		// 管理画面からの保存は明示操作: 総合ロビー自動判定の対象から外す
+		room_type_source: "manual",
 	};
 }
 

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -1601,6 +1601,8 @@ export interface AnimeListOptions {
 	broadcastStatus?: Exclude<BroadcastStatus, "unknown">;
 	sortBy?: "popular" | "trending" | "top_rated" | "created";
 	listedByUserId?: string | null;
+	/** 明示したanime.idのみに絞る（スケジュール等、対象集合が先に決まる文脈用） */
+	ids?: number[];
 	limit?: number;
 	userId?: string | null;
 	query?: string;
@@ -1727,7 +1729,14 @@ export async function getAnimeList(
 		query: searchQuery,
 	} = options;
 	const selectedGenres = normalizeGenreFilters(genres ?? genre);
-	const listedAnimeIds = listedByUserId ? await getListedAnimeIds(supabase, listedByUserId) : null;
+	const listedIds = listedByUserId ? await getListedAnimeIds(supabase, listedByUserId) : null;
+	if (listedIds && listedIds.length === 0) return [];
+	const listedAnimeIds =
+		options.ids != null
+			? listedIds
+				? listedIds.filter((id) => options.ids?.includes(id))
+				: options.ids
+			: listedIds;
 	if (listedAnimeIds && listedAnimeIds.length === 0) return [];
 
 	const seasonFilter = buildSeasonFilter(
@@ -3061,6 +3070,65 @@ export async function getBroadcastRoomOverridesForAnimeIds(
 		grouped[key].push(row);
 	}
 	return grouped;
+}
+
+export interface ScheduleBroadcastSession {
+	anime_id: number;
+	room_date: string;
+	scheduled_at: string;
+}
+
+/**
+ * 週間カレンダー用: しょぼい番組同期が作成したエピソードセッション。
+ * しょぼいがカレンダーの唯一の情報源なので、schedule_source='syobocal' のみを返す
+ * （オーバーライド起点の掲載は呼び出し側がオーバーライド行から組み立てる）。
+ */
+export async function getScheduleBroadcastSessionsInRange(
+	supabase: SupabaseClient<Database>,
+	startDate: string,
+	endDate: string,
+): Promise<ScheduleBroadcastSession[]> {
+	// biome-ignore lint/suspicious/noExplicitAny: migration 104 columns are not in generated types until applied
+	const reader = supabase as SupabaseClient<any>;
+	const { data, error } = await reader
+		.from("broadcast_room_sessions")
+		.select("anime_id,room_date,scheduled_at")
+		.eq("room_kind", "episode")
+		.eq("schedule_source", "syobocal")
+		.gte("room_date", startDate)
+		.lte("room_date", endDate)
+		.order("scheduled_at", { ascending: true })
+		.limit(2000);
+	if (error) {
+		console.error("schedule broadcast sessions query failed:", error);
+		return [];
+	}
+	return ((data ?? []) as Record<string, unknown>[]).map((row) => ({
+		anime_id: Number(row["anime_id"]),
+		room_date: String(row["room_date"] ?? "").slice(0, 10),
+		scheduled_at: String(row["scheduled_at"] ?? ""),
+	}));
+}
+
+/** 週間カレンダー用: 期間内にオーバーライドを持つanime_id（休止告知・臨時枠の掲載元） */
+export async function getOverrideAnimeIdsInRange(
+	supabase: SupabaseClient<Database>,
+	startDate: string,
+	endDate: string,
+): Promise<number[]> {
+	// biome-ignore lint/suspicious/noExplicitAny: broadcast_room_overrides not yet in generated types
+	const reader = supabase as SupabaseClient<any>;
+	const { data, error } = await reader
+		.from("broadcast_room_overrides")
+		.select("anime_id")
+		.gte("room_date", startDate)
+		.lte("room_date", endDate)
+		.limit(2000);
+	if (error) {
+		console.error("override anime ids query failed:", error);
+		return [];
+	}
+	return [...new Set(((data ?? []) as Record<string, unknown>[]).map((row) => Number(row["anime_id"])))];
 }
 
 export async function getBroadcastRoomMutes(

--- a/src/lib/syobocal-schedule.test.ts
+++ b/src/lib/syobocal-schedule.test.ts
@@ -124,6 +124,30 @@ describe("selectPrimarySyobocalPrograms", () => {
 		expect(selected[0]).toMatchObject({ pid: 4, channelName: "サンテレビ" });
 	});
 
+	it("breaks exact same-time ties with the title's home channel", () => {
+		const base = {
+			tid: 10,
+			endsAt: "2026-07-01T15:00:00.000Z",
+			episodeNumber: 1,
+			subtitle: null,
+			deleted: false,
+		};
+		const selected = selectPrimarySyobocalPrograms(
+			[{ malId: 1, tid: 10, validFrom: null, validTo: null }],
+			[{ tid: 10, firstChannel: "TOKYO MX" }],
+			[
+				{ chid: 1, name: "サンテレビ", epgName: null, channelGroupId: 8 },
+				{ chid: 2, name: "TOKYO MX", epgName: null, channelGroupId: 1 },
+			],
+			[
+				{ ...base, pid: 1, chid: 1, startsAt: "2026-07-01T14:00:00.000Z" },
+				{ ...base, pid: 2, chid: 2, startsAt: "2026-07-01T14:00:00.000Z" },
+			],
+		);
+		expect(selected).toHaveLength(1);
+		expect(selected[0]).toMatchObject({ pid: 2, channelName: "TOKYO MX" });
+	});
+
 	it("falls back to BS when a title has no terrestrial airing", () => {
 		const selected = selectPrimarySyobocalPrograms(
 			[{ malId: 1, tid: 10, validFrom: null, validTo: null }],

--- a/src/lib/syobocal-schedule.test.ts
+++ b/src/lib/syobocal-schedule.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { rollingSyobocalProgramRange, selectPrimarySyobocalPrograms } from "./syobocal-schedule";
+import {
+	jstBroadcastDate,
+	jstBroadcastTimeLabel,
+	rollingSyobocalProgramRange,
+	selectPrimarySyobocalPrograms,
+} from "./syobocal-schedule";
+
+describe("late-night broadcast convention", () => {
+	it("assigns pre-4am slots to the previous broadcast day with 24h+ time labels", () => {
+		// 火曜25:30 = 水曜01:30 JST = 火曜16:30 UTC
+		expect(jstBroadcastDate("2026-07-07T16:30:00.000Z")).toBe("2026-07-07");
+		expect(jstBroadcastTimeLabel("2026-07-07T16:30:00.000Z")).toBe("25:30");
+		// 通常枠はそのまま
+		expect(jstBroadcastDate("2026-07-07T09:45:00.000Z")).toBe("2026-07-07");
+		expect(jstBroadcastTimeLabel("2026-07-07T09:45:00.000Z")).toBe("18:45");
+		// 4:00ちょうどは当日扱い (JST 04:00 = 前日19:00 UTC)
+		expect(jstBroadcastDate("2026-07-06T19:00:00.000Z")).toBe("2026-07-07");
+		expect(jstBroadcastTimeLabel("2026-07-06T19:00:00.000Z")).toBe("04:00");
+	});
+});
 
 describe("selectPrimarySyobocalPrograms", () => {
 	it("uses FirstCh for each episode and falls back to the earliest channel", () => {

--- a/src/lib/syobocal-schedule.ts
+++ b/src/lib/syobocal-schedule.ts
@@ -52,6 +52,37 @@ export function jstDate(value: string | Date): string {
 	return JST_DATE_FORMATTER.format(typeof value === "string" ? new Date(value) : value);
 }
 
+const JST_HOUR_FORMATTER = new Intl.DateTimeFormat("en-GB", {
+	timeZone: "Asia/Tokyo",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+});
+
+const LATE_NIGHT_BOUNDARY_HOUR = 4;
+
+/**
+ * 放送日付（深夜アニメ慣習）: JSTで午前4時より前の枠は前日の放送として扱う。
+ * broadcast_room_overrides / ensure_broadcast_room_session の room_date と同じ基準。
+ */
+export function jstBroadcastDate(value: string | Date): string {
+	const date = typeof value === "string" ? new Date(value) : value;
+	return jstDate(new Date(date.getTime() - LATE_NIGHT_BOUNDARY_HOUR * 60 * 60 * 1000));
+}
+
+/** 放送時刻表示（深夜アニメ慣習）: 午前4時より前は「25:30」のような24時間超表記 */
+export function jstBroadcastTimeLabel(value: string | Date): string | null {
+	const date = typeof value === "string" ? new Date(value) : value;
+	if (Number.isNaN(date.getTime())) return null;
+	const formatted = JST_HOUR_FORMATTER.format(date);
+	const [hourText, minuteText] = formatted.split(":");
+	const hour = Number.parseInt(hourText ?? "", 10);
+	if (!Number.isFinite(hour) || minuteText === undefined) return null;
+	return hour < LATE_NIGHT_BOUNDARY_HOUR
+		? `${hour + 24}:${minuteText}`
+		: `${String(hour).padStart(2, "0")}:${minuteText}`;
+}
+
 function episodeIdentity(program: SyobocalScheduleProgram): string {
 	if (program.episodeNumber !== null) return `episode:${program.episodeNumber}`;
 	if (program.subtitle) return `subtitle:${program.subtitle.normalize("NFKC").trim()}`;
@@ -99,7 +130,8 @@ export function selectPrimarySyobocalPrograms(
 			if (program.tid !== mapping.tid || program.deleted) return false;
 			if (!isSchedulableProgram(program)) return false;
 			if (channelTier(channelByChid.get(program.chid)) === null) return false;
-			const date = jstDate(program.startsAt);
+			// クール境界は放送日慣習で判定する（9/30深夜25:30の枠は9月クール側）
+			const date = jstBroadcastDate(program.startsAt);
 			return (!mapping.validFrom || date >= mapping.validFrom) && (!mapping.validTo || date <= mapping.validTo);
 		});
 		const byEpisode = new Map<string, SyobocalScheduleProgram[]>();

--- a/src/lib/syobocal.test.ts
+++ b/src/lib/syobocal.test.ts
@@ -138,6 +138,8 @@ describe("syobocalTypeConflicts", () => {
 		expect(syobocalTypeConflicts("Movie", 8)).toBe(false);
 		expect(syobocalTypeConflicts("TV", 10)).toBe(false);
 		expect(syobocalTypeConflicts("TV", 7)).toBe(true);
+		// 劇場先行→TV放送の作品はしょぼい側がcat8のことがある（シャニマス型）
+		expect(syobocalTypeConflicts("TV", 8)).toBe(false);
 		expect(syobocalTypeConflicts(null, 1)).toBe(false);
 		expect(syobocalTypeConflicts("TV", null)).toBe(false);
 	});
@@ -151,22 +153,27 @@ describe("matchSyobocalTitlesByReading", () => {
 		expect(latinFoldTitle("おね→ショタ←おね THE ANIMATION")).toBe(null);
 	});
 
-	it("matches across scripts via TitleYomi and the Latin fold with date agreement", () => {
+	it("matches across scripts via TitleYomi and folded titles with date agreement", () => {
 		const matches = matchSyobocalTitlesByReading(
 			[
 				{ malId: 1, title: "アトリ", firstYear: 2026, firstMonth: 7 },
 				{ malId: 2, title: "シェンムー", firstYear: 2026, firstMonth: 1 },
 				{ malId: 3, title: "遠い作品", firstYear: 2010, firstMonth: 1 },
+				// mostly-Latin titles pair via the shared fold (kanaFoldTitle keeps
+				// Latin letters, so the kana: key wins before the latin: key)
+				{ malId: 4, title: "Shangri-La Frontier", firstYear: 2026, firstMonth: 4 },
 			],
 			[
 				{ tid: 10, title: "ATRI -My Dear Moments-", titleYomi: "あとり", firstYear: 2026, firstMonth: 7 },
 				{ tid: 20, title: "Shenmue the Animation", titleYomi: "しぇんむー", firstYear: 2026, firstMonth: 2 },
 				{ tid: 30, title: "遠い作品(新)", titleYomi: "とおいさくひん", firstYear: 2026, firstMonth: 1 },
+				{ tid: 40, title: "SHANGRI-LA FRONTIER", titleYomi: "しゃんぐりらふろんてぃあ", firstYear: 2026, firstMonth: 4 },
 			],
 		);
 		expect(matches).toEqual([
 			{ malId: 1, tid: 10, matchKey: "kana:あとり" },
 			{ malId: 2, tid: 20, matchKey: "kana:しぇんむー" },
+			{ malId: 4, tid: 40, matchKey: "kana:shangrilafrontier" },
 		]);
 	});
 

--- a/src/lib/syobocal.ts
+++ b/src/lib/syobocal.ts
@@ -174,6 +174,8 @@ export function syobocalTypeConflicts(
 ): boolean {
 	if (!mediaType || category === null || category === undefined) return false;
 	const tvAnime = SYOBOCAL_TV_ANIME_CATEGORIES.has(category);
+	// "TV" × 映画カテゴリ(8)は意図的に許可: 劇場先行上映の作品はしょぼい側で
+	// cat 8 のTIDにTV放送も記録される（例: シャニマス1st/2nd season）。
 	if (mediaType === "TV") return !tvAnime && category !== 8;
 	if (mediaType === "Movie") return tvAnime || category === 7;
 	if (mediaType === "OVA") return tvAnime || category === 8;
@@ -279,8 +281,10 @@ export function matchSyobocalTitlesExactly(
 
 // Second-tier matcher for pairs the normalized-title matcher cannot see:
 // script differences (アトリ ⇔ ATRI via TitleYomi, シェンムー ⇔ Shenmue via the
-// Latin fold). Stricter than the exact matcher: both sides must carry premiere
-// dates within three months, and the pairing must be unique in both directions.
+// Latin fold). Compared with the exact matcher this REQUIRES premiere dates on
+// both sides, unique pairing in both directions, and a media-type check — but
+// its date window is wider (three months instead of one) to absorb
+// theatrical-advance and delayed-broadcast gaps.
 export function matchSyobocalTitlesByReading(
 	catalog: readonly SyobocalTitleMatchCandidate[],
 	titles: readonly SyobocalTitleForMatching[],

--- a/src/lib/utils/broadcast-room.ts
+++ b/src/lib/utils/broadcast-room.ts
@@ -36,13 +36,11 @@ function dateKeyToDate(value: string) {
  * 2026-winter以前の作品は、閉場済みルームであっても生成・表示しない。
  */
 export function isEligibleForRoomLog(season: string | null): boolean {
-	if (!season) return false;
-	const parts = season.split("-");
-	const year = Number.parseInt(parts[0] ?? "", 10);
-	const name = parts[1];
-	if (!Number.isFinite(year)) return false;
+	const match = season?.match(/^(\d{4})-(winter|spring|summer|fall)$/);
+	if (!match) return false;
+	const year = Number.parseInt(match[1] ?? "", 10);
 	if (year > 2026) return true;
-	return year === 2026 && name !== "winter";
+	return year === 2026 && match[2] !== "winter";
 }
 
 export function animeIsScheduledForRoomDate(

--- a/src/lib/utils/broadcast-room.ts
+++ b/src/lib/utils/broadcast-room.ts
@@ -31,6 +31,20 @@ function dateKeyToDate(value: string) {
 	return date;
 }
 
+/**
+ * 各話ルーム（開催・ログ閲覧とも）の対象シーズン。サービス開始前の
+ * 2026-winter以前の作品は、閉場済みルームであっても生成・表示しない。
+ */
+export function isEligibleForRoomLog(season: string | null): boolean {
+	if (!season) return false;
+	const parts = season.split("-");
+	const year = Number.parseInt(parts[0] ?? "", 10);
+	const name = parts[1];
+	if (!Number.isFinite(year)) return false;
+	if (year > 2026) return true;
+	return year === 2026 && name !== "winter";
+}
+
 export function animeIsScheduledForRoomDate(
 	anime: BroadcastScheduleBounds,
 	dateKey: string,

--- a/src/routes/anime/[id]/+page.server.ts
+++ b/src/routes/anime/[id]/+page.server.ts
@@ -12,17 +12,8 @@ import {
 	isAdminUser,
 } from "$lib/server/queries";
 import { normalizedBroadcastEpisodeLabel } from "$lib/utils/broadcast-episodes";
-import { roomDateKey } from "$lib/utils/broadcast-room";
+import { isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
-
-function isEligibleForRoomLog(season: string | null): boolean {
-	if (!season) return false;
-	const parts = season.split("-");
-	const y = parseInt(parts[0] ?? "", 10);
-	const name = parts[1];
-	if (y > 2026) return true;
-	return y === 2026 && name !== "winter";
-}
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
 	const { user } = await safeGetSession();

--- a/src/routes/anime/[id]/+page.server.ts
+++ b/src/routes/anime/[id]/+page.server.ts
@@ -11,7 +11,8 @@ import {
 	getUsersWhoListedAnime,
 	isAdminUser,
 } from "$lib/server/queries";
-import { generateBroadcastEpisodeSlots } from "$lib/utils/broadcast-episodes";
+import { normalizedBroadcastEpisodeLabel } from "$lib/utils/broadcast-episodes";
+import { roomDateKey } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
 
 function isEligibleForRoomLog(season: string | null): boolean {
@@ -42,32 +43,22 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		getBroadcastRoomScheduleSnapshotsForAnime(supabase, Number(anime.id)),
 	]);
 
-	const inferredEpisodes =
-		isEligibleForRoomLog(anime.season) &&
-		anime.room_type === "episode" &&
-		anime.aired_from != null &&
-		(anime.broadcast_day != null || broadcastOverrides.length > 0)
-			? generateBroadcastEpisodeSlots({
-					airedFrom: anime.aired_from,
-					airedTo: anime.aired_to ?? null,
-					broadcastDay: anime.broadcast_day,
-					broadcastTime: anime.broadcast_time,
-					episodeCount: anime.episode_count,
-					overrides: broadcastOverrides,
-				}).reverse()
-			: [];
-	const episodeByDate = new Map(inferredEpisodes.map((episode) => [episode.date, episode]));
-	for (const snapshot of scheduleSnapshots) {
-		const inferred = episodeByDate.get(snapshot.date);
-		episodeByDate.set(snapshot.date, {
-			date: snapshot.date,
-			start: snapshot.start ?? inferred?.start ?? null,
-			end: snapshot.end ?? inferred?.end ?? null,
-			label: snapshot.label ?? inferred?.label ?? null,
-		});
-	}
+	// 各話ルームの履歴は実際に開催されたセッション（しょぼい由来の話数付き
+	// スナップショット）が唯一の情報源。曜日からの機械カウントは行わない。
+	// 管理者オーバーライドはラベル（総集編等）の上書きにだけ使う。
+	const overrideByDate = new Map(broadcastOverrides.map((override) => [roomDateKey(override.room_date), override]));
 	const episodes = isEligibleForRoomLog(anime.season)
-		? [...episodeByDate.values()].sort((left, right) => right.date.localeCompare(left.date))
+		? scheduleSnapshots
+				.map((snapshot) => {
+					const override = overrideByDate.get(snapshot.date);
+					return {
+						date: snapshot.date,
+						start: snapshot.start,
+						end: snapshot.end,
+						label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
+					};
+				})
+				.sort((left, right) => right.date.localeCompare(left.date))
 		: [];
 
 	return { anime, user, isAdmin, listedUsers, relations, dataAttributions, episodes, broadcastOverrides, events };

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -18,10 +18,47 @@ import {
 	createRoomExperimentServiceClient,
 	getActiveRoomExperimentRunForAnime as getActiveExperimentRun,
 } from "$lib/server/room-experiments";
-import type { Anime } from "$lib/types";
+import type { Anime, BroadcastRoomOverride, BroadcastRoomSession } from "$lib/types";
 import { calcEpisodeNumberFromDate } from "$lib/types";
-import { animeIsScheduledForRoomDate } from "$lib/utils/broadcast-room";
+import { animeIsScheduledForRoomDate, broadcastTimeMinutes } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
+
+// 過去ルームの表示専用セッション。かつては閲覧時にフォールバックがセッション行を
+// 偽装生成して表示していたが、しょぼい絶対化でDBへの偽装生成を廃止したため、
+// 「行が無い閉場済みルーム」はこの合成オブジェクトで履歴閲覧だけを復元する
+// （投稿は締切済みで不可、投稿・アンケート等の参照は空を返す）。
+const SYNTHETIC_ROOM_SESSION_ID = "00000000-0000-0000-0000-000000000000";
+
+function synthesizeClosedRoomSession(
+	anime: Anime,
+	roomDate: string,
+	override: BroadcastRoomOverride | null,
+): BroadcastRoomSession | null {
+	const time = override?.broadcast_time ?? anime.broadcast_time;
+	const minutes = broadcastTimeMinutes(time);
+	if (minutes == null) return null;
+	const [year, month, day] = roomDate.split("-").map((part) => Number.parseInt(part, 10));
+	if (!year || !month || !day) return null;
+	// JST固定(+9): サーバーTZに依存させない
+	const scheduledMs = Date.UTC(year, month - 1, day, Math.floor(minutes / 60) - 9, minutes % 60);
+	const duration = override?.duration_minutes ?? anime.broadcast_duration_minutes ?? 30;
+	const preOpen = override?.pre_open_minutes ?? anime.broadcast_room_pre_open_minutes ?? 5;
+	const postClose = override?.post_close_minutes ?? anime.broadcast_room_post_close_minutes ?? 30;
+	const closesMs = scheduledMs + (duration + postClose) * 60_000;
+	// 未来・開催中のルームは実セッション（しょぼい同期かオーバーライド起点）が必須
+	if (closesMs > Date.now()) return null;
+	return {
+		id: SYNTHETIC_ROOM_SESSION_ID,
+		anime_id: Number(anime.id),
+		room_date: roomDate,
+		room_kind: "episode",
+		room_key: roomDate,
+		scheduled_at: new Date(scheduledMs).toISOString(),
+		duration_minutes: duration,
+		posting_opens_at: new Date(scheduledMs - preOpen * 60_000).toISOString(),
+		posting_closes_at: new Date(closesMs).toISOString(),
+	};
+}
 
 function fallbackRoomHashtag(title: string) {
 	return title.replace(/\s+/g, "").replace(/[^\p{L}\p{N}_]/gu, "");
@@ -57,11 +94,17 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	if (override?.is_cancelled) {
 		throw error(404, "放送ルームが見つかりません");
 	}
-	if (!animeIsScheduledForRoomDate(anime, params.date, override != null)) {
-		throw error(404, "放送ルームが見つかりません");
-	}
 
-	const session = await getBroadcastRoomSession(supabase, anime.id, params.date);
+	// 実セッション（しょぼい同期・オーバーライド起点）が最優先。深夜枠は
+	// room_dateが放送日（前日）でMAL由来のbroadcast_dayと曜日が一致しないため、
+	// 曜日ゲートは実セッションが無い場合の合成時にだけ適用する。
+	let session = await getBroadcastRoomSession(supabase, anime.id, params.date);
+	if (!session) {
+		if (!animeIsScheduledForRoomDate(anime, params.date, override != null)) {
+			throw error(404, "放送ルームが見つかりません");
+		}
+		session = synthesizeClosedRoomSession(anime, params.date, override ?? null);
+	}
 	if (!session) throw error(404, "放送ルームが見つかりません");
 
 	const hashtag = roomHashtag(anime);

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -162,10 +162,11 @@ export const actions: Actions = {
 		if (override?.is_cancelled) {
 			return fail(404, { message: "放送ルームが見つかりません" });
 		}
-		if (!anime || !animeIsScheduledForRoomDate(anime, params.date, override != null)) {
-			return fail(404, { message: "放送ルームが見つかりません" });
-		}
+		if (!anime) return fail(404, { message: "放送ルームが見つかりません" });
 
+		// 表示側と同じ判定順: 実セッション（しょぼい同期・オーバーライド起点）が
+		// あれば曜日ゲートを通さない。深夜枠は room_date が放送日（前日）で
+		// MAL由来の broadcast_day と一致しないため、ゲート先行だと投稿が404になる。
 		const session = await getBroadcastRoomSession(supabase, anime.id, params.date);
 		if (!session) return fail(404, { message: "放送ルームが見つかりません" });
 		const now = Date.now();

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -20,7 +20,7 @@ import {
 } from "$lib/server/room-experiments";
 import type { Anime, BroadcastRoomOverride, BroadcastRoomSession } from "$lib/types";
 import { calcEpisodeNumberFromDate } from "$lib/types";
-import { animeIsScheduledForRoomDate, broadcastTimeMinutes } from "$lib/utils/broadcast-room";
+import { animeIsScheduledForRoomDate, broadcastTimeMinutes, isEligibleForRoomLog } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
 
 // 過去ルームの表示専用セッション。かつては閲覧時にフォールバックがセッション行を
@@ -100,6 +100,10 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	// 曜日ゲートは実セッションが無い場合の合成時にだけ適用する。
 	let session = await getBroadcastRoomSession(supabase, anime.id, params.date);
 	if (!session) {
+		// ルーム対象外シーズン（2026-winter以前）は閉場済みルームも生成しない
+		if (!isEligibleForRoomLog(anime.season)) {
+			throw error(404, "放送ルームが見つかりません");
+		}
 		if (!animeIsScheduledForRoomDate(anime, params.date, override != null)) {
 			throw error(404, "放送ルームが見つかりません");
 		}

--- a/src/routes/schedule/+page.server.ts
+++ b/src/routes/schedule/+page.server.ts
@@ -18,6 +18,8 @@ import {
 	getEventNotificationSubscriptions,
 	getEventsByRange,
 	getMutedEventIds,
+	getOverrideAnimeIdsInRange,
+	getScheduleBroadcastSessionsInRange,
 	isAdminUser,
 } from "$lib/server/queries";
 import type { Anime, BroadcastNotificationSettings, BroadcastRoomOverride, Event } from "$lib/types";
@@ -69,18 +71,18 @@ function toDateInputValue(date: Date) {
 	return `${y}-${m}-${d}`;
 }
 
-function toDateKey(value: string | null) {
-	return value?.slice(0, 10) ?? null;
-}
+// カレンダー掲載時刻はしょぼい由来のセッション時刻（JST）が唯一の情報源
+const JST_TIME_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
+	timeZone: "Asia/Tokyo",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+});
 
-function isAnimeOnAirDate(anime: Anime, date: string) {
-	const airedFrom = toDateKey(anime.aired_from);
-	if (airedFrom && date < airedFrom) return false;
-
-	const airedTo = toDateKey(anime.aired_to);
-	if (airedTo && date > airedTo) return false;
-
-	return true;
+function jstBroadcastTime(iso: string): string | null {
+	const parsed = new Date(iso);
+	if (Number.isNaN(parsed.getTime())) return null;
+	return JST_TIME_FORMATTER.format(parsed);
 }
 
 function announcementMessage(override: BroadcastRoomOverride): string {
@@ -122,6 +124,13 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		end: toDateInputValue(addDays(weekStart, 6)),
 	};
 
+	// しょぼい絶対: 掲載対象は「同期済みセッションがある」か「オーバーライドがある」作品のみ
+	const [sessions, overrideAnimeIdsInRange] = await Promise.all([
+		getScheduleBroadcastSessionsInRange(supabase, scheduleRange.start, scheduleRange.end),
+		getOverrideAnimeIdsInRange(supabase, scheduleRange.start, scheduleRange.end),
+	]);
+	const scheduleAnimeIds = [...new Set([...sessions.map((session) => session.anime_id), ...overrideAnimeIdsInRange])];
+
 	const [
 		animeList,
 		events,
@@ -133,7 +142,9 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		mutedEventIds,
 		eventNotificationSubscriptions,
 	] = await Promise.all([
-		getAnimeList(supabase, { scheduleRange, limit: 1000, userId: user?.id ?? null }),
+		scheduleAnimeIds.length
+			? getAnimeList(supabase, { ids: scheduleAnimeIds, limit: 1000, userId: user?.id ?? null })
+			: Promise.resolve([] as Anime[]),
 		getEventsByRange(supabase, weekStart.toISOString(), eventRangeEnd.toISOString()),
 		user ? getBroadcastSubscriptions(supabase, user.id) : Promise.resolve([] as string[]),
 		user
@@ -169,24 +180,32 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		announcements: [],
 	}));
 
-	for (const anime of animeList.filter((a): a is Anime & { broadcast_day: number } => a.broadcast_day != null)) {
-		if (anime.room_type === "global") continue;
-		const day = days[anime.broadcast_day];
-		if (day && isAnimeOnAirDate(anime, day.date)) {
-			const override = overrideForRoomDate(broadcastOverrides[anime.id], day.date);
-			if (override?.is_cancelled) {
-				pushAnnouncement(day, anime, override, broadcastOverrides);
-				continue;
-			}
-			day.anime.push(anime);
+	// しょぼい同期セッション: 実在の番組枠だけがカレンダーに載る
+	const animeById = new Map(animeList.map((anime) => [Number(anime.id), anime]));
+	for (const session of sessions) {
+		const anime = animeById.get(session.anime_id);
+		if (!anime || anime.room_type === "global") continue;
+		const day = days.find((candidate) => candidate.date === session.room_date);
+		if (!day) continue;
+		const override = overrideForRoomDate(broadcastOverrides[anime.id], day.date);
+		if (override?.is_cancelled) {
+			pushAnnouncement(day, anime, override, broadcastOverrides);
+			continue;
 		}
+		if (day.anime.some((scheduledAnime) => scheduledAnime.id === anime.id)) continue;
+		day.anime.push({
+			...anime,
+			broadcast_day: new Date(`${session.room_date}T00:00:00`).getDay(),
+			broadcast_time: jstBroadcastTime(session.scheduled_at) ?? anime.broadcast_time,
+		});
 	}
 
+	// 管理者オーバーライド: 休止は告知、それ以外はセッション未生成でも掲載する
 	for (const anime of animeList) {
 		if (anime.room_type === "global") continue;
 		for (const override of broadcastOverrides[anime.id] ?? []) {
 			const date = roomDateKey(override.room_date);
-			if (date < scheduleRange.start || date > scheduleRange.end || !isAnimeOnAirDate(anime, date)) continue;
+			if (date < scheduleRange.start || date > scheduleRange.end) continue;
 
 			const day = days.find((candidate) => candidate.date === date);
 			if (day && override.is_cancelled) {

--- a/src/routes/schedule/+page.server.ts
+++ b/src/routes/schedule/+page.server.ts
@@ -22,6 +22,7 @@ import {
 	getScheduleBroadcastSessionsInRange,
 	isAdminUser,
 } from "$lib/server/queries";
+import { jstBroadcastTimeLabel } from "$lib/syobocal-schedule";
 import type { Anime, BroadcastNotificationSettings, BroadcastRoomOverride, Event } from "$lib/types";
 import { formatBroadcastOverrideAnnouncement } from "$lib/utils/broadcast-episodes";
 import {
@@ -69,20 +70,6 @@ function toDateInputValue(date: Date) {
 	const m = String(date.getMonth() + 1).padStart(2, "0");
 	const d = String(date.getDate()).padStart(2, "0");
 	return `${y}-${m}-${d}`;
-}
-
-// カレンダー掲載時刻はしょぼい由来のセッション時刻（JST）が唯一の情報源
-const JST_TIME_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
-	timeZone: "Asia/Tokyo",
-	hour: "2-digit",
-	minute: "2-digit",
-	hour12: false,
-});
-
-function jstBroadcastTime(iso: string): string | null {
-	const parsed = new Date(iso);
-	if (Number.isNaN(parsed.getTime())) return null;
-	return JST_TIME_FORMATTER.format(parsed);
 }
 
 function announcementMessage(override: BroadcastRoomOverride): string {
@@ -193,10 +180,11 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 			continue;
 		}
 		if (day.anime.some((scheduledAnime) => scheduledAnime.id === anime.id)) continue;
+		// 掲載時刻はしょぼいの実枠（深夜は25:30のような24時間超表記で前日枠に載る）
 		day.anime.push({
 			...anime,
 			broadcast_day: new Date(`${session.room_date}T00:00:00`).getDay(),
-			broadcast_time: jstBroadcastTime(session.scheduled_at) ?? anime.broadcast_time,
+			broadcast_time: jstBroadcastTimeLabel(session.scheduled_at) ?? anime.broadcast_time,
 		});
 	}
 

--- a/src/routes/schedule/+page.server.ts
+++ b/src/routes/schedule/+page.server.ts
@@ -26,8 +26,10 @@ import { jstBroadcastTimeLabel } from "$lib/syobocal-schedule";
 import type { Anime, BroadcastNotificationSettings, BroadcastRoomOverride, Event } from "$lib/types";
 import { formatBroadcastOverrideAnnouncement } from "$lib/utils/broadcast-episodes";
 import {
+	animeIsScheduledForRoomDate,
 	broadcastTimeSortValue,
 	effectiveBroadcastTime,
+	isEligibleForRoomLog,
 	overrideForRoomDate,
 	roomDateKey,
 } from "$lib/utils/broadcast-room";
@@ -111,15 +113,25 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		end: toDateInputValue(addDays(weekStart, 6)),
 	};
 
-	// しょぼい絶対: 掲載対象は「同期済みセッションがある」か「オーバーライドがある」作品のみ
-	const [sessions, overrideAnimeIdsInRange] = await Promise.all([
+	// しょぼい絶対: 今日以降の掲載対象は「同期済みセッションがある」か「オーバーライド
+	// がある」作品のみ。過去日はしょぼい番組データが残らないため、ルームページの
+	// 合成表示と同じルール（対象シーズン+曜日・放送期間）で履歴として掲載する。
+	const todayKey = toDateInputValue(new Date());
+	const hasPastDays = scheduleRange.start < todayKey;
+	const [sessions, overrideAnimeIdsInRange, pastFillList] = await Promise.all([
 		getScheduleBroadcastSessionsInRange(supabase, scheduleRange.start, scheduleRange.end),
 		getOverrideAnimeIdsInRange(supabase, scheduleRange.start, scheduleRange.end),
+		hasPastDays
+			? getAnimeList(supabase, { scheduleRange, limit: 1000, userId: user?.id ?? null })
+			: Promise.resolve([] as Anime[]),
 	]);
-	const scheduleAnimeIds = [...new Set([...sessions.map((session) => session.anime_id), ...overrideAnimeIdsInRange])];
+	const pastFillIds = pastFillList.map((anime) => Number(anime.id));
+	const scheduleAnimeIds = [
+		...new Set([...sessions.map((session) => session.anime_id), ...overrideAnimeIdsInRange]),
+	].filter((id) => !pastFillIds.includes(id));
 
 	const [
-		animeList,
+		sessionAnimeList,
 		events,
 		subscriptions,
 		notificationSettings,
@@ -147,6 +159,15 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 		user ? getMutedEventIds(supabase, user.id) : Promise.resolve(new Set<string>()),
 		user ? getEventNotificationSubscriptions(supabase, user.id) : Promise.resolve([] as string[]),
 	]);
+
+	// セッション/オーバーライド由来と過去日補完の作品リストを統合
+	const animeList: Anime[] = [...pastFillList];
+	{
+		const known = new Set(animeList.map((anime) => anime.id));
+		for (const anime of sessionAnimeList) {
+			if (!known.has(anime.id)) animeList.push(anime);
+		}
+	}
 
 	const broadcastOverrides = await getBroadcastRoomOverridesForAnimeIds(
 		supabase,
@@ -186,6 +207,24 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 			broadcast_day: new Date(`${session.room_date}T00:00:00`).getDay(),
 			broadcast_time: jstBroadcastTimeLabel(session.scheduled_at) ?? anime.broadcast_time,
 		});
+	}
+
+	// 過去日の履歴掲載: しょぼいの番組データは過去に遡れないため、セッションが
+	// 残っていない過去日はルームページの合成表示と同じルール（対象シーズン+
+	// 曜日・放送期間ゲート）で補完する。今日以降はしょぼい絶対のまま。
+	for (const day of days) {
+		if (day.date >= todayKey) continue;
+		for (const anime of pastFillList) {
+			if (anime.room_type === "global") continue;
+			if (!isEligibleForRoomLog(anime.season)) continue;
+			if (!animeIsScheduledForRoomDate(anime, day.date, false)) continue;
+			const override = overrideForRoomDate(broadcastOverrides[anime.id], day.date);
+			if (override?.is_cancelled) {
+				pushAnnouncement(day, anime, override, broadcastOverrides);
+				continue;
+			}
+			if (!day.anime.some((scheduledAnime) => scheduledAnime.id === anime.id)) day.anime.push(anime);
+		}
 	}
 
 	// 管理者オーバーライド: 休止は告知、それ以外はセッション未生成でも掲載する

--- a/supabase/migrations/115_syobocal_source_of_truth.sql
+++ b/supabase/migrations/115_syobocal_source_of_truth.sql
@@ -1,0 +1,140 @@
+-- Syobocal becomes the single source of truth for the calendar and broadcast
+-- rooms. The on-demand fallback that fabricated sessions from anime.broadcast_day
+-- / broadcast_time is removed: episode sessions now exist only when the Syobocal
+-- program sync created them, or when an admin registered an explicit override
+-- for that date. Also adds tracking for automatic global-lobby classification.
+
+-- 1) Track how room_type was decided so the automatic short-anime rule never
+--    overwrites an explicit admin choice.
+ALTER TABLE public.anime
+    ADD COLUMN IF NOT EXISTS room_type_source text NOT NULL DEFAULT 'default';
+ALTER TABLE public.anime
+    DROP CONSTRAINT IF EXISTS anime_room_type_source_check;
+ALTER TABLE public.anime
+    ADD CONSTRAINT anime_room_type_source_check
+    CHECK (room_type_source IN ('default', 'auto', 'manual'));
+COMMENT ON COLUMN public.anime.room_type_source IS
+    'How room_type was decided: default (never touched), auto (short-anime rule), manual (admin).';
+
+-- 2) ensure_broadcast_room_session no longer fabricates sessions from
+--    broadcast_day/broadcast_time. It returns existing (Syobocal-synced)
+--    sessions, and creates one only for an explicit non-cancelled override.
+CREATE OR REPLACE FUNCTION public.ensure_broadcast_room_session(p_anime_id integer, p_room_date date)
+RETURNS SETOF public.broadcast_room_sessions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_anime public.anime%ROWTYPE;
+    override_row public.broadcast_room_overrides%ROWTYPE;
+    effective_broadcast_time text;
+    effective_duration_minutes integer;
+    effective_pre_open_minutes integer;
+    effective_post_close_minutes integer;
+    scheduled_jst timestamp;
+    scheduled_at timestamptz;
+BEGIN
+    SELECT * INTO target_anime FROM public.anime WHERE id = p_anime_id;
+    IF NOT FOUND OR target_anime.room_type = 'global' THEN
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.broadcast_room_sessions session
+        WHERE session.anime_id = p_anime_id
+          AND session.room_kind = 'episode'
+          AND session.room_key = p_room_date::text
+    ) THEN
+        RETURN QUERY
+            SELECT session.*
+            FROM public.broadcast_room_sessions session
+            WHERE session.anime_id = p_anime_id
+              AND session.room_kind = 'episode'
+              AND session.room_key = p_room_date::text;
+        RETURN;
+    END IF;
+
+    SELECT * INTO override_row
+    FROM public.broadcast_room_overrides
+    WHERE anime_id = p_anime_id AND room_date = p_room_date;
+    -- No Syobocal session and no explicit admin override: nothing is created.
+    IF NOT FOUND OR override_row.is_cancelled THEN
+        RETURN;
+    END IF;
+
+    effective_broadcast_time := COALESCE(override_row.broadcast_time, target_anime.broadcast_time);
+    effective_duration_minutes := COALESCE(override_row.duration_minutes, target_anime.broadcast_duration_minutes);
+    effective_pre_open_minutes := COALESCE(override_row.pre_open_minutes, target_anime.broadcast_room_pre_open_minutes);
+    effective_post_close_minutes := COALESCE(override_row.post_close_minutes, target_anime.broadcast_room_post_close_minutes);
+
+    IF effective_broadcast_time IS NULL THEN
+        RETURN;
+    END IF;
+
+    scheduled_jst :=
+        p_room_date::timestamp
+        + (split_part(effective_broadcast_time, ':', 1)::integer || ' hours')::interval
+        + (split_part(effective_broadcast_time, ':', 2)::integer || ' minutes')::interval;
+    scheduled_at := scheduled_jst AT TIME ZONE 'Asia/Tokyo';
+
+    INSERT INTO public.broadcast_room_sessions (
+        anime_id,
+        room_date,
+        room_kind,
+        room_key,
+        scheduled_at,
+        duration_minutes,
+        posting_opens_at,
+        posting_closes_at
+    )
+    VALUES (
+        target_anime.id,
+        p_room_date,
+        'episode',
+        p_room_date::text,
+        scheduled_at,
+        effective_duration_minutes,
+        scheduled_at - (effective_pre_open_minutes || ' minutes')::interval,
+        scheduled_at + ((effective_duration_minutes + effective_post_close_minutes) || ' minutes')::interval
+    )
+    ON CONFLICT (anime_id, room_kind, room_key) DO UPDATE
+    SET scheduled_at = EXCLUDED.scheduled_at,
+        duration_minutes = EXCLUDED.duration_minutes,
+        posting_opens_at = EXCLUDED.posting_opens_at,
+        posting_closes_at = EXCLUDED.posting_closes_at
+    WHERE public.broadcast_room_sessions.schedule_source IS NULL
+      AND public.broadcast_room_sessions.source_program_id IS NULL
+      AND public.broadcast_room_sessions.schedule_frozen_at IS NULL
+      AND public.broadcast_room_sessions.posting_opens_at > now()
+      AND (
+          public.broadcast_room_sessions.scheduled_at IS DISTINCT FROM EXCLUDED.scheduled_at
+          OR public.broadcast_room_sessions.duration_minutes IS DISTINCT FROM EXCLUDED.duration_minutes
+          OR public.broadcast_room_sessions.posting_opens_at IS DISTINCT FROM EXCLUDED.posting_opens_at
+          OR public.broadcast_room_sessions.posting_closes_at IS DISTINCT FROM EXCLUDED.posting_closes_at
+      );
+
+    RETURN QUERY
+        SELECT session.*
+        FROM public.broadcast_room_sessions session
+        WHERE session.anime_id = p_anime_id
+          AND session.room_kind = 'episode'
+          AND session.room_key = p_room_date::text;
+END;
+$$;
+
+-- 3) Remove future sessions the old fallback fabricated (no Syobocal origin,
+--    no admin override, not frozen, not yet open). Past sessions stay as held
+--    room history.
+DELETE FROM public.broadcast_room_sessions session
+WHERE session.room_kind = 'episode'
+  AND session.schedule_source IS NULL
+  AND session.schedule_frozen_at IS NULL
+  AND session.posting_opens_at > now()
+  AND NOT EXISTS (
+      SELECT 1
+      FROM public.broadcast_room_overrides override
+      WHERE override.anime_id = session.anime_id
+        AND override.room_date::text = session.room_key
+  );


### PR DESCRIPTION
## Summary

Stacked on #175. Implements the "しょぼい絶対" policy from the Zenitendou investigation: the calendar and broadcast rooms are driven exclusively by Syobocal-synced program data, never by MAL-derived static schedule fields.

### Fallback removal — migration 115 (apply manually before merge)
- `ensure_broadcast_room_session` no longer fabricates sessions from `broadcast_day`/`broadcast_time` at view time. It returns Syobocal-synced sessions and creates rows only for explicit admin overrides (放送休止/時間変更/総集編 remain fully supported)
- Deletes future fallback-fabricated sessions (`schedule_source IS NULL`, no override); past ones stay as held-room history
- Adds `anime.room_type_source` (`default`/`auto`/`manual`) for the lobby rule below

### Calendar rebuilt on sessions
- `/schedule` lists shows from synced sessions (+ admin overrides) instead of `broadcast_day` guesses; displayed time is the actual Syobocal slot time (JST). Shows without Syobocal programs no longer appear — including reruns of MAL-stale "airing" titles like ふしぎ駄菓子屋 銭天堂
- Program sync now follows **every confirmed primary mapping** in a pure rolling window (yesterday → +91 days), so continuing shows from earlier seasons (ちいかわ・ポケモン・split cours) keep their schedule, and ended shows drop off naturally

### Episode numbering without mechanical counting
- The anime-page episode log lists actually-held sessions with Syobocal episode numbers/subtitles (admin override labels win); the "aired_from + weekly +1" counter is gone. Total episode count is displayed as source data only

### Global lobby auto-classification
- MAL `average_episode_duration` imported as `episode_duration_minutes`
- Resolver reclassifies ≤15-minute shows to `room_type='global'`; admin saves set `room_type_source='manual'` and are never overridden
- Backfill of durations for the existing 8,026 catalog entries is running via `scripts/local/backfill-episode-durations.ts` (gitignored local tooling)

### Notes / behavior changes
- Web-only titles with no Syobocal listing have no calendar entry or episode rooms by design (global lobby still available)
- Late-night slots follow the 深夜表記 convention: pre-04:00 JST slots are keyed and displayed on the previous broadcast day with a 24h+ time label (火曜25:30). Session room_date now matches the override/RPC convention, and cour validity windows are evaluated on the broadcast day

## Test plan
- `pnpm check` clean; `pnpm test` 137/137
- After migration 115: verify Zenitendou has no calendar entry / no room; verify continuing shows appear via catalog-wide sync; run resolver to apply the lobby rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)