### PR TITLE
Forward-number ended shows that have no syobocal anchor

### DIFF
--- a/src/lib/server/broadcast-episode-log.test.ts
+++ b/src/lib/server/broadcast-episode-log.test.ts
@@ -127,6 +127,30 @@ describe("buildBroadcastEpisodeLog", () => {
 		]);
 	});
 
+	it("forward-numbers an ended show with no syobocal anchor", () => {
+		// 同期開始前に放送を終えた作品: アンカーが無いので第1話から前進カウント
+		const anime = {
+			...ANIME,
+			aired_from: "2026-07-04",
+			aired_to: "2026-07-25",
+			broadcast_day: 6,
+			broadcast_time: "21:00",
+		};
+		const log = buildBroadcastEpisodeLog(anime, [], []);
+		expect(log.map((slot) => [slot.date, slot.start])).toEqual([
+			["2026-07-04", 1],
+			["2026-07-11", 2],
+			["2026-07-18", 3],
+			["2026-07-25", 4],
+		]);
+	});
+
+	it("leaves an airing show without an anchor unnumbered (mapping issue, not countable)", () => {
+		const anime = { ...ANIME, aired_from: "2026-07-04", broadcast_day: 6, broadcast_time: "21:00" };
+		const log = buildBroadcastEpisodeLog(anime, [snapshot("2026-07-04"), snapshot("2026-07-11")], []);
+		expect(log.every((slot) => slot.start == null)).toBe(true);
+	});
+
 	it("drops cancelled dates even when a stale session row still exists", () => {
 		// 放送休止オーバーライドより前に（旧フォールバック等で）セッション行が
 		// 作られていた場合でも、ログから除外され番号カウントも消費しない。

--- a/src/lib/server/broadcast-episode-log.ts
+++ b/src/lib/server/broadcast-episode-log.ts
@@ -3,6 +3,7 @@ import type { Anime, BroadcastRoomOverride } from "$lib/types";
 import {
 	type BroadcastEpisodeSlot,
 	inferEpisodeNumbersBackward,
+	inferEpisodeNumbersForward,
 	normalizedBroadcastEpisodeLabel,
 } from "$lib/utils/broadcast-episodes";
 import { broadcastTimeMinutes, isEligibleForRoomLog, roomDateKey } from "$lib/utils/broadcast-room";
@@ -93,5 +94,10 @@ export function buildBroadcastEpisodeLog(
 	const ascending = [...slotByDate.values()].sort((left, right) => left.date.localeCompare(right.date));
 	// オーバーライド（話数明示・総集編）を尊重した逆算。整合しない作品は番号なしのまま。
 	inferEpisodeNumbersBackward(ascending, overrideByDate);
+	// アンカーが1件も無い＝しょぼい同期開始前に放送を終えた作品は、逆算の起点が
+	// 永遠に得られない。放送終了済みに限り、第1話からの前進カウントで補う
+	// （放送中でアンカーが無いのはマッピング不備なので番号なしのまま残す）。
+	const ended = anime.aired_to != null && anime.aired_to.slice(0, 10) < jstBroadcastDate(new Date());
+	if (!anchorSlot && ended) inferEpisodeNumbersForward(ascending, overrideByDate);
 	return ascending;
 }

--- a/src/lib/utils/broadcast-episodes.test.ts
+++ b/src/lib/utils/broadcast-episodes.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { BroadcastRoomOverride } from "$lib/types";
-import { type BroadcastEpisodeSlot, inferEpisodeNumbersBackward } from "./broadcast-episodes";
+import {
+	type BroadcastEpisodeSlot,
+	inferEpisodeNumbersBackward,
+	inferEpisodeNumbersForward,
+} from "./broadcast-episodes";
 
 function slot(date: string, start: number | null = null, label: string | null = null): BroadcastEpisodeSlot {
 	return { date, start, end: start, label };
@@ -76,5 +80,36 @@ describe("inferEpisodeNumbersBackward", () => {
 		const mismatch = inferEpisodeNumbersBackward(slots, new Map());
 		expect(mismatch).toEqual({ kind: "underflow", date: "2026-07-14" });
 		expect(slots.map((s) => s.start)).toEqual([null, null, 1, 2]);
+	});
+});
+
+describe("inferEpisodeNumbersForward", () => {
+	it("numbers from episode 1 respecting recap and marathon overrides", () => {
+		const overrides = new Map<string, BroadcastRoomOverride>([
+			["2026-07-14", override({ room_date: "2026-07-14", episode_count_increment: 0, episode_label: "総集編" })],
+			["2026-07-21", override({ room_date: "2026-07-21", episode_start: 2, episode_end: 3 })],
+		]);
+		const slots = [
+			slot("2026-07-07"),
+			slot("2026-07-14", null, "総集編"),
+			slot("2026-07-21"),
+			slot("2026-07-28"),
+			slot("2026-08-04"),
+		];
+		const last = inferEpisodeNumbersForward(slots, overrides);
+		expect(slots.map((s) => [s.start, s.end])).toEqual([
+			[1, 1],
+			[null, null],
+			[2, 3],
+			[4, 4],
+			[5, 5],
+		]);
+		expect(last).toBe(5);
+	});
+
+	it("does not consume counts for slots that already carry a label", () => {
+		const slots = [slot("2026-07-07"), slot("2026-07-14", null, "特番"), slot("2026-07-21")];
+		expect(inferEpisodeNumbersForward(slots, new Map())).toBe(2);
+		expect(slots.map((s) => s.start)).toEqual([1, null, 2]);
 	});
 });

--- a/src/lib/utils/broadcast-episodes.ts
+++ b/src/lib/utils/broadcast-episodes.ts
@@ -267,6 +267,45 @@ export function inferEpisodeNumbersBackward(
 	return mismatch;
 }
 
+/**
+ * アンカー（しょぼい話数）が1件も無い作品向けの前進カウント。同期開始前に
+ * 放送を終えた作品はしょぼいが過去に遡れず永遠に番号が付かないため、
+ * 第1話からの週次カウントで補う（ユーザー承認済みの例外運用）。
+ * オーバーライドの扱いは逆算と同じ:
+ * - episode_start/end 明示 → その値を採用し、続きから再カウント
+ * - ラベル持ち（総集編・特番等） → 番号を振らず、カウントも消費しない
+ * slots は日付昇順で渡すこと。返り値は最後に割り当てた話数（検証用）。
+ */
+export function inferEpisodeNumbersForward(
+	slots: BroadcastEpisodeSlot[],
+	overrides: ReadonlyMap<string, BroadcastRoomOverride>,
+): number | null {
+	let current = 1;
+	let lastAssigned: number | null = null;
+	for (const slot of slots) {
+		if (slot.start != null) {
+			// 既に番号を持つ（実セッション等）→ 続きから再カウント
+			current = (slot.end ?? slot.start) + 1;
+			lastAssigned = slot.end ?? slot.start;
+			continue;
+		}
+		const override = overrides.get(slot.date);
+		if (override?.episode_start != null && override.episode_end != null) {
+			slot.start = override.episode_start;
+			slot.end = override.episode_end;
+			current = override.episode_end + 1;
+			lastAssigned = override.episode_end;
+			continue;
+		}
+		if (slot.label != null || (override && normalizedBroadcastEpisodeLabel(override) !== null)) continue;
+		slot.start = current;
+		slot.end = current;
+		lastAssigned = current;
+		current += 1;
+	}
+	return lastAssigned;
+}
+
 export function resolveBroadcastEpisodeSlot(input: ResolveBroadcastEpisodeInput): BroadcastEpisodeSlot | null {
 	const target = parseDate(input.date);
 	const slots = generateBroadcastEpisodeSlots({ ...input, today: target });


### PR DESCRIPTION
## Summary
- 同期開始前に放送を終えた作品（no_anchor 53件）はしょぼいアンカーが永遠に得られないため、承認済みの例外運用として第1話からの前進カウントで話数を付与
- オーバーライドの意味論は逆算と同一（episode_start/end明示で再カウント、ラベル持ち総集編・特番はカウント非消費）
- 放送中でアンカーが無い作品は番号なしのまま（マッピング不備のシグナルであり推測しない）
- 監査は前進カウントの最終話数と総話数(episode_count)を突き合わせ、ズレた作品をforward_mismatchとして列挙

## Test plan
- [x] ユニットテスト4件追加 / `pnpm check` 通過 / `pnpm exec vitest run` 157/157 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)