### PR TITLE
Backfill room-log dates that predate the Syobocal sync

### DIFF
--- a/src/routes/anime/[id]/+page.server.ts
+++ b/src/routes/anime/[id]/+page.server.ts
@@ -11,8 +11,9 @@ import {
 	getUsersWhoListedAnime,
 	isAdminUser,
 } from "$lib/server/queries";
+import { jstBroadcastDate } from "$lib/syobocal-schedule";
 import { normalizedBroadcastEpisodeLabel } from "$lib/utils/broadcast-episodes";
-import { roomDateKey } from "$lib/utils/broadcast-room";
+import { isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
@@ -41,17 +42,50 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	// 実在セッションの一覧には適用しない: 2026-spring以前開始の長期放送作品
 	// （BEYBLADE X等）も、サービス開始後に開催されたルームは列挙する。
 	const overrideByDate = new Map(broadcastOverrides.map((override) => [roomDateKey(override.room_date), override]));
-	const episodes = scheduleSnapshots
-		.map((snapshot) => {
+	const episodeByDate = new Map(
+		scheduleSnapshots.map((snapshot) => {
 			const override = overrideByDate.get(snapshot.date);
-			return {
-				date: snapshot.date,
-				start: snapshot.start,
-				end: snapshot.end,
-				label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
-			};
-		})
-		.sort((left, right) => right.date.localeCompare(left.date));
+			return [
+				snapshot.date,
+				{
+					date: snapshot.date,
+					start: snapshot.start,
+					end: snapshot.end,
+					label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
+				},
+			] as const;
+		}),
+	);
+	// しょぼい同期開始前の放送分にはセッション行が無い。ルームページの合成表示
+	// （対象シーズン+曜日・放送期間ゲート）と同じルールで過去日を補完して、
+	// 「ログに載る日付 ⇔ ルームページが開ける日付」を一致させる。話数は情報源
+	// （しょぼい）が過去に遡れないため付けない — 機械カウントはしない。
+	if (
+		isEligibleForRoomLog(anime.season) &&
+		anime.room_type === "episode" &&
+		anime.aired_from != null &&
+		anime.broadcast_day != null &&
+		anime.broadcast_time != null
+	) {
+		const todayKey = jstBroadcastDate(new Date());
+		const airedToKey = anime.aired_to?.slice(0, 10) ?? null;
+		const cursor = new Date(`${anime.aired_from.slice(0, 10)}T00:00:00`);
+		while (cursor.getDay() !== anime.broadcast_day) cursor.setDate(cursor.getDate() + 1);
+		for (let guard = 0; guard < 400; guard += 1, cursor.setDate(cursor.getDate() + 7)) {
+			const date = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`;
+			if (date >= todayKey || (airedToKey && date > airedToKey)) break;
+			if (episodeByDate.has(date)) continue;
+			const override = overrideByDate.get(date);
+			if (override?.is_cancelled) continue;
+			episodeByDate.set(date, {
+				date,
+				start: null,
+				end: null,
+				label: override ? normalizedBroadcastEpisodeLabel(override) : null,
+			});
+		}
+	}
+	const episodes = [...episodeByDate.values()].sort((left, right) => right.date.localeCompare(left.date));
 
 	return { anime, user, isAdmin, listedUsers, relations, dataAttributions, episodes, broadcastOverrides, events };
 };


### PR DESCRIPTION
## Summary
The anime-page room log listed only stored sessions, which exist from the sync start (2026-08-24) plus legacy view-time leftovers — so 対ありでした showed ep 8 (synced) and two unnumbered July dates (legacy) while eps 3-7 were missing entirely.

The log now merges synthesized past dates using exactly the room page's closed-room synthesis rules (eligible season ≥ 2026-spring, weekday/aired-window gates, cancelled overrides excluded). Result: a date is listed iff its room page renders. Stored sessions keep their Syobocal episode numbers; synthesized dates show no number (Syobocal cannot be fetched retroactively and mechanical counting is banned by policy).

## Test plan
- `pnpm check` clean, `pnpm test` 142/142
- 対ありでした: log lists 7/7〜前日の毎火曜(話数なし) + 8/25以降は第8話〜の話数付き
- BEYBLADE X (2023-fall, boundary-ineligible): unchanged — real sessions only, no synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)