### PR TITLE
Drop the ◯分枠 label from the room header

### DIFF
--- a/src/lib/components/room/LiveRoomView.svelte
+++ b/src/lib/components/room/LiveRoomView.svelte
@@ -593,12 +593,10 @@ const timerLabel = $derived.by(() => {
 	return "このルームは終了しました";
 });
 
+// 「◯分枠」表示は廃止: イレギュラー放送で枠が変動すると実態とズレるため放送局のみ
 const broadcastMetaLine = $derived.by(() => {
 	if (isGlobalLobby) return "";
-	const station = data.anime?.broadcast_station?.filter(Boolean).join(" / ");
-	const frame = data.room.duration_minutes != null ? `${data.room.duration_minutes}分枠` : "";
-	if (station && frame) return `${station} · ${frame}`;
-	return station || frame;
+	return data.anime?.broadcast_station?.filter(Boolean).join(" / ") ?? "";
 });
 
 function formatCompactDate(iso: string) {


### PR DESCRIPTION
## Summary
- ルーム右上の「30分枠」表示を一律廃止。イレギュラー放送（拡大SP・時間変更）で実態とズレて紛らわしいため、放送局名のみ表示する

## Test plan
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 153/153 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)