### PR TITLE
Fix episode numbering and room-log listing for long-running shows

### DIFF
--- a/src/lib/anime-catalog-resolver.test.ts
+++ b/src/lib/anime-catalog-resolver.test.ts
@@ -122,6 +122,26 @@ describe("resolveAnimeCatalog", () => {
 		expect(resolved.fieldSources["title"]?.source).toBe("manual");
 	});
 
+	it("does not trust the offline-database episode total while a show is airing", () => {
+		const airing = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "長期作品", episode_count: "128", status: "airing" }),
+			source("mal", { title_ja: "ながいさくひん", status: "airing" }),
+		]);
+		expect(airing.canonical.episode_count).toBeNull();
+		// MALが総話数を出していれば放送中でも採用する
+		const announced = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "長期作品", episode_count: "128", status: "airing" }),
+			source("mal", { title_ja: "ながいさくひん", status: "airing", episode_count: "24" }),
+		]);
+		expect(announced.canonical.episode_count).toBe("24");
+		// 放送終了後はスナップショット値で問題ない
+		const finished = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "長期作品", episode_count: "128", status: "finished" }),
+			source("mal", { title_ja: "ながいさくひん", status: "finished" }),
+		]);
+		expect(finished.canonical.episode_count).toBe("128");
+	});
+
 	it("rejects native-language titles smuggled into MAL's Japanese-title field", () => {
 		// 韓国作品: MALのja欄にハングル題
 		const korean = resolveAnimeCatalog([

--- a/src/lib/anime-catalog-resolver.ts
+++ b/src/lib/anime-catalog-resolver.ts
@@ -449,6 +449,15 @@ export function resolveAnimeCatalog(
 	const blockedMediaType = mediaTypeLabel !== null && ["music", "pv", "cm"].includes(mediaTypeLabel);
 	if (blockedMediaType) resolutionReasons.push("Music/PV/CM entries are not published.");
 
+	// 放送中の作品では anime-offline-database の話数がスナップショット時点で
+	// 固定された古い値になりがち（例: BEYBLADE X）。放送中はMAL/Jikanの現行値を
+	// 優先し、どちらにも無ければ「総話数未確定」として null にする。
+	if (status.value === "airing" && episodeCount.source === "anime_offline_database") {
+		const liveCount = stringValue(mal, "episode_count") ?? stringValue(jikan, "episode_count") ?? null;
+		episodeCount.value = liveCount;
+		if (liveCount !== null) episodeCount.source = stringValue(mal, "episode_count") ? "mal" : "jikan";
+	}
+
 	const resolvedFields = {
 		title,
 		title_en: titleEnglish,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -605,6 +605,9 @@ export interface BroadcastRoomSession {
 	duration_minutes: number;
 	posting_opens_at: string;
 	posting_closes_at: string;
+	/** しょぼい番組表由来の話数・サブタイトル（同期セッションのみ） */
+	episode_number?: number | null;
+	episode_title?: string | null;
 }
 
 export interface OpenBroadcastRoomSummary {

--- a/src/routes/anime/[id]/+page.server.ts
+++ b/src/routes/anime/[id]/+page.server.ts
@@ -12,7 +12,7 @@ import {
 	isAdminUser,
 } from "$lib/server/queries";
 import { normalizedBroadcastEpisodeLabel } from "$lib/utils/broadcast-episodes";
-import { isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
+import { roomDateKey } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
@@ -34,23 +34,24 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		getBroadcastRoomScheduleSnapshotsForAnime(supabase, Number(anime.id)),
 	]);
 
-	// 各話ルームの履歴は実際に開催されたセッション（しょぼい由来の話数付き
+	// 各話ルームの履歴は実際に存在するセッション（しょぼい由来の話数付き
 	// スナップショット）が唯一の情報源。曜日からの機械カウントは行わない。
 	// 管理者オーバーライドはラベル（総集編等）の上書きにだけ使う。
+	// シーズン境界（isEligibleForRoomLog）はルーム「合成」のゲートであり、
+	// 実在セッションの一覧には適用しない: 2026-spring以前開始の長期放送作品
+	// （BEYBLADE X等）も、サービス開始後に開催されたルームは列挙する。
 	const overrideByDate = new Map(broadcastOverrides.map((override) => [roomDateKey(override.room_date), override]));
-	const episodes = isEligibleForRoomLog(anime.season)
-		? scheduleSnapshots
-				.map((snapshot) => {
-					const override = overrideByDate.get(snapshot.date);
-					return {
-						date: snapshot.date,
-						start: snapshot.start,
-						end: snapshot.end,
-						label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
-					};
-				})
-				.sort((left, right) => right.date.localeCompare(left.date))
-		: [];
+	const episodes = scheduleSnapshots
+		.map((snapshot) => {
+			const override = overrideByDate.get(snapshot.date);
+			return {
+				date: snapshot.date,
+				start: snapshot.start,
+				end: snapshot.end,
+				label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
+			};
+		})
+		.sort((left, right) => right.date.localeCompare(left.date));
 
 	return { anime, user, isAdmin, listedUsers, relations, dataAttributions, episodes, broadcastOverrides, events };
 };

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -19,7 +19,6 @@ import {
 	getActiveRoomExperimentRunForAnime as getActiveExperimentRun,
 } from "$lib/server/room-experiments";
 import type { Anime, BroadcastRoomOverride, BroadcastRoomSession } from "$lib/types";
-import { calcEpisodeNumberFromDate } from "$lib/types";
 import { animeIsScheduledForRoomDate, broadcastTimeMinutes, isEligibleForRoomLog } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
 
@@ -112,7 +111,9 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	if (!session) throw error(404, "放送ルームが見つかりません");
 
 	const hashtag = roomHashtag(anime);
-	const episodeNumber = calcEpisodeNumberFromDate(session.room_date, anime.aired_from, anime.broadcast_time);
+	// 話数はしょぼい番組表由来の値のみ（曜日からの機械カウントはしない）。
+	// 同期セッション以外（合成表示・オーバーライド起点）は話数なしで表示する。
+	const episodeNumber = session.episode_number ?? null;
 	const roomExperimentSupabase = user ? createRoomExperimentServiceClient() : null;
 	const [posts, trending, animeTrending, roomExperimentRun, roomExitSurveyLoadState] = await Promise.all([
 		getBroadcastRoomPosts(supabase, session.id, user?.id ?? null, { limit: 100, ascending: true }),


### PR DESCRIPTION
## Summary
BEYBLADE X (2023-fall, ongoing) surfaced three follow-up bugs from the Syobocal source-of-truth work:

1. **放送話数のズレ** — the room title still used a mechanical weekly count from `aired_from` (`calcEpisodeNumberFromDate`), showing ~151 vs the actual #130. Rooms now use the Syobocal `episode_number` stored on the session; synthesized/override rooms show no number instead of a guessed one.
2. **総話数のズレ** — `episode_count` preferred the anime-offline-database snapshot ("128"), which goes stale for ongoing shows. While `status=airing`, MAL/Jikan current totals win and the value is null (hidden) when neither provides one. Finished shows keep the snapshot value.
3. **ルームログが空** — the 2026-spring room-log boundary was applied to the *listing* of real sessions, so pre-boundary long-runners lost their entire log. The boundary now gates only room synthesis; actually-held service-era sessions always list.

## Test plan
- `pnpm check` clean, `pnpm test` 142/142 (new resolver test: airing+offline→null / airing+MAL announced→kept / finished→kept)
- After merge: rerun `resolve:anime-catalog` across seasons so stale airing totals are nulled in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)