### PR TITLE
Lock room sessions to the leading broadcast channel

### DIFF
--- a/src/lib/syobocal-schedule.test.ts
+++ b/src/lib/syobocal-schedule.test.ts
@@ -183,6 +183,38 @@ describe("selectPrimarySyobocalPrograms", () => {
 		expect(selected[0]).toMatchObject({ pid: 2, channelName: "BS11" });
 	});
 
+	it("locks onto the leading channel so lagged regional airings of old episodes are dropped", () => {
+		// 神の雫パターン: 同期ウィンドウ内で主局(MX)が第20-21話を放送中、
+		// 遅れネット局(KBS京都)はまだ第19話。旧話が「その話の最速」として
+		// 混入するとアンカー逆算が壊れる（false underflow）。
+		const base = {
+			tid: 10,
+			endsAt: "2026-08-28T15:00:00.000Z",
+			subtitle: null,
+			deleted: false,
+		};
+		const selected = selectPrimarySyobocalPrograms(
+			[{ malId: 1, tid: 10, validFrom: null, validTo: null }],
+			[{ tid: 10, firstChannel: "TOKYO MX" }],
+			[
+				{ chid: 1, name: "TOKYO MX", epgName: null, channelGroupId: 1 },
+				{ chid: 2, name: "KBS京都", epgName: null, channelGroupId: 8 },
+			],
+			[
+				// 主局: 第20話 → 第21話
+				{ ...base, pid: 1, chid: 1, startsAt: "2026-08-21T14:30:00.000Z", episodeNumber: 20 },
+				{ ...base, pid: 2, chid: 1, startsAt: "2026-08-28T14:30:00.000Z", episodeNumber: 21 },
+				// 遅れネット局: 主局より後の日付で旧話（第19話）を放送
+				{ ...base, pid: 3, chid: 2, startsAt: "2026-08-27T15:56:00.000Z", episodeNumber: 19 },
+			],
+		);
+		expect(selected.map((program) => [program.pid, program.episodeNumber])).toEqual([
+			[1, 20],
+			[2, 21],
+		]);
+		expect(selected.every((program) => program.channelName === "TOKYO MX")).toBe(true);
+	});
+
 	it("skips rerun slots but keeps recap specials for the override system", () => {
 		const base = {
 			tid: 10,

--- a/src/lib/syobocal-schedule.ts
+++ b/src/lib/syobocal-schedule.ts
@@ -126,6 +126,14 @@ export function selectPrimarySyobocalPrograms(
 	for (const mapping of mappings) {
 		const title = titleByTid.get(mapping.tid);
 		const preferredChannel = title?.firstChannel ? normalizeChannelName(title.firstChannel) : null;
+		const isPreferred = (program: SyobocalScheduleProgram) => {
+			if (!preferredChannel) return false;
+			const channel = channelByChid.get(program.chid);
+			return (
+				normalizeChannelName(channel?.name ?? "") === preferredChannel ||
+				normalizeChannelName(channel?.epgName ?? "") === preferredChannel
+			);
+		};
 		const eligible = programs.filter((program) => {
 			if (program.tid !== mapping.tid || program.deleted) return false;
 			if (!isSchedulableProgram(program)) return false;
@@ -134,8 +142,30 @@ export function selectPrimarySyobocalPrograms(
 			const date = jstBroadcastDate(program.startsAt);
 			return (!mapping.validFrom || date >= mapping.validFrom) && (!mapping.validTo || date <= mapping.validTo);
 		});
+		// 最速局ロック: 最大話数を最も早く放送する局（地上波優先）を主局とし、
+		// その局の枠だけを使う。遅れネット局で今も放送中の旧話が「その話の最速」
+		// として紛れ込み、本放送より古い話数のルームが立つのを防ぐ。
+		const numbered = eligible.filter((program) => program.episodeNumber !== null);
+		let primaryChid: number | null = null;
+		for (const tier of [0, 1]) {
+			const tierNumbered = numbered.filter((program) => channelTier(channelByChid.get(program.chid)) === tier);
+			if (tierNumbered.length === 0) continue;
+			const maxEpisode = Math.max(...tierNumbered.map((program) => program.episodeNumber ?? 0));
+			const leader = tierNumbered
+				.filter((program) => program.episodeNumber === maxEpisode)
+				.sort(
+					(left, right) =>
+						Date.parse(left.startsAt) - Date.parse(right.startsAt) ||
+						Number(isPreferred(right)) - Number(isPreferred(left)) ||
+						left.pid - right.pid,
+				)[0];
+			if (leader) primaryChid = leader.chid;
+			break;
+		}
+		const pool = primaryChid !== null ? eligible.filter((program) => program.chid === primaryChid) : eligible;
+
 		const byEpisode = new Map<string, SyobocalScheduleProgram[]>();
-		for (const program of eligible) {
+		for (const program of pool) {
 			const key = episodeIdentity(program);
 			const values = byEpisode.get(key) ?? [];
 			values.push(program);
@@ -145,14 +175,6 @@ export function selectPrimarySyobocalPrograms(
 		for (const candidates of byEpisode.values()) {
 			// Earliest airing on the best available tier (terrestrial before BS);
 			// the title's home channel only breaks exact same-time ties.
-			const isPreferred = (program: SyobocalScheduleProgram) => {
-				if (!preferredChannel) return false;
-				const channel = channelByChid.get(program.chid);
-				return (
-					normalizeChannelName(channel?.name ?? "") === preferredChannel ||
-					normalizeChannelName(channel?.epgName ?? "") === preferredChannel
-				);
-			};
 			const chosen = [...candidates].sort(
 				(left, right) =>
 					(channelTier(channelByChid.get(left.chid)) ?? 9) -


### PR DESCRIPTION
## Summary
- 遅れネット局が同期ウィンドウ内で旧話を放送していると、その旧話が「その話の最速」としてセッション化され、古い話数のルームが立つバグを修正（神の雫: KBS京都の第19話枠が8/27に混入し、逆算アンカーが壊れてfalse underflowを報告していた）
- `selectPrimarySyobocalPrograms` にTIDごとの最速局ロックを導入: 話数付き番組のうち地上波優先で「最大話数を最も早く放送している局」（同時刻はFirstChでタイブレーク）を主局とし、その局の枠だけをエピソード選定に使う
- 話数なし番組しかない作品（キッズ帯等）は従来どおり全局対象のフォールバック

## Test plan
- [x] 回帰テスト追加: 遅れネット局の旧話が主局ロックで除外されること
- [x] `pnpm check` 通過
- [x] `pnpm exec vitest run` 147/147 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)