### PR TITLE
Gate the airing episode-count rule by dates; sanitize cancelled overrides

### DIFF
--- a/src/lib/anime-catalog-resolver.test.ts
+++ b/src/lib/anime-catalog-resolver.test.ts
@@ -204,6 +204,36 @@ describe("resolveAnimeCatalog", () => {
 		expect(resolved.canonical.resources).toEqual([]);
 	});
 
+	it("applies the airing episode-count rule by dates even when the stored status is stale", () => {
+		// BLEACH禍進譚パターン: 放送開始済みなのにソースレコードが upcoming のまま
+		const resolved = resolveAnimeCatalog([
+			source("anime_offline_database", {
+				title: "Example",
+				episode_count: "12",
+				status: "upcoming",
+				aired_from: "2020-01-01",
+			}),
+			source("mal", { title_ja: "例の作品", status: "upcoming", aired_from: "2020-01-01" }),
+		]);
+		// 日付上は放送中（from過去・to無し・finishedでない）→ AODBの固定値は使わない
+		expect(resolved.canonical.episode_count).toBeNull();
+	});
+
+	it("keeps the offline episode total for a show that ended by dates despite a stale airing status", () => {
+		// ちびゴジラパターン: 終了済みなのにソースレコードが airing のまま
+		const resolved = resolveAnimeCatalog([
+			source("anime_offline_database", {
+				title: "Example",
+				episode_count: "24",
+				status: "airing",
+				aired_from: "2020-01-01",
+				aired_to: "2020-06-30",
+			}),
+			source("mal", { title_ja: "例の作品", status: "airing", aired_from: "2020-01-01", aired_to: "2020-06-30" }),
+		]);
+		expect(resolved.canonical.episode_count).toBe("24");
+	});
+
 	it("prefers Syobocal's leading-channel broadcast day/time over MAL's pre-air slot", () => {
 		// 骸骨騎士様Ⅱパターン: MALはAT-X先行の月曜22:00、地上波最速はMX木曜24:00
 		const resolved = resolveAnimeCatalog([

--- a/src/lib/anime-catalog-resolver.ts
+++ b/src/lib/anime-catalog-resolver.ts
@@ -463,7 +463,22 @@ export function resolveAnimeCatalog(
 	// 放送中の作品では anime-offline-database の話数がスナップショット時点で
 	// 固定された古い値になりがち（例: BEYBLADE X）。放送中はMAL/Jikanの現行値を
 	// 優先し、どちらにも無ければ「総話数未確定」として null にする。
-	if (status.value === "airing" && episodeCount.source === "anime_offline_database") {
+	// 「放送中」の判定は放送日付を優先する: ソースレコードの status は取り込みが
+	// 止まると陳腐化し（放送開始後もupcomingのまま等）、保存statusだけに頼ると
+	// このルールが素通り/誤発動する。日付が無い場合のみ status にフォールバック。
+	const todayJst = new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Tokyo" }).format(new Date());
+	const airedFromKey = airedFrom.value?.slice(0, 10) ?? null;
+	const airedToKey = airedTo.value?.slice(0, 10) ?? null;
+	// 終了日不明（単発映画等はtoが無いままfinishedになる）は status で補完する
+	const effectivelyAiring =
+		airedFromKey != null && airedFromKey <= todayJst
+			? airedToKey != null
+				? airedToKey >= todayJst
+				: status.value !== "finished"
+			: airedFromKey != null
+				? false
+				: status.value === "airing";
+	if (effectivelyAiring && episodeCount.source === "anime_offline_database") {
 		const liveCount = stringValue(mal, "episode_count") ?? stringValue(jikan, "episode_count") ?? null;
 		episodeCount.value = liveCount;
 		if (liveCount !== null) episodeCount.source = stringValue(mal, "episode_count") ? "mal" : "jikan";

--- a/src/lib/server/anime-admin.ts
+++ b/src/lib/server/anime-admin.ts
@@ -379,10 +379,12 @@ export async function addBroadcastOverrideAction(
 			duration_minutes: durationMinutes,
 			pre_open_minutes: preOpenMinutes,
 			post_close_minutes: postCloseMinutes,
-			episode_start: episodeStart,
-			episode_end: episodeEnd,
-			episode_label: episodeLabel,
-			episode_count_increment: episodeCountIncrement,
+			// 放送休止はルーム自体が立たないため話数系フィールドは意味を持たない。
+			// UIの種別切替で残った値が保存されないようサーバー側で落とす
+			episode_start: isCancelled ? null : episodeStart,
+			episode_end: isCancelled ? null : episodeEnd,
+			episode_label: isCancelled ? null : episodeLabel,
+			episode_count_increment: isCancelled ? null : episodeCountIncrement,
 			is_cancelled: isCancelled,
 			announcement_label: announcementLabel,
 			note: nullableText(fd, "note"),


### PR DESCRIPTION
## Summary
- 「放送中はAODB総話数を隠す」ルールの判定を保存statusから放送日付ベースに変更。取り込み停止でstatusが陳腐化しても（BLEACH禍進譚: 放送開始後もupcoming→ルール素通り / ちびゴジラ3期: 終了後もairing→総話数を誤って隠す）正しく動作する。日付で判定できない場合のみstatusにフォールバック
- 放送休止オーバーライドは話数系フィールド（episode_start/end・label・increment）をサーバー側で必ずnull保存。管理UIの種別切替で残った値が矛盾行を作らない
- 既存の矛盾6行（転スラ4期・本好き×2・最強の王様2・DIGIMON×2）はDB上でクリア済み

## Test plan
- [x] リゾルバテスト2件追加（status陳腐化の両方向）
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 161/161 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)