### PR TITLE
Snap day-late MAL aired_from to the late-night convention weekday

### DIFF
--- a/src/lib/server/broadcast-episode-log.test.ts
+++ b/src/lib/server/broadcast-episode-log.test.ts
@@ -107,6 +107,26 @@ describe("buildBroadcastEpisodeLog", () => {
 		]);
 	});
 
+	it("snaps a day-late MAL aired_from back to the late-night convention weekday", () => {
+		// MALは24時超表記に対応せず、土曜25:30の初回を「日曜」の実日付で返すことが
+		// ある。1日前から探索して土曜(慣習日)の週次パターンに吸着させる。
+		const anime = {
+			...ANIME,
+			aired_from: "2026-07-05",
+			aired_to: "2026-08-01",
+			broadcast_day: 6,
+			broadcast_time: "25:30",
+		};
+		const log = buildBroadcastEpisodeLog(anime, [snapshot("2026-08-01", 5)], []);
+		expect(log.map((slot) => [slot.date, slot.start])).toEqual([
+			["2026-07-04", 1],
+			["2026-07-11", 2],
+			["2026-07-18", 3],
+			["2026-07-25", 4],
+			["2026-08-01", 5],
+		]);
+	});
+
 	it("drops cancelled dates even when a stale session row still exists", () => {
 		// 放送休止オーバーライドより前に（旧フォールバック等で）セッション行が
 		// 作られていた場合でも、ログから除外され番号カウントも消費しない。

--- a/src/lib/server/broadcast-episode-log.ts
+++ b/src/lib/server/broadcast-episode-log.ts
@@ -5,7 +5,7 @@ import {
 	inferEpisodeNumbersBackward,
 	normalizedBroadcastEpisodeLabel,
 } from "$lib/utils/broadcast-episodes";
-import { isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
+import { broadcastTimeMinutes, isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
 
 export type BroadcastEpisodeLogSlot = BroadcastEpisodeSlot & { opened: boolean };
 
@@ -69,6 +69,11 @@ export function buildBroadcastEpisodeLog(
 		const todayKey = jstBroadcastDate(new Date());
 		const airedToKey = anime.aired_to?.slice(0, 10) ?? null;
 		const cursor = new Date(`${anime.aired_from.slice(0, 10)}T00:00:00`);
+		// MALの開始日は24時超の慣習表記に対応せず、深夜帯では翌日の実日付が入る
+		// ことがある。24時以降の作品は1日前から探索を始めて放送日慣習（前日側）の
+		// 週次パターンに吸着させる。開始日が既に慣習日なら曜日が合わず素通りする
+		// だけなので影響しない。
+		if ((broadcastTimeMinutes(anime.broadcast_time) ?? 0) >= 24 * 60) cursor.setDate(cursor.getDate() - 1);
 		while (cursor.getDay() !== effectiveBroadcastDay) cursor.setDate(cursor.getDate() + 1);
 		for (let guard = 0; guard < 400; guard += 1, cursor.setDate(cursor.getDate() + 7)) {
 			const date = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`;


### PR DESCRIPTION
## Summary
- MALは24時超表記に対応しないため、土曜25:30初回の作品で aired_from が実日付（日曜）になることがあり、合成補完が初回週を丸ごと飛ばして逆算話数が1週ズレる
- 深夜帯（broadcast_time >= 24:00）の作品は探索を1日前から始め、放送日慣習の曜日に吸着させる。開始日が既に慣習日なら曜日が合わず素通りするだけで無影響
- 現行対象シーズンに該当作品なし（スキャンで確認: ズレは旧シーズンと2026-fallプレースホルダーのみ）。秋クール取り込みへの予防措置

## Test plan
- [x] ユニットテスト追加（日曜付きaired_from→土曜慣習日への吸着）
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 153/153 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)