### PR TITLE
Use future numbered sessions as anchors for room-log numbering

### DIFF
--- a/src/lib/server/broadcast-episode-log.test.ts
+++ b/src/lib/server/broadcast-episode-log.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { BroadcastRoomOverride } from "$lib/types";
+import { type BroadcastEpisodeLogSlot, buildBroadcastEpisodeLog } from "./broadcast-episode-log";
+
+// broadcast_day/time を null にして今日基準の合成補完を切り、実在セッションの
+// スナップショットだけで決定的にテストする。
+const ANIME = {
+	season: "2026-spring",
+	room_type: "episode",
+	aired_from: "2026-04-10",
+	aired_to: null,
+	broadcast_day: null,
+	broadcast_time: null,
+};
+
+function snapshot(
+	date: string,
+	start: number | null = null,
+	opened = true,
+	label: string | null = null,
+): BroadcastEpisodeLogSlot {
+	return { date, start, end: start, label, opened };
+}
+
+function override(partial: Partial<BroadcastRoomOverride> & { room_date: string }): BroadcastRoomOverride {
+	return {
+		anime_id: 1,
+		is_cancelled: false,
+		broadcast_time: null,
+		duration_minutes: null,
+		pre_open_minutes: null,
+		post_close_minutes: null,
+		episode_start: null,
+		episode_end: null,
+		episode_label: null,
+		episode_count_increment: null,
+		announcement_label: null,
+		note: null,
+		...partial,
+	} as BroadcastRoomOverride;
+}
+
+describe("buildBroadcastEpisodeLog", () => {
+	it("numbers unnumbered past sessions backward from an unopened future anchor", () => {
+		// 神の雫パターン: 過去の実在セッションは話数なし（同期前に開催）、
+		// 番号付きセッションはローリング同期範囲の未来（未開場）にしかない。
+		const log = buildBroadcastEpisodeLog(
+			ANIME,
+			[
+				snapshot("2026-07-31"),
+				snapshot("2026-08-07"),
+				snapshot("2026-08-14"),
+				snapshot("2026-08-21"),
+				snapshot("2026-08-28", 5, false),
+			],
+			[],
+		);
+		expect(log.map((slot) => [slot.date, slot.start, slot.opened])).toEqual([
+			["2026-07-31", 1, true],
+			["2026-08-07", 2, true],
+			["2026-08-14", 3, true],
+			["2026-08-21", 4, true],
+			["2026-08-28", 5, false],
+		]);
+	});
+
+	it("applies recap overrides while numbering backward", () => {
+		const overrides = [override({ room_date: "2026-08-07", episode_count_increment: 0, episode_label: "総集編" })];
+		const log = buildBroadcastEpisodeLog(
+			ANIME,
+			[snapshot("2026-07-31"), snapshot("2026-08-07"), snapshot("2026-08-14"), snapshot("2026-08-21", 3, false)],
+			overrides,
+		);
+		expect(log.map((slot) => [slot.date, slot.start, slot.label])).toEqual([
+			["2026-07-31", 1, null],
+			["2026-08-07", null, "総集編"],
+			["2026-08-14", 2, null],
+			["2026-08-21", 3, null],
+		]);
+	});
+});

--- a/src/lib/server/broadcast-episode-log.ts
+++ b/src/lib/server/broadcast-episode-log.ts
@@ -1,0 +1,78 @@
+import { jstBroadcastDate } from "$lib/syobocal-schedule";
+import type { Anime, BroadcastRoomOverride } from "$lib/types";
+import {
+	type BroadcastEpisodeSlot,
+	inferEpisodeNumbersBackward,
+	normalizedBroadcastEpisodeLabel,
+} from "$lib/utils/broadcast-episodes";
+import { isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
+
+export type BroadcastEpisodeLogSlot = BroadcastEpisodeSlot & { opened: boolean };
+
+type BroadcastEpisodeLogAnime = Pick<
+	Anime,
+	"season" | "room_type" | "aired_from" | "aired_to" | "broadcast_day" | "broadcast_time"
+>;
+
+/**
+ * 各話ルームの履歴タイムラインを組み立てる。実在セッション（しょぼい由来の
+ * 話数付きスナップショット）が唯一の情報源で、曜日からの機械カウントはしない。
+ * 管理者オーバーライドはラベル（総集編等）の上書きにだけ使う。
+ *
+ * しょぼい同期開始前の放送分にはセッション行が無いため、ルームページの合成表示
+ * （対象シーズン+曜日・放送期間ゲート）と同じルールで過去日を補完し、しょぼい
+ * 話数（アンカー）からの逆算で番号を振る。アンカーはローリング同期の範囲でしか
+ * 付かないので、未開場の番号付きセッションも逆算には参加させる（opened=false、
+ * ログ表示は呼び出し側で opened のみに絞る）。
+ *
+ * 返り値は日付昇順。
+ */
+export function buildBroadcastEpisodeLog(
+	anime: BroadcastEpisodeLogAnime,
+	snapshots: readonly BroadcastEpisodeLogSlot[],
+	overrides: readonly BroadcastRoomOverride[],
+): BroadcastEpisodeLogSlot[] {
+	const overrideByDate = new Map(overrides.map((override) => [roomDateKey(override.room_date), override]));
+	const slotByDate = new Map<string, BroadcastEpisodeLogSlot>(
+		snapshots.map((snapshot) => {
+			const override = overrideByDate.get(snapshot.date);
+			return [
+				snapshot.date,
+				{
+					...snapshot,
+					label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
+				},
+			];
+		}),
+	);
+	if (
+		isEligibleForRoomLog(anime.season) &&
+		anime.room_type === "episode" &&
+		anime.aired_from != null &&
+		anime.broadcast_day != null &&
+		anime.broadcast_time != null
+	) {
+		const todayKey = jstBroadcastDate(new Date());
+		const airedToKey = anime.aired_to?.slice(0, 10) ?? null;
+		const cursor = new Date(`${anime.aired_from.slice(0, 10)}T00:00:00`);
+		while (cursor.getDay() !== anime.broadcast_day) cursor.setDate(cursor.getDate() + 1);
+		for (let guard = 0; guard < 400; guard += 1, cursor.setDate(cursor.getDate() + 7)) {
+			const date = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`;
+			if (date >= todayKey || (airedToKey && date > airedToKey)) break;
+			if (slotByDate.has(date)) continue;
+			const override = overrideByDate.get(date);
+			if (override?.is_cancelled) continue;
+			slotByDate.set(date, {
+				date,
+				start: null,
+				end: null,
+				label: override ? normalizedBroadcastEpisodeLabel(override) : null,
+				opened: true,
+			});
+		}
+	}
+	const ascending = [...slotByDate.values()].sort((left, right) => left.date.localeCompare(right.date));
+	// オーバーライド（話数明示・総集編）を尊重した逆算。整合しない作品は番号なしのまま。
+	inferEpisodeNumbersBackward(ascending, overrideByDate);
+	return ascending;
+}

--- a/src/lib/server/queries.ts
+++ b/src/lib/server/queries.ts
@@ -2965,15 +2965,18 @@ export async function getBroadcastRoomSession(
 export async function getBroadcastRoomScheduleSnapshotsForAnime(
 	supabase: SupabaseClient<Database>,
 	animeId: number,
-): Promise<import("$lib/utils/broadcast-episodes").BroadcastEpisodeSlot[]> {
+): Promise<(import("$lib/utils/broadcast-episodes").BroadcastEpisodeSlot & { opened: boolean })[]> {
 	// biome-ignore lint/suspicious/noExplicitAny: migration 104 columns are not in generated types until applied
 	const reader = supabase as SupabaseClient<any>;
+	// 未来セッションも返す: しょぼい話数はローリング同期の範囲でしか付かないため、
+	// 未開場の番号付きセッションが過去日付への逆算の唯一のアンカーになることがある。
+	// ログに表示してよいのは opened のものだけ（呼び出し側でフィルタする）。
+	const nowIso = new Date().toISOString();
 	const { data, error } = await reader
 		.from("broadcast_room_sessions")
 		.select("room_date,episode_number,episode_title,posting_opens_at")
 		.eq("anime_id", animeId)
 		.eq("room_kind", "episode")
-		.lte("posting_opens_at", new Date().toISOString())
 		.order("room_date", { ascending: true });
 	if (error) {
 		console.error("getBroadcastRoomScheduleSnapshotsForAnime failed:", error);
@@ -2981,11 +2984,13 @@ export async function getBroadcastRoomScheduleSnapshotsForAnime(
 	}
 	return (data ?? []).map((row: Record<string, unknown>) => {
 		const episodeNumber = typeof row["episode_number"] === "number" ? row["episode_number"] : null;
+		const postingOpensAt = typeof row["posting_opens_at"] === "string" ? row["posting_opens_at"] : null;
 		return {
 			date: String(row["room_date"] ?? "").slice(0, 10),
 			start: episodeNumber,
 			end: episodeNumber,
 			label: typeof row["episode_title"] === "string" ? row["episode_title"] : null,
+			opened: postingOpensAt !== null && postingOpensAt <= nowIso,
 		};
 	});
 }

--- a/src/routes/anime/[id]/+page.server.ts
+++ b/src/routes/anime/[id]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail } from "@sveltejs/kit";
 import { recommendAnimeAction, removeUserAnimeEntry, upsertUserAnimeEntry } from "$lib/server/actions";
 import { addBroadcastOverrideAction, deleteBroadcastOverrideAction, updateAnimeAction } from "$lib/server/anime-admin";
+import { buildBroadcastEpisodeLog } from "$lib/server/broadcast-episode-log";
 import {
 	getAnime,
 	getAnimeDataAttributions,
@@ -11,9 +12,6 @@ import {
 	getUsersWhoListedAnime,
 	isAdminUser,
 } from "$lib/server/queries";
-import { jstBroadcastDate } from "$lib/syobocal-schedule";
-import { inferEpisodeNumbersBackward, normalizedBroadcastEpisodeLabel } from "$lib/utils/broadcast-episodes";
-import { isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ params, locals: { supabase, safeGetSession } }) => {
@@ -35,61 +33,12 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 		getBroadcastRoomScheduleSnapshotsForAnime(supabase, Number(anime.id)),
 	]);
 
-	// 各話ルームの履歴は実際に存在するセッション（しょぼい由来の話数付き
-	// スナップショット）が唯一の情報源。曜日からの機械カウントは行わない。
-	// 管理者オーバーライドはラベル（総集編等）の上書きにだけ使う。
-	// シーズン境界（isEligibleForRoomLog）はルーム「合成」のゲートであり、
-	// 実在セッションの一覧には適用しない: 2026-spring以前開始の長期放送作品
-	// （BEYBLADE X等）も、サービス開始後に開催されたルームは列挙する。
-	const overrideByDate = new Map(broadcastOverrides.map((override) => [roomDateKey(override.room_date), override]));
-	const episodeByDate = new Map<string, import("$lib/utils/broadcast-episodes").BroadcastEpisodeSlot>(
-		scheduleSnapshots.map((snapshot) => {
-			const override = overrideByDate.get(snapshot.date);
-			return [
-				snapshot.date,
-				{
-					date: snapshot.date,
-					start: snapshot.start,
-					end: snapshot.end,
-					label: (override ? normalizedBroadcastEpisodeLabel(override) : null) ?? snapshot.label,
-				},
-			];
-		}),
-	);
-	// しょぼい同期開始前の放送分にはセッション行が無い。ルームページの合成表示
-	// （対象シーズン+曜日・放送期間ゲート）と同じルールで過去日を補完して、
-	// 「ログに載る日付 ⇔ ルームページが開ける日付」を一致させる。話数は情報源
-	// （しょぼい）が過去に遡れないため付けない — 機械カウントはしない。
-	if (
-		isEligibleForRoomLog(anime.season) &&
-		anime.room_type === "episode" &&
-		anime.aired_from != null &&
-		anime.broadcast_day != null &&
-		anime.broadcast_time != null
-	) {
-		const todayKey = jstBroadcastDate(new Date());
-		const airedToKey = anime.aired_to?.slice(0, 10) ?? null;
-		const cursor = new Date(`${anime.aired_from.slice(0, 10)}T00:00:00`);
-		while (cursor.getDay() !== anime.broadcast_day) cursor.setDate(cursor.getDate() + 1);
-		for (let guard = 0; guard < 400; guard += 1, cursor.setDate(cursor.getDate() + 7)) {
-			const date = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`;
-			if (date >= todayKey || (airedToKey && date > airedToKey)) break;
-			if (episodeByDate.has(date)) continue;
-			const override = overrideByDate.get(date);
-			if (override?.is_cancelled) continue;
-			episodeByDate.set(date, {
-				date,
-				start: null,
-				end: null,
-				label: override ? normalizedBroadcastEpisodeLabel(override) : null,
-			});
-		}
-	}
-	// 同期開始前の合成日付に、しょぼい話数（アンカー）からの逆算で番号を振る。
-	// オーバーライド（話数明示・総集編）を尊重し、整合しない作品は番号なしのまま。
-	const ascending = [...episodeByDate.values()].sort((left, right) => left.date.localeCompare(right.date));
-	inferEpisodeNumbersBackward(ascending, overrideByDate);
-	const episodes = ascending.sort((left, right) => right.date.localeCompare(left.date));
+	// 各話ルームの履歴タイムライン（実在セッション+同期前の合成補完+アンカー逆算）
+	// の構築は buildBroadcastEpisodeLog に集約。未開場セッションは逆算のアンカー
+	// としてだけ使い、ログには開場済み（opened）の日付のみ載せる。
+	const episodes = buildBroadcastEpisodeLog(anime, scheduleSnapshots, broadcastOverrides)
+		.filter((slot) => slot.opened)
+		.sort((left, right) => right.date.localeCompare(left.date));
 
 	return { anime, user, isAdmin, listedUsers, relations, dataAttributions, episodes, broadcastOverrides, events };
 };

--- a/src/routes/rooms/anime/[id]/[date]/+page.server.ts
+++ b/src/routes/rooms/anime/[id]/[date]/+page.server.ts
@@ -6,11 +6,14 @@ import {
 	toggleLikeAction,
 	toggleRepostAction,
 } from "$lib/server/actions";
+import { buildBroadcastEpisodeLog } from "$lib/server/broadcast-episode-log";
 import {
 	getAnime,
 	getAnimeRankingTrending,
 	getBroadcastRoomOverride,
+	getBroadcastRoomOverridesForAnime,
 	getBroadcastRoomPosts,
+	getBroadcastRoomScheduleSnapshotsForAnime,
 	getBroadcastRoomSession,
 } from "$lib/server/queries";
 import { getRoomExitSurveyLoadState, ROOM_EXIT_SURVEY_VERSION } from "$lib/server/room-exit-survey";
@@ -111,9 +114,18 @@ export const load: PageServerLoad = async ({ params, locals: { supabase, safeGet
 	if (!session) throw error(404, "放送ルームが見つかりません");
 
 	const hashtag = roomHashtag(anime);
-	// 話数はしょぼい番組表由来の値のみ（曜日からの機械カウントはしない）。
-	// 同期セッション以外（合成表示・オーバーライド起点）は話数なしで表示する。
-	const episodeNumber = session.episode_number ?? null;
+	// 話数はしょぼい番組表由来の値が第一。番号の無いセッション（同期開始前の
+	// 実在・合成ルーム）は、詳細ページのルームログと同じアンカー逆算で補う
+	// （曜日からの機械カウントはしない）。一挙放送等の範囲はタイトルに使わない。
+	let episodeNumber = session.episode_number ?? null;
+	if (episodeNumber == null && isEligibleForRoomLog(anime.season)) {
+		const [snapshots, overrides] = await Promise.all([
+			getBroadcastRoomScheduleSnapshotsForAnime(supabase, Number(anime.id)),
+			getBroadcastRoomOverridesForAnime(supabase, params.id),
+		]);
+		const slot = buildBroadcastEpisodeLog(anime, snapshots, overrides).find((entry) => entry.date === params.date);
+		if (slot && slot.start != null && slot.start === slot.end) episodeNumber = slot.start;
+	}
 	const roomExperimentSupabase = user ? createRoomExperimentServiceClient() : null;
 	const [posts, trending, animeTrending, roomExperimentRun, roomExitSurveyLoadState] = await Promise.all([
 		getBroadcastRoomPosts(supabase, session.id, user?.id ?? null, { limit: 100, ascending: true }),


### PR DESCRIPTION
## Summary
- 神の雫のように「番号付きセッションが未来（未開場）にしかない」作品のルームログに話数が付かない問題を修正。スナップショットクエリが未開場セッションを除外していたため、アンカー逆算の起点が届いていなかった
- 詳細ページのタイムライン構築+アンカー逆算を `buildBroadcastEpisodeLog`（`src/lib/server/broadcast-episode-log.ts`）に集約。未開場セッションは逆算のアンカーとしてのみ参加し、ログ表示は開場済み（opened）の日付だけ
- ルームページでも同じ逆算を使い、話数なしの過去/合成ルームのタイトルに推定話数を表示（`session.episode_number` が第一、逆算はフォールバック）

## Test plan
- [x] ユニットテスト追加: 未開場アンカーからの逆算、総集編オーバーライドの尊重
- [x] `pnpm check` 通過
- [x] `pnpm exec vitest run` 149/149 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)