### PR TITLE
Anchored backward episode numbering for pre-sync room-log dates

### DIFF
--- a/src/lib/utils/broadcast-episodes.test.ts
+++ b/src/lib/utils/broadcast-episodes.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { BroadcastRoomOverride } from "$lib/types";
+import { type BroadcastEpisodeSlot, inferEpisodeNumbersBackward } from "./broadcast-episodes";
+
+function slot(date: string, start: number | null = null, label: string | null = null): BroadcastEpisodeSlot {
+	return { date, start, end: start, label };
+}
+
+function override(partial: Partial<BroadcastRoomOverride> & { room_date: string }): BroadcastRoomOverride {
+	return {
+		anime_id: 1,
+		is_cancelled: false,
+		broadcast_time: null,
+		duration_minutes: null,
+		pre_open_minutes: null,
+		post_close_minutes: null,
+		episode_start: null,
+		episode_end: null,
+		episode_label: null,
+		episode_count_increment: null,
+		announcement_label: null,
+		note: null,
+		...partial,
+	} as BroadcastRoomOverride;
+}
+
+describe("inferEpisodeNumbersBackward", () => {
+	it("numbers pre-sync dates backward from the Syobocal anchor", () => {
+		const slots = [slot("2026-07-07"), slot("2026-07-14"), slot("2026-07-21"), slot("2026-08-25", 8)];
+		// 途中3週分は掲載していない想定（合成が全週返す実運用では連続になる）
+		const mismatch = inferEpisodeNumbersBackward(slots, new Map());
+		expect(slots.map((s) => s.start)).toEqual([5, 6, 7, 8]);
+		// 最古が第1話にならない → leftoverとして検出される
+		expect(mismatch).toEqual({ kind: "leftover", firstNumber: 5 });
+	});
+
+	it("reaches episode 1 cleanly for a continuous weekly run", () => {
+		const slots = [
+			slot("2026-07-07"),
+			slot("2026-07-14"),
+			slot("2026-07-21"),
+			slot("2026-07-28"),
+			slot("2026-08-04"),
+			slot("2026-08-11"),
+			slot("2026-08-18"),
+			slot("2026-08-25", 8),
+		];
+		expect(inferEpisodeNumbersBackward(slots, new Map())).toBeNull();
+		expect(slots.map((s) => s.start)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+	});
+
+	it("respects recap overrides (no number, no count) and explicit episode ranges", () => {
+		const overrides = new Map<string, BroadcastRoomOverride>([
+			["2026-07-21", override({ room_date: "2026-07-21", episode_count_increment: 0, episode_label: "総集編" })],
+			["2026-07-14", override({ room_date: "2026-07-14", episode_start: 2, episode_end: 3 })],
+		]);
+		const slots = [
+			slot("2026-07-07"),
+			slot("2026-07-14"),
+			slot("2026-07-21", null, "総集編"),
+			slot("2026-07-28"),
+			slot("2026-08-04", 5),
+		];
+		expect(inferEpisodeNumbersBackward(slots, overrides)).toBeNull();
+		expect(slots.map((s) => [s.start, s.end])).toEqual([
+			[1, 1],
+			[2, 3],
+			[null, null],
+			[4, 4],
+			[5, 5],
+		]);
+	});
+
+	it("flags underflow when there are more dates than episodes", () => {
+		const slots = [slot("2026-07-07"), slot("2026-07-14"), slot("2026-07-21"), slot("2026-07-28", 2)];
+		const mismatch = inferEpisodeNumbersBackward(slots, new Map());
+		expect(mismatch).toEqual({ kind: "underflow", date: "2026-07-14" });
+		expect(slots.map((s) => s.start)).toEqual([null, null, 1, 2]);
+	});
+});

--- a/src/lib/utils/broadcast-episodes.ts
+++ b/src/lib/utils/broadcast-episodes.ts
@@ -201,6 +201,70 @@ export function generateBroadcastEpisodeSlots({
 		.filter((slot): slot is BroadcastEpisodeSlot => slot !== null);
 }
 
+export type AnchoredNumberingMismatch = { kind: "underflow"; date: string } | { kind: "leftover"; firstNumber: number };
+
+/**
+ * しょぼい由来の話数（アンカー）から過去方向へ週次逆算して、同期開始前の
+ * 日付に話数を振る。オーバーライドを尊重する:
+ * - episode_start/end 明示 → その値を採用し、そこから再逆算
+ * - 総集編等（話数進行なしのラベル） → 番号を振らず、カウントも消費しない
+ * 前方カウントと違い、誤差が出るとしても最古側に寄る。整合しない場合は
+ * mismatch を返す（underflow=第1話より前に到達 / leftover=最古が第1話にならない）。
+ * slots は日付昇順で渡すこと。
+ */
+export function inferEpisodeNumbersBackward(
+	slots: BroadcastEpisodeSlot[],
+	overrides: ReadonlyMap<string, BroadcastRoomOverride>,
+): AnchoredNumberingMismatch | null {
+	const anchorIndex = slots.findIndex((slot) => slot.start != null);
+	if (anchorIndex <= 0) {
+		// アンカー無し、またはアンカーより前の日付が無い
+		if (anchorIndex === 0 && slots[0]?.start != null && (slots[0]?.start ?? 1) > 1) {
+			return { kind: "leftover", firstNumber: slots[0]?.start ?? 1 };
+		}
+		return null;
+	}
+	let mismatch: AnchoredNumberingMismatch | null = null;
+	let current = slots[anchorIndex]?.start ?? 1;
+	for (let index = anchorIndex - 1; index >= 0; index -= 1) {
+		const slot = slots[index];
+		if (!slot) continue;
+		const override = overrides.get(slot.date);
+		if (slot.start != null) {
+			// 既に番号を持つ（別の実セッション等）→ 再アンカー
+			current = slot.start;
+			continue;
+		}
+		if (override?.episode_start != null && override.episode_end != null) {
+			slot.start = override.episode_start;
+			slot.end = override.episode_end;
+			current = override.episode_start;
+			continue;
+		}
+		if (override && normalizedBroadcastEpisodeLabel(override) !== null) {
+			// 総集編等: 番号なし・カウント消費なし（ラベルは呼び出し側で設定済み）
+			continue;
+		}
+		const candidate = current - 1;
+		if (candidate < 1) {
+			// 数えられる話数より掲載日が多い: 未登録の総集編・特番が疑われる
+			mismatch = mismatch ?? { kind: "underflow", date: slot.date };
+			continue;
+		}
+		slot.start = candidate;
+		slot.end = candidate;
+		current = candidate;
+	}
+	if (!mismatch) {
+		const firstNumbered = slots.find((slot) => slot.start != null);
+		if (firstNumbered && (firstNumbered.start ?? 1) > 1) {
+			// 最古の掲載日が第1話にならない: 休止週の未登録などが疑われる
+			mismatch = { kind: "leftover", firstNumber: firstNumbered.start ?? 1 };
+		}
+	}
+	return mismatch;
+}
+
 export function resolveBroadcastEpisodeSlot(input: ResolveBroadcastEpisodeInput): BroadcastEpisodeSlot | null {
 	const target = parseDate(input.date);
 	const slots = generateBroadcastEpisodeSlots({ ...input, today: target });

--- a/src/routes/anime/[id]/+page.server.ts
+++ b/src/routes/anime/[id]/+page.server.ts
@@ -12,7 +12,7 @@ import {
 	isAdminUser,
 } from "$lib/server/queries";
 import { jstBroadcastDate } from "$lib/syobocal-schedule";
-import { normalizedBroadcastEpisodeLabel } from "$lib/utils/broadcast-episodes";
+import { inferEpisodeNumbersBackward, normalizedBroadcastEpisodeLabel } from "$lib/utils/broadcast-episodes";
 import { isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
 
@@ -42,7 +42,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	// 実在セッションの一覧には適用しない: 2026-spring以前開始の長期放送作品
 	// （BEYBLADE X等）も、サービス開始後に開催されたルームは列挙する。
 	const overrideByDate = new Map(broadcastOverrides.map((override) => [roomDateKey(override.room_date), override]));
-	const episodeByDate = new Map(
+	const episodeByDate = new Map<string, import("$lib/utils/broadcast-episodes").BroadcastEpisodeSlot>(
 		scheduleSnapshots.map((snapshot) => {
 			const override = overrideByDate.get(snapshot.date);
 			return [
@@ -53,7 +53,7 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 					end: snapshot.end,
 					label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
 				},
-			] as const;
+			];
 		}),
 	);
 	// しょぼい同期開始前の放送分にはセッション行が無い。ルームページの合成表示
@@ -85,7 +85,11 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 			});
 		}
 	}
-	const episodes = [...episodeByDate.values()].sort((left, right) => right.date.localeCompare(left.date));
+	// 同期開始前の合成日付に、しょぼい話数（アンカー）からの逆算で番号を振る。
+	// オーバーライド（話数明示・総集編）を尊重し、整合しない作品は番号なしのまま。
+	const ascending = [...episodeByDate.values()].sort((left, right) => left.date.localeCompare(right.date));
+	inferEpisodeNumbersBackward(ascending, overrideByDate);
+	const episodes = ascending.sort((left, right) => right.date.localeCompare(left.date));
 
 	return { anime, user, isAdmin, listedUsers, relations, dataAttributions, episodes, broadcastOverrides, events };
 };


### PR DESCRIPTION
## Summary
Pre-sync room-log dates (synthesized) now get episode numbers by counting **backwards from the earliest Syobocal-numbered session** instead of showing no number:

- Recent dates are always correct (anchored to Syobocal truth); any drift from unmarked recaps lands only on the oldest dates
- Admin overrides win and re-anchor the count: explicit `episode_start/end` ranges are adopted, recap/label slots (総集編等) take no number and consume no count
- `inferEpisodeNumbersBackward` reports mismatches (`underflow` / `leftover`) consumed by a new local audit script (`scripts/local/audit-episode-numbering.ts`) that lists shows needing manual overrides

Audit across 153 eligible shows: 17 underflow (unmarked recap/special suspected), 7 leftover (mostly sequels whose Syobocal numbering continues from the previous cour — correct as-is), 53 no-anchor (ended before the sync started; dates listed without numbers).

## Test plan
- `pnpm check` clean, `pnpm test` 146/146 (4 new unit tests: clean run, recap/explicit-range handling, underflow flag, leftover flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)