### PR TITLE
Give first-time manual source records a non-null source_url

### DIFF
--- a/src/lib/server/anime-admin.ts
+++ b/src/lib/server/anime-admin.ts
@@ -62,7 +62,8 @@ async function upsertManualSourceRecord(
 			mal_id: malId,
 			source: "manual",
 			source_version: new Date().toISOString().slice(0, 10),
-			source_url: (existing?.source_url as string | null) ?? null,
+			// source_url は NOT NULL: 既存が無い初回作成は MAL ページを充てる
+			source_url: (existing?.source_url as string | null) ?? `https://myanimelist.net/anime/${malId}`,
 			normalized_data: { ...((existing?.normalized_data as Record<string, unknown>) ?? {}), ...changed },
 		},
 		{ onConflict: "mal_id,source" },


### PR DESCRIPTION
## Summary
- `anime_source_records.source_url`はNOT NULLのため、管理画面編集による初回のmanualレコード作成が黙って失敗し、編集が再解決から保護されないままになる欠陥を修正（PR #189のフォローアップ、season手動修正の適用中に発覚）
- 既存レコードが無い場合はMALページURLをデフォルトに使用

## Test plan
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 163/163 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)