### PR TITLE
Minor catalog fixes: stale seasons, non-TV lobby default, type badges

### DIFF
--- a/scripts/resolve-anime-catalog.ts
+++ b/scripts/resolve-anime-catalog.ts
@@ -489,9 +489,19 @@ async function applyShortAnimeLobbyRule(
 				? (mal.normalized_data as Record<string, unknown>)
 				: null;
 		const duration = normalized?.["episode_duration_minutes"];
-		if (typeof duration !== "number" || duration <= 0) continue;
-		const autoRoomType = duration <= SHORT_ANIME_LOBBY_MINUTES ? "global" : "episode";
-		if ((current?.room_type ?? "episode") !== autoRoomType) {
+		let autoRoomType: string | null = null;
+		if (typeof duration === "number" && duration > 0) {
+			autoRoomType = duration <= SHORT_ANIME_LOBBY_MINUTES ? "global" : "episode";
+		}
+		// 非TV（OVA/ONA/Movie/Special）で放送情報が無い作品は各話ルームを開けない
+		// （しょぼい同期の対象外・曜日合成も不可）ため総合ロビーに落とす。後から
+		// TV放送が付いた場合（ONAのTV放送等）は broadcast 情報が入り episode に戻る。
+		const isTv = (resolution.canonical.type ?? "").toLowerCase() === "tv";
+		const noBroadcastInfo = canonical["broadcast_day"] == null && canonical["broadcast_time"] == null;
+		if (!isTv && noBroadcastInfo && autoRoomType !== "global") {
+			autoRoomType = "global";
+		}
+		if (autoRoomType !== null && (current?.room_type ?? "episode") !== autoRoomType) {
 			canonical["room_type"] = autoRoomType;
 			canonical["room_type_source"] = "auto";
 			applied += 1;

--- a/src/lib/anime-catalog-resolver.test.ts
+++ b/src/lib/anime-catalog-resolver.test.ts
@@ -204,6 +204,25 @@ describe("resolveAnimeCatalog", () => {
 		expect(resolved.canonical.resources).toEqual([]);
 	});
 
+	it("replaces a stale AODB season with the MAL season when only MAL matches aired_from", () => {
+		// 魔法使いの夜パターン: AODBは発表時の2026-winterのまま、実放送は11/20（fall）
+		const resolved = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "Example", season: "2026-winter", status: "upcoming" }),
+			source("mal", { title_ja: "例の作品", season: "2026-fall", aired_from: "2026-11-20" }),
+		]);
+		expect(resolved.canonical.season).toBe("2026-fall");
+		expect(resolved.fieldSources["season"]).toEqual({ source: "mal", confidence: "source" });
+	});
+
+	it("keeps the AODB season when aired_from is only a placeholder that matches nothing", () => {
+		// 年始プレースホルダー（01-01）はどのクールとも矛盾しうるが、代替も整合しなければ据え置く
+		const resolved = resolveAnimeCatalog([
+			source("anime_offline_database", { title: "Example", season: "2026-fall", status: "upcoming" }),
+			source("mal", { title_ja: "例の作品", season: "2026-fall", aired_from: "2026-01-01" }),
+		]);
+		expect(resolved.canonical.season).toBe("2026-fall");
+	});
+
 	it("applies the airing episode-count rule by dates even when the stored status is stale", () => {
 		// BLEACH禍進譚パターン: 放送開始済みなのにソースレコードが upcoming のまま
 		const resolved = resolveAnimeCatalog([

--- a/src/lib/anime-catalog-resolver.ts
+++ b/src/lib/anime-catalog-resolver.ts
@@ -217,6 +217,28 @@ function mergeResources(syobocal: Record<string, unknown>): { name: string; url:
 		.sort((left, right) => left.url.localeCompare(right.url));
 }
 
+const SEASON_MONTHS: Record<string, readonly number[]> = {
+	winter: [12, 1, 2, 3],
+	spring: [3, 4, 5, 6],
+	summer: [6, 7, 8, 9],
+	fall: [9, 10, 11, 12],
+};
+
+/** 「YYYY-season」が放送開始日の月とおおまかに整合するか（境界月は両側許容） */
+function seasonMatchesAiredFrom(season: string, airedFrom: string): boolean {
+	const match = season.match(/^(\d{4})-(winter|spring|summer|fall)$/);
+	if (!match) return true; // 形式外は判定しない（誤補正を避ける）
+	const year = Number(airedFrom.slice(0, 4));
+	const month = Number(airedFrom.slice(5, 7));
+	if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1) return true;
+	const seasonYear = Number(match[1]);
+	const months = SEASON_MONTHS[match[2] ?? ""] ?? [];
+	if (match[2] === "winter") {
+		return (year === seasonYear - 1 && month === 12) || (year === seasonYear && months.includes(month));
+	}
+	return year === seasonYear && months.includes(month);
+}
+
 export function resolveAnimeCatalog(
 	sourceRecords: readonly CatalogSourceRecord[],
 	legacyRow?: LegacyAnimeCatalogRow,
@@ -466,6 +488,31 @@ export function resolveAnimeCatalog(
 	// 「放送中」の判定は放送日付を優先する: ソースレコードの status は取り込みが
 	// 止まると陳腐化し（放送開始後もupcomingのまま等）、保存statusだけに頼ると
 	// このルールが素通り/誤発動する。日付が無い場合のみ status にフォールバック。
+	// season は AODB 優先だが、AODB のスナップショットは延期作品で「発表時の
+	// クール」のまま陳腐化する（魔法使いの夜: AODB=2026-winter / 実放送=11月）。
+	// 解決済み season が放送開始日と矛盾し、MAL/Jikan の season が開始日と
+	// 整合する場合のみそちらへ差し替える（manual はそのまま）。
+	if (season.source !== "manual" && season.value && airedFrom.value) {
+		const matches = seasonMatchesAiredFrom(season.value, airedFrom.value);
+		if (!matches) {
+			const alternative = (
+				[
+					{ value: stringValue(mal, "season"), source: "mal" as const },
+					{ value: stringValue(jikan, "season"), source: "jikan" as const },
+				] as const
+			).find(
+				(candidateSeason) =>
+					candidateSeason.value != null &&
+					seasonMatchesAiredFrom(candidateSeason.value, airedFrom.value ?? ""),
+			);
+			if (alternative?.value) {
+				season.value = alternative.value;
+				season.source = alternative.source;
+				season.confidence = "source";
+			}
+		}
+	}
+
 	const todayJst = new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Tokyo" }).format(new Date());
 	const airedFromKey = airedFrom.value?.slice(0, 10) ?? null;
 	const airedToKey = airedTo.value?.slice(0, 10) ?? null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -304,6 +304,7 @@ export type AnimeListItem = Pick<
 	| "cover_url"
 	| "season"
 	| "episode_count"
+	| "type"
 	| "broadcast_day"
 	| "computed_broadcast_status"
 	| "user_entry"

--- a/src/routes/anime/+page.server.ts
+++ b/src/routes/anime/+page.server.ts
@@ -15,7 +15,7 @@ import {
 import type { Anime, AnimeListItem } from "$lib/types";
 import type { Actions, PageServerLoad } from "./$types";
 
-/** Anime 全フィールドを HTML に埋め込まず、カード描画に必要な9フィールドだけへ射影する。 */
+/** Anime 全フィールドを HTML に埋め込まず、カード描画に必要なフィールドだけへ射影する。 */
 function toAnimeListItem(a: Anime): AnimeListItem {
 	return {
 		id: a.id,
@@ -24,6 +24,7 @@ function toAnimeListItem(a: Anime): AnimeListItem {
 		cover_url: a.cover_url,
 		season: a.season,
 		episode_count: a.episode_count,
+		type: a.type,
 		broadcast_day: a.broadcast_day,
 		computed_broadcast_status: a.computed_broadcast_status,
 		user_entry: a.user_entry ?? null,

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -751,6 +751,9 @@ function isAiringToday(anime: AnimeListItem): boolean {
 										aria-hidden={anime.season ? undefined : "true"}
 									>
 										{anime.season ?? '\u00A0'}
+										{#if anime.type && anime.type !== 'TV'}
+											<span class="anime-type-badge">{anime.type}</span>
+										{/if}
 									</span>
 								</div>
 								<div class="mylist-badge-slot">
@@ -1639,6 +1642,16 @@ function isAiringToday(anime: AnimeListItem): boolean {
 	color: var(--color-text-muted);
 	overflow: hidden;
 	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+/* 同一シーズンに同名のTV版とSpecial/ONA版が並ぶことがあるため、非TVは媒体を明示 */
+.anime-type-badge {
+	margin-left: 4px;
+	padding: 0 4px;
+	border: 1px solid var(--color-border);
+	border-radius: 3px;
+	font-size: 0.62rem;
+	color: var(--color-text-muted);
 	white-space: nowrap;
 }
 .anime-season--placeholder {


### PR DESCRIPTION
## Summary
- **season陳腐化の補正**: season解決はAODB優先だが、延期作品では発表時クールのまま古くなる（魔法使いの夜: AODB=2026-winter/実放送11/20）。解決済みseasonが放送開始日と矛盾し、MAL/Jikanのseasonが開始日と整合する場合のみ差し替える（manualは不変）。MAL照合で対象15件中12件がこのパターンと確認済み
- **非TV作品のロビー既定**: 放送曜日・時刻の無いOVA/ONA/Movie/Specialは各話ルームを開けないため、総合ロビーに自動分類（放送データが付けばepisodeに戻る・manualは不変）。該当79件（OVA61+ONA16+Movie2）
- **メディア種別バッジ**: カタログカードで非TV作品に種別バッジを表示し、同一シーズン同名の11組（TV版とSpecial/ONA版）を区別可能に

## Test plan
- [x] リゾルバテスト2件追加（season差し替え・プレースホルダー日付の据え置き）
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 163/163 通過
- [ ] マージ後に対象シーズンを再解決して反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)