### PR TITLE
Revoke anon EXECUTE on invite RPCs

### DIFF
--- a/supabase/migrations/117_invite_revoke_anon_execute.sql
+++ b/supabase/migrations/117_invite_revoke_anon_execute.sql
@@ -1,0 +1,14 @@
+-- 招待RPCから anon の EXECUTE を剥奪する（防御の多層化）。
+--
+-- Supabase の ALTER DEFAULT PRIVILEGES は新規関数の EXECUTE を PUBLIC ではなく
+-- anon / authenticated / service_role の各ロールへ直接付与する。112 の
+-- `REVOKE ALL ... FROM PUBLIC` ではこの直接付与は剥がれず、anon でも関数本体まで
+-- 到達できていた（auth.uid() が NULL のため 'login required' で止まるが、
+-- 意図した権限面とはズレている）。
+--
+-- check_invite_code は未ログインの招待リンク検証（/auth のプリフィル）で
+-- anon から呼ぶ正当な経路があるため対象外。
+
+REVOKE EXECUTE ON FUNCTION public.create_invite(integer, timestamptz) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.redeem_invite(text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.revoke_invite(uuid) FROM anon;


### PR DESCRIPTION
## Summary
- migration 116の検証中に発見: Supabaseのdefault privilegesは関数のEXECUTEをPUBLICではなくanon/authenticated等へ直接付与するため、112の`REVOKE FROM PUBLIC`ではanonの実行権が残っていた（`auth.uid()`チェックで実害は無いが権限面を意図に一致させる）
- `create_invite`・`redeem_invite`・`revoke_invite`からanonのEXECUTEを剥奪（migration 117・要手動適用）
- `check_invite_code`は未ログインの招待リンク検証で正当にanonから呼ばれるため対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)