### PR TITLE
Address CodeRabbit findings on the release PR

### DIFF
--- a/.github/workflows/syobocal-sync.yml
+++ b/.github/workflows/syobocal-sync.yml
@@ -81,6 +81,9 @@ jobs:
           SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
           MAL_CLIENT_ID: ${{ secrets.MAL_CLIENT_ID }}
         run: |
+          # シーズン単位で失敗を隔離する: 1シーズン目のしょぼい照合が落ちても
+          # 2シーズン目まで巻き添えにしない。失敗があれば最後にジョブを失敗させる。
+          FAILED=0
           for TARGET in \
             "${{ steps.season.outputs.year }} ${{ steps.season.outputs.season }}" \
             "${{ steps.season.outputs.next_year }} ${{ steps.season.outputs.next_season }}"; do
@@ -88,6 +91,11 @@ jobs:
             echo "=== $1-$2 ==="
             pnpm import:mal -- --year "$1" --season "$2" || echo "MAL import for $1-$2 failed; continuing"
             pnpm import:jikan -- --year "$1" --season "$2" || echo "Jikan import for $1-$2 failed; continuing"
-            pnpm import:syobocal -- --year "$1" --season "$2"
-            pnpm resolve:anime-catalog -- --year "$1" --season "$2"
+            if pnpm import:syobocal -- --year "$1" --season "$2"; then
+              pnpm resolve:anime-catalog -- --year "$1" --season "$2" || { echo "Resolve for $1-$2 failed"; FAILED=1; }
+            else
+              echo "Syobocal import for $1-$2 failed; skipping resolve"
+              FAILED=1
+            fi
           done
+          exit "$FAILED"

--- a/scripts/import-syobocal.ts
+++ b/scripts/import-syobocal.ts
@@ -289,7 +289,10 @@ async function fetchWithRetry(url: URL, accept: string): Promise<Response> {
 			const response = await fetch(url, { headers: { Accept: accept, "User-Agent": USER_AGENT } });
 			if (response.ok) return response;
 			if (response.status < 500 && response.status !== 429) {
-				throw new Error(`${response.status} ${response.statusText}`);
+				// 恒久エラー（400/404等）はリトライしても無駄なので即座に失敗させる。
+				// try内でthrowするとcatchに拾われてリトライ対象になってしまう。
+				lastError = new Error(`${response.status} ${response.statusText}`);
+				break;
 			}
 			lastError = new Error(`${response.status} ${response.statusText}`);
 			// Rate limiting needs a real cool-down, not a sub-second retry.
@@ -449,6 +452,17 @@ async function fetchChannels(): Promise<SyobocalChannel[]> {
 	if (channels.length < 10) {
 		throw new Error(`Syobocal channel snapshot is unexpectedly small (${channels.length} rows).`);
 	}
+	// ChGID欠損のチャンネルはtier判定でnullになり、その局の枠は黙って除外される。
+	// しょぼい側のデータ欠けや新規グループID追加に気づけるよう件数を出しておく。
+	const missingGroup = channels.filter((channel) => channel.channelGroupId === null);
+	if (missingGroup.length > 0) {
+		console.warn(
+			`${missingGroup.length} Syobocal channels have no ChGID and will be excluded from scheduling: ${missingGroup
+				.slice(0, 5)
+				.map((channel) => channel.name)
+				.join(", ")}${missingGroup.length > 5 ? ", ..." : ""}`,
+		);
+	}
 	return channels;
 }
 
@@ -507,7 +521,7 @@ async function fetchSourceRecords(supabase: ReturnType<typeof getSupabaseClient>
 			.from("anime_source_records")
 			.select("mal_id,source,normalized_data")
 			.in("mal_id", malIds.slice(start, start + DATABASE_BATCH_SIZE))
-			.in("source", ["manual", "wikidata", "jikan", "anime_offline_database"]);
+			.in("source", ["manual", "wikidata", "mal", "jikan", "anime_offline_database"]);
 		if (error) throw new Error(`Could not read anime source records: ${error.message}`);
 		rows.push(...((data ?? []) as SourceRecord[]));
 	}
@@ -1397,16 +1411,24 @@ async function saveBroadcastRoomSessions(
 	if (animeIds.length === 0) return;
 	const existing: BroadcastRoomSessionRow[] = [];
 	for (let start = 0; start < animeIds.length; start += DATABASE_BATCH_SIZE) {
-		const { data, error } = await supabase
-			.from("broadcast_room_sessions")
-			.select(
-				"id,anime_id,room_key,schedule_source,source_program_id,schedule_frozen_at,scheduled_at,posting_opens_at",
-			)
-			.eq("room_kind", "episode")
-			.in("anime_id", animeIds.slice(start, start + DATABASE_BATCH_SIZE));
-		if (error)
-			throw new Error(`Could not read broadcast room sessions (apply migration 104 first): ${error.message}`);
-		existing.push(...((data ?? []) as BroadcastRoomSessionRow[]));
+		// PostgRESTのmax_rows(1000)対策: 1バッチ内でもページングして全件読む。
+		// 取りこぼすと既存セッションがnewRows扱いになり、一意制約経由のupsertで
+		// 凍結・開場済みガードを迂回した更新や、誤った陳腐化削除につながる。
+		for (let page = 0; ; page += 1000) {
+			const { data, error } = await supabase
+				.from("broadcast_room_sessions")
+				.select(
+					"id,anime_id,room_key,schedule_source,source_program_id,schedule_frozen_at,scheduled_at,posting_opens_at",
+				)
+				.eq("room_kind", "episode")
+				.in("anime_id", animeIds.slice(start, start + DATABASE_BATCH_SIZE))
+				.order("id")
+				.range(page, page + 999);
+			if (error)
+				throw new Error(`Could not read broadcast room sessions (apply migration 104 first): ${error.message}`);
+			existing.push(...((data ?? []) as BroadcastRoomSessionRow[]));
+			if (!data || data.length < 1000) break;
+		}
 	}
 	const byPid = new Map(
 		existing.flatMap((session) =>

--- a/scripts/import-wikidata-studio-names.ts
+++ b/scripts/import-wikidata-studio-names.ts
@@ -289,26 +289,18 @@ async function main() {
 	console.log(
 		`Studio resolution preview for ${season}: ${sourceNames.length} source names; ${aliasRows.length} matched aliases; ${sourceRows.length} identities; ${japaneseCount} Japanese names; ${jikanNameCount} Jikan-preferred names.`,
 	);
-	const tezukaExample = aliasRows.find((row) => row.alias_key === "tezukaproductions");
-	if (tezukaExample) {
-		console.log(
-			"Tezuka example:",
-			JSON.stringify({
-				alias: tezukaExample.alias,
-				studio: sourceRows.find((row) => row.source_key === tezukaExample.source_key),
-			}),
-		);
-	}
-	console.log(
-		JSON.stringify(
-			aliasRows
-				.slice(0, 20)
-				.map((alias) => ({ ...alias, studio: sourceRows.find((row) => row.source_key === alias.source_key) })),
-			null,
-			2,
-		),
-	);
 	if (options.dryRun) {
+		// 照合内容の確認はdry-runのときだけ出す（本番実行のログを埋めない）
+		console.log(
+			JSON.stringify(
+				aliasRows.slice(0, 20).map((alias) => ({
+					...alias,
+					studio: sourceRows.find((row) => row.source_key === alias.source_key),
+				})),
+				null,
+				2,
+			),
+		);
 		console.log("Dry run complete. No database writes were made.");
 		return;
 	}

--- a/src/lib/anime-catalog-resolver.ts
+++ b/src/lib/anime-catalog-resolver.ts
@@ -170,13 +170,16 @@ export function selectVerifiedRomajiCandidate(
 	if (!offlineTitle || containsJapaneseScript(offlineTitle)) return undefined;
 	const normalizedOffline = normalizeLatinTitle(offlineTitle);
 	if (!normalizedOffline) return undefined;
+	// 部分一致は短い文字列だと無関係なエイリアスに誤爆する（例: \"ao\" が長い別作品名に
+	// 含まれる）ため、包含判定は両者が一定長以上のときだけ許す。完全一致は長さ不問。
+	const INCLUSION_MIN_LENGTH = 6;
 	const matchingAliases = aliases.filter((alias) => {
 		if (!alias.trim() || alias === englishTitle) return false;
 		const normalizedAlias = normalizeLatinTitle(alias);
+		if (normalizedAlias === normalizedOffline) return true;
 		return (
-			normalizedAlias === normalizedOffline ||
-			normalizedAlias.includes(normalizedOffline) ||
-			normalizedOffline.includes(normalizedAlias)
+			(normalizedOffline.length >= INCLUSION_MIN_LENGTH && normalizedAlias.includes(normalizedOffline)) ||
+			(normalizedAlias.length >= INCLUSION_MIN_LENGTH && normalizedOffline.includes(normalizedAlias))
 		);
 	});
 	return matchingAliases.length > 0 ? offlineTitle : undefined;

--- a/src/lib/broadcast-status.test.ts
+++ b/src/lib/broadcast-status.test.ts
@@ -62,4 +62,10 @@ describe("computeBroadcastStatus", () => {
 			"airing",
 		);
 	});
+
+	it("returns unknown when neither dates nor a recognized status are available", () => {
+		expect(computeBroadcastStatus({ airedFrom: null, airedTo: null, type: "TV", status: null }, TODAY)).toBe(
+			"unknown",
+		);
+	});
 });

--- a/src/lib/server/broadcast-episode-log.test.ts
+++ b/src/lib/server/broadcast-episode-log.test.ts
@@ -64,6 +64,22 @@ describe("buildBroadcastEpisodeLog", () => {
 		]);
 	});
 
+	it("suppresses inferred numbers when backward numbering underflows", () => {
+		// 4掲載日に対して3話分しかない＝未登録の総集編・特番疑い。ずれた推定番号を
+		// 出さず、アンカー（実セッション）の番号だけ残す。
+		const log = buildBroadcastEpisodeLog(
+			ANIME,
+			[snapshot("2026-07-31"), snapshot("2026-08-07"), snapshot("2026-08-14"), snapshot("2026-08-21", 3, false)],
+			[],
+		);
+		expect(log.map((slot) => [slot.date, slot.start])).toEqual([
+			["2026-07-31", null],
+			["2026-08-07", null],
+			["2026-08-14", null],
+			["2026-08-21", 3],
+		]);
+	});
+
 	it("does not count unnumbered syobocal slots that carry their own subtitle (特番)", () => {
 		// ヤニねこパターン: しょぼいが話数を付けず「特番」とだけ題した枠は
 		// 通常話ではないので、逆算のカウントを消費しない。

--- a/src/lib/server/broadcast-episode-log.ts
+++ b/src/lib/server/broadcast-episode-log.ts
@@ -93,7 +93,20 @@ export function buildBroadcastEpisodeLog(
 	}
 	const ascending = [...slotByDate.values()].sort((left, right) => left.date.localeCompare(right.date));
 	// オーバーライド（話数明示・総集編）を尊重した逆算。整合しない作品は番号なしのまま。
-	inferEpisodeNumbersBackward(ascending, overrideByDate);
+	const unnumberedBefore = new Set(ascending.filter((slot) => slot.start == null).map((slot) => slot.date));
+	const mismatch = inferEpisodeNumbersBackward(ascending, overrideByDate);
+	if (mismatch?.kind === "underflow") {
+		// 話数より掲載日が多い＝未登録の総集編・特番がどこかにあり、逆算した番号は
+		// その日より古い側で1話ずれている可能性がある。推定番号は表示せず、実在
+		// セッションとオーバーライド明示の番号だけを残す（監査リストで手動補正する）。
+		for (const slot of ascending) {
+			if (!unnumberedBefore.has(slot.date)) continue;
+			const override = overrideByDate.get(slot.date);
+			if (override?.episode_start != null && override.episode_end != null) continue;
+			slot.start = null;
+			slot.end = null;
+		}
+	}
 	// アンカーが1件も無い＝しょぼい同期開始前に放送を終えた作品は、逆算の起点が
 	// 永遠に得られない。放送終了済みに限り、第1話からの前進カウントで補う
 	// （放送中でアンカーが無いのはマッピング不備なので番号なしのまま残す）。

--- a/src/lib/syobocal-schedule.ts
+++ b/src/lib/syobocal-schedule.ts
@@ -86,7 +86,9 @@ export function jstBroadcastTimeLabel(value: string | Date): string | null {
 function episodeIdentity(program: SyobocalScheduleProgram): string {
 	if (program.episodeNumber !== null) return `episode:${program.episodeNumber}`;
 	if (program.subtitle) return `subtitle:${program.subtitle.normalize("NFKC").trim()}`;
-	return "unnumbered";
+	// 話数も副題も無い枠は放送日で区別する: 単一キーに潰すと別日の特番が
+	// 「同じ話の別局」扱いされて1本しか残らない。同日内の局違いは従来どおり統合。
+	return `unnumbered:${jstBroadcastDate(program.startsAt)}`;
 }
 
 // Syobocal ChGID groups for free-to-air TV. Everything else (CS incl. AT-X,

--- a/src/lib/syobocal.ts
+++ b/src/lib/syobocal.ts
@@ -55,7 +55,7 @@ export function normalizeSyobocalTitle(value: string): string {
 export function parseSyobocalLinks(comment: string): SyobocalLink[] {
 	const links: SyobocalLink[] = [];
 	const seen = new Set<string>();
-	for (const match of comment.matchAll(/-\[\[(.*?)\s+(https?:\/\/[^\]]+)\]\]/g)) {
+	for (const match of comment.matchAll(/-\[\[(.*?)\s+(https?:\/\/[^\]\s]+)\]\]/g)) {
 		const name = match[1]?.trim();
 		const url = match[2]?.trim();
 		if (!name || !url) continue;

--- a/src/routes/auth/+page.server.ts
+++ b/src/routes/auth/+page.server.ts
@@ -57,7 +57,8 @@ export const load: PageServerLoad = async ({ url, cookies, locals: { supabase, s
 	let inviteCodeValid = false;
 	if (betaGateEnabled) {
 		const queryValid = queryInviteCode ? await validateInviteCode(supabase, queryInviteCode) : false;
-		if (queryValid || (queryInviteCode && !cookieInviteCode)) setInviteCodeCookie(cookies, queryInviteCode);
+		// 検証を通らないコードは保存しない（無効コードがCookieに居座るのを防ぐ）
+		if (queryValid) setInviteCodeCookie(cookies, queryInviteCode);
 		if (queryValid) {
 			inviteCodeValid = true;
 		} else if (cookieInviteCode) {

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -131,7 +131,7 @@ const hasInviteAccess = $derived(!data.betaGateEnabled || data.inviteCodeValid);
 					</button>
 				</form>
 			{:else}
-				{#if data.betaGateEnabled && (activeMode !== 'login' || (form && 'needInvite' in form && form.needInvite))}
+				{#if data.betaGateEnabled && (activeMode !== 'login' || (form && 'needInvite' in form && form.needInvite) || ['not_member', 'invite_required', 'invalid_invite', 'invite_exhausted'].includes(data.error ?? ''))}
 					<div class="field">
 						<label for="invite-code" class="field-label">招待コード</label>
 						<input

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -85,6 +85,8 @@ export const GET: RequestHandler = async ({ url, cookies, locals: { supabase } }
 				}
 			} else {
 				errorCode = redeemResult.detail === "INVITE_EXHAUSTED" ? "invite_exhausted" : "invalid_invite";
+				// 無効・失効が確定したコードを残すと、再ログインのたびに同じエラーを踏む
+				clearInviteCodeCookie(cookies);
 			}
 		} else if (!discordIdentity) {
 			errorCode = "invite_required";

--- a/src/routes/schedule/+page.server.ts
+++ b/src/routes/schedule/+page.server.ts
@@ -125,10 +125,10 @@ export const load: PageServerLoad = async ({ url, locals: { supabase, safeGetSes
 			? getAnimeList(supabase, { scheduleRange, limit: 1000, userId: user?.id ?? null })
 			: Promise.resolve([] as Anime[]),
 	]);
-	const pastFillIds = pastFillList.map((anime) => Number(anime.id));
+	const pastFillIds = new Set(pastFillList.map((anime) => Number(anime.id)));
 	const scheduleAnimeIds = [
 		...new Set([...sessions.map((session) => session.anime_id), ...overrideAnimeIdsInRange]),
-	].filter((id) => !pastFillIds.includes(id));
+	].filter((id) => !pastFillIds.has(id));
 
 	const [
 		sessionAnimeList,


### PR DESCRIPTION
## Summary
PR #197（リリース）へのCodeRabbitレビュー29件のうち、機能バグ・クイックウィン13件に対応:

- **malソース欠落**: しょぼい照合の`fetchSourceRecords`が`mal`を取得せず、MAL優先のタイトル・日付・型参照が全て空振りしていた（Major）
- **既存セッション取得のページング**: PostgREST `max_rows`(1000)超で凍結・開場済みガードと陳腐化削除の判定が壊れるのを防止（現在1,440行で実リスク・Major）
- **逆算underflow時の推定番号抑止**: 未登録総集編があると1話ズレた番号が表示される問題。実セッション・明示オーバーライドの番号のみ残す（Major）
- fetchWithRetryの恒久エラー即時失敗、話数なし特番の別日識別、リンク正規表現の空白飲み込み、ローマ字部分一致の最短長ガード、招待コードUI/Cookie後片付け×3、週次workflowのシーズン単位失敗隔離、ChGID欠損ログ、デバッグ出力のdry-run化、Set化、unknownテスト追加

データ修正（適用済み）: migration 115以前に管理設定されたglobal 13行を`room_type_source='manual'`にバックフィルし、自動分類からの上書きを防止。

## Test plan
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 165/165 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)