### PR TITLE
Fix invite self-issuance, OAuth redemption FK, cover-upload provenance

### DIFF
--- a/src/lib/server/anime-admin.ts
+++ b/src/lib/server/anime-admin.ts
@@ -35,8 +35,10 @@ const MANUAL_SOURCE_KEYS = [
 /**
  * 管理画面の編集内容を manual ソースレコードへ差分マージする。失敗しても
  * anime 行の更新自体は成功しているので、ログだけ残して処理は続行する。
+ * カバーアップロードAPIのような service-role 経路からも使う（DBトリガーの
+ * capture_anime_manual_source は auth.uid() が無いと発火しないため）。
  */
-async function upsertManualSourceRecord(
+export async function upsertManualSourceRecord(
 	// biome-ignore lint/suspicious/noExplicitAny: generated types may lag behind source-record migrations
 	writer: SupabaseClient<any>,
 	malId: number,

--- a/src/routes/api/upload/anime-cover/+server.ts
+++ b/src/routes/api/upload/anime-cover/+server.ts
@@ -2,6 +2,7 @@ import { createClient } from "@supabase/supabase-js";
 import { error, json } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
 import { PUBLIC_SUPABASE_URL } from "$env/static/public";
+import { upsertManualSourceRecord } from "$lib/server/anime-admin";
 import { isAdminUser } from "$lib/server/queries";
 import { MULTIPART_OVERHEAD_BYTES, readFormDataWithLimit, validateImageBuffer } from "$lib/server/upload";
 import type { RequestHandler } from "./$types";
@@ -59,7 +60,7 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 		.from("anime")
 		.update({ cover_url: publicUrl })
 		.eq("id", animeId)
-		.select("id")
+		.select("id,mal_id")
 		.single();
 
 	if (updateError || !updatedRow) {
@@ -69,6 +70,14 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 			console.error("anime cover storage cleanup error (path=%s):", path, deleteError);
 		}
 		error(500, "DBの更新に失敗しました");
+	}
+
+	// service-role 経由の更新は capture_anime_manual_source トリガーが発火しない
+	// （auth.uid() なし）ため、manual ソースレコードを明示的に残す。これが無いと
+	// 次回のカタログ再解決でアップロードしたカバーが取り込み元の画像に戻る。
+	const malId = (updatedRow as { mal_id: number | null }).mal_id;
+	if (malId != null) {
+		await upsertManualSourceRecord(adminClient, malId, {}, { cover_url: publicUrl });
 	}
 
 	return json({ url: publicUrl });

--- a/supabase/migrations/116_invite_hardening.sql
+++ b/supabase/migrations/116_invite_hardening.sql
@@ -1,0 +1,90 @@
+-- 招待システムの2つの穴を塞ぐ（リリースPRレビュー指摘）。
+--
+-- (1) create_invite が auth.uid() の存在しか要求しないため、公開 signup で
+--     作ったメールユーザーが RPC を直接呼んで自己招待でき、クローズドβを
+--     迂回できた。発行は管理者または既存βメンバー（JWT の
+--     app_metadata.beta_member）に限定する。
+--
+-- (2) invite_redemptions.user_id が public.profiles(id) を参照していたが、
+--     083 は OAuth ユーザーの profile 作成をオンボーディング完了まで遅延する。
+--     コールバックはオンボーディング前に redeem_invite を呼ぶため、新規
+--     Google / X ユーザーは外部キー違反で償還できずログインを拒否された。
+--     償還記録は auth.users(id) に紐付ける。
+
+-- ----------------------------------------------------------------
+-- (2) 償還記録の外部キーを auth.users へ付け替え
+-- ----------------------------------------------------------------
+ALTER TABLE public.invite_redemptions
+    DROP CONSTRAINT IF EXISTS invite_redemptions_user_id_fkey;
+ALTER TABLE public.invite_redemptions
+    ADD CONSTRAINT invite_redemptions_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+-- ----------------------------------------------------------------
+-- (1) create_invite: 発行者は管理者または既存βメンバーのみ
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.create_invite(
+    p_max_uses integer DEFAULT 1,
+    p_expires_at timestamptz DEFAULT NULL
+)
+RETURNS text AS $$
+DECLARE
+    current_user_id uuid := auth.uid();
+    caller_is_admin boolean;
+    caller_is_beta_member boolean;
+    normalized_max_uses integer := GREATEST(1, COALESCE(p_max_uses, 1));
+    normalized_expires_at timestamptz := p_expires_at;
+    active_invite_count integer;
+    generated_code text;
+    attempt integer := 0;
+BEGIN
+    IF current_user_id IS NULL THEN
+        RAISE EXCEPTION 'login required';
+    END IF;
+
+    caller_is_admin := public.is_current_user_admin();
+    caller_is_beta_member := COALESCE(
+        (auth.jwt() -> 'app_metadata' ->> 'beta_member')::boolean,
+        false
+    );
+
+    IF NOT caller_is_admin AND NOT caller_is_beta_member THEN
+        -- β許可を持たないユーザーに発行させると自己招待でゲートを迂回できる
+        RAISE EXCEPTION 'beta membership required' USING DETAIL = 'INVITE_FORBIDDEN';
+    END IF;
+
+    IF NOT caller_is_admin THEN
+        -- 非管理者は1コードあたり最大10回まで、有効期限は最長30日にクランプ
+        normalized_max_uses := LEAST(normalized_max_uses, 10);
+        normalized_expires_at := LEAST(COALESCE(normalized_expires_at, now() + interval '30 days'), now() + interval '30 days');
+
+        SELECT count(*)
+          INTO active_invite_count
+          FROM public.invites i
+         WHERE i.created_by = current_user_id
+           AND i.revoked_at IS NULL
+           AND i.use_count < i.max_uses
+           AND (i.expires_at IS NULL OR i.expires_at > now());
+
+        IF active_invite_count >= 3 THEN
+            RAISE EXCEPTION 'invite creation limit reached'
+                USING DETAIL = 'INVITE_CREATE_LIMIT';
+        END IF;
+    END IF;
+
+    LOOP
+        attempt := attempt + 1;
+        generated_code := upper(substr(replace(gen_random_uuid()::text, '-', ''), 1, 10));
+
+        BEGIN
+            INSERT INTO public.invites (code, created_by, max_uses, expires_at)
+            VALUES (generated_code, current_user_id, normalized_max_uses, normalized_expires_at);
+            RETURN generated_code;
+        EXCEPTION WHEN unique_violation THEN
+            IF attempt >= 5 THEN
+                RAISE EXCEPTION 'failed to generate a unique invite code';
+            END IF;
+        END;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;


### PR DESCRIPTION
## Summary
リリースPR #197へのCodexレビュー3件（P0×1・P1×2）に対応:

1. **[P0] 自己招待によるβ迂回**: `create_invite`が`auth.uid()`の存在しか要求せず、公開signupのメールユーザーがRPC直呼びで自己招待できた。migration 116で発行者を**管理者または既存βメンバー**（JWTの`app_metadata.beta_member`）に限定（`INVITE_FORBIDDEN`）。償還側の権限は不変
2. **[P1] OAuth新規ユーザーの償還FK違反**: `invite_redemptions.user_id`が`profiles(id)`参照だが、083はOAuthユーザーのprofile作成をオンボーディングまで遅延するため、初回Google/Xログインが償還時に外部キー違反で拒否された。FKを`auth.users(id)`へ付け替え
3. **[P1] カバーアップロードの再解決戻り**: service-role経由の`cover_url`更新は`capture_anime_manual_source`トリガーが発火せず（auth.uid()なし）、次回再解決で取り込み元画像に戻っていた。共有ヘルパー`upsertManualSourceRecord`でmanualソースレコードを明示保存

## リリース時の注意
- **migration 116はリモートへの手動適用が必要です**（プロジェクトの運用どおり）

## Test plan
- [x] `pnpm check` 通過 / `pnpm exec vitest run` 165/165 通過
- [ ] migration 116適用後: 非βメンバーの`create_invite`拒否・新規Google/Xログイン+招待コードの成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)