### PR TITLE
Skip labeled specials in numbering; synthesize on the anchor weekday

### DIFF
--- a/src/lib/server/broadcast-episode-log.test.ts
+++ b/src/lib/server/broadcast-episode-log.test.ts
@@ -64,6 +64,49 @@ describe("buildBroadcastEpisodeLog", () => {
 		]);
 	});
 
+	it("does not count unnumbered syobocal slots that carry their own subtitle (特番)", () => {
+		// ヤニねこパターン: しょぼいが話数を付けず「特番」とだけ題した枠は
+		// 通常話ではないので、逆算のカウントを消費しない。
+		const log = buildBroadcastEpisodeLog(
+			ANIME,
+			[
+				snapshot("2026-07-31"),
+				snapshot("2026-08-07"),
+				snapshot("2026-08-14", null, true, "特番"),
+				snapshot("2026-08-21"),
+				snapshot("2026-08-28", 4, false),
+			],
+			[],
+		);
+		expect(log.map((slot) => [slot.date, slot.start, slot.label])).toEqual([
+			["2026-07-31", 1, null],
+			["2026-08-07", 2, null],
+			["2026-08-14", null, "特番"],
+			["2026-08-21", 3, null],
+			["2026-08-28", 4, null],
+		]);
+	});
+
+	it("synthesizes gap dates on the anchor's weekday, not a stale broadcast_day", () => {
+		// 骸骨騎士様Ⅱパターン: MAL由来 broadcast_day がAT-X先行の月曜のままでも、
+		// しょぼいアンカー（木曜）の曜日で過去日を補完する。
+		const anime = {
+			...ANIME,
+			aired_from: "2026-07-06",
+			aired_to: "2026-08-06",
+			broadcast_day: 1,
+			broadcast_time: "22:00",
+		};
+		const log = buildBroadcastEpisodeLog(anime, [snapshot("2026-08-06", 5)], []);
+		expect(log.map((slot) => [slot.date, slot.start])).toEqual([
+			["2026-07-09", 1],
+			["2026-07-16", 2],
+			["2026-07-23", 3],
+			["2026-07-30", 4],
+			["2026-08-06", 5],
+		]);
+	});
+
 	it("drops cancelled dates even when a stale session row still exists", () => {
 		// 放送休止オーバーライドより前に（旧フォールバック等で）セッション行が
 		// 作られていた場合でも、ログから除外され番号カウントも消費しない。

--- a/src/lib/server/broadcast-episode-log.ts
+++ b/src/lib/server/broadcast-episode-log.ts
@@ -50,17 +50,26 @@ export function buildBroadcastEpisodeLog(
 			];
 		}),
 	);
+	// 合成補完の曜日はしょぼい由来の話数付きセッション（アンカー）の曜日を最優先
+	// する。MAL由来の broadcast_day が AT-X 等の先行放送の曜日を指している作品
+	// （骸骨騎士様Ⅱ: MAL=月曜(AT-X) / 地上波最速=MX木曜）で、存在しない曜日の
+	// 日付を合成してしまうのを防ぐ。room_date は放送日慣習で統一されているので
+	// アンカーの曜日はそのままログの週次パターンになる。
+	const anchorSlot = [...slotByDate.values()]
+		.filter((slot) => slot.start != null)
+		.sort((left, right) => left.date.localeCompare(right.date))[0];
+	const effectiveBroadcastDay = anchorSlot ? new Date(`${anchorSlot.date}T00:00:00`).getDay() : anime.broadcast_day;
 	if (
 		isEligibleForRoomLog(anime.season) &&
 		anime.room_type === "episode" &&
 		anime.aired_from != null &&
-		anime.broadcast_day != null &&
+		effectiveBroadcastDay != null &&
 		anime.broadcast_time != null
 	) {
 		const todayKey = jstBroadcastDate(new Date());
 		const airedToKey = anime.aired_to?.slice(0, 10) ?? null;
 		const cursor = new Date(`${anime.aired_from.slice(0, 10)}T00:00:00`);
-		while (cursor.getDay() !== anime.broadcast_day) cursor.setDate(cursor.getDate() + 1);
+		while (cursor.getDay() !== effectiveBroadcastDay) cursor.setDate(cursor.getDate() + 1);
 		for (let guard = 0; guard < 400; guard += 1, cursor.setDate(cursor.getDate() + 7)) {
 			const date = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`;
 			if (date >= todayKey || (airedToKey && date > airedToKey)) break;

--- a/src/lib/utils/broadcast-episodes.ts
+++ b/src/lib/utils/broadcast-episodes.ts
@@ -241,8 +241,10 @@ export function inferEpisodeNumbersBackward(
 			current = override.episode_start;
 			continue;
 		}
-		if (override && normalizedBroadcastEpisodeLabel(override) !== null) {
-			// 総集編等: 番号なし・カウント消費なし（ラベルは呼び出し側で設定済み）
+		if (slot.label != null || (override && normalizedBroadcastEpisodeLabel(override) !== null)) {
+			// 総集編・特番等: 番号なし・カウント消費なし。slot.label はオーバーライド
+			// 由来のほか、しょぼいが話数を付けずサブタイトルだけ付けた枠（「特番」等）
+			// も含む — しょぼい絶対の原則では話数なし枠は通常話ではない。
 			continue;
 		}
 		const candidate = current - 1;


### PR DESCRIPTION
## Summary
- しょぼいが話数を付けずサブタイトルだけ付けた枠（ヤニねこ8/27「特番」）は通常話ではないため、総集編と同様に番号なし・カウント非消費で扱う
- 過去日の合成補完の曜日を、MAL由来`broadcast_day`よりしょぼいアンカー（話数付きセッション）の曜日を優先。AT-X等の先行放送の曜日がMALに載っている作品（骸骨騎士様Ⅱ: MAL=月曜(AT-X)/地上波最速=MX木曜）で、放送のない曜日の日付を合成してしまうのを防ぐ
- 監査スクリプトにも同じ扱いを反映

## Test plan
- [x] ユニットテスト2件追加（特番スロットのカウント非消費・アンカー曜日での合成）
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 152/152 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)