### PR TITLE
Revoke PUBLIC execute on invite RPCs, not just anon

### DIFF
--- a/supabase/migrations/117_invite_revoke_anon_execute.sql
+++ b/supabase/migrations/117_invite_revoke_anon_execute.sql
@@ -1,14 +1,19 @@
--- 招待RPCから anon の EXECUTE を剥奪する（防御の多層化）。
+-- 招待RPCから anon の実行権を確実に剥奪する（防御の多層化）。
 --
--- Supabase の ALTER DEFAULT PRIVILEGES は新規関数の EXECUTE を PUBLIC ではなく
--- anon / authenticated / service_role の各ロールへ直接付与する。112 の
--- `REVOKE ALL ... FROM PUBLIC` ではこの直接付与は剥がれず、anon でも関数本体まで
--- 到達できていた（auth.uid() が NULL のため 'login required' で止まるが、
--- 意図した権限面とはズレている）。
+-- 初版は `REVOKE ... FROM anon` のみだったが、リモートでは関数ACLがデフォルト
+-- 状態（= PUBLIC に EXECUTE）になっており、anon への直接付与が存在しないため
+-- 何も剥がれず、anon が関数本体まで到達できたままだった（auth.uid() が NULL の
+-- ため 'login required' で止まるが、意図した権限面とはズレている）。
+-- PUBLIC ごと剥奪した上で、必要なロールにだけ明示的に再付与する。
+-- REVOKE / GRANT は冪等なので再適用しても安全。
 --
 -- check_invite_code は未ログインの招待リンク検証（/auth のプリフィル）で
 -- anon から呼ぶ正当な経路があるため対象外。
 
-REVOKE EXECUTE ON FUNCTION public.create_invite(integer, timestamptz) FROM anon;
-REVOKE EXECUTE ON FUNCTION public.redeem_invite(text) FROM anon;
-REVOKE EXECUTE ON FUNCTION public.revoke_invite(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.create_invite(integer, timestamptz) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.redeem_invite(text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.revoke_invite(uuid) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.create_invite(integer, timestamptz) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.redeem_invite(text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.revoke_invite(uuid) TO authenticated, service_role;


### PR DESCRIPTION
## Summary
- 初版117適用後の実地検証で、anonがまだ関数本体に到達できることを確認。リモートの関数ACLはデフォルト状態（PUBLIC経由のEXECUTE）で、anonへの直接付与が無いため`REVOKE FROM anon`では何も剥がれなかった
- PUBLICごと剥奪し、authenticated・service_roleへ明示再付与する形に改訂（冪等なので再適用安全）

## 適用のお願い
- **改訂版117の再適用が必要です**（同ファイルをDashboardで再実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)