### PR TITLE
Stop deleting just-held sessions in the sync cleanup

### DIFF
--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -1324,7 +1324,6 @@ function buildBroadcastRoomSessionRows(
 	importedAt: string,
 ) {
 	const animeByMal = new Map(animeRows.map((anime) => [anime.mal_id, anime]));
-	const now = Date.now();
 	const rows = primaryPrograms.flatMap((program) => {
 		const anime = animeByMal.get(program.malId);
 		if (!anime || anime.room_type === "global" || !anime.metadata_ready || anime.hidden_by_admin) return [];
@@ -1337,7 +1336,10 @@ function buildBroadcastRoomSessionRows(
 		const preOpenMinutes = anime.broadcast_room_pre_open_minutes ?? 5;
 		const postCloseMinutes = anime.broadcast_room_post_close_minutes ?? 30;
 		const postingOpensAt = startsAt - preOpenMinutes * 60_000;
-		if (postingOpensAt <= now) return [];
+		// 開場済みの枠もここでは除外しない: ローリング窓の先頭（昨日）に落ちた
+		// 「昨夜開催されたばかりのルーム」も現在の選定の一部であり、除外すると
+		// 陳腐化クリーンアップが正当な開催済みセッションを削除してしまう。
+		// 開場済み行の扱い（既存は更新しない・新規は遡及作成）は保存側で行う。
 		// 深夜アニメ慣習: 4時前の枠は前日の放送日として room_date を振る
 		// （overrides / ensure_broadcast_room_session と同じ基準）
 		const roomDate = jstBroadcastDate(program.startsAt);


### PR DESCRIPTION
## Summary
- 昨日の陳腐化クリーンアップ拡張のリグレッション修正: 開場済み番組が行構築から除外されるため、ローリング窓先頭（昨夜）の開催済みセッションが「選定外」に見え、正当な番号付きセッション8件（8/26放送の幼女戦記Ⅱ・落第賢者・片田舎Ⅱ等）が削除されていた
- 開場済み番組も選定に残す: 既存セッションはused判定に参加（更新はしない従来挙動を維持）、行が無い場合は遡及作成（窓は昨日開始なので直近1日分のみ）
- 同期の再実行で削除された8件が復元される

## Test plan
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 159/159 通過
- [ ] マージ後に同期を再実行し、8/26放送分セッションの復元と監査のleftover回復を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)