### PR TITLE
Codex全量監査P1指摘の修正: 直接Supabase迂回経路の遮断

### DIFF
--- a/src/lib/server/actions.test.ts
+++ b/src/lib/server/actions.test.ts
@@ -132,4 +132,47 @@ describe("insertPostWithHashtags", () => {
 			ignoreDuplicates: true,
 		});
 	});
+
+	it("rejects more than 4 attached images", async () => {
+		const { client, insertedPosts } = createInsertPostClient(null);
+		const ownUrl = (n: number) =>
+			`https://example.supabase.co/storage/v1/object/public/post-images/user-1/${n}.png`;
+
+		const result = await insertPostWithHashtags(client, "user-1", "too many images", null, [
+			ownUrl(1),
+			ownUrl(2),
+			ownUrl(3),
+			ownUrl(4),
+			ownUrl(5),
+		]);
+
+		expect(result).toMatchObject({ status: 400 });
+		expect(insertedPosts).toHaveLength(0);
+	});
+
+	it("rejects image URLs outside the poster's own post-images folder", async () => {
+		const { client, insertedPosts } = createInsertPostClient(null);
+		const foreignUrls = [
+			"https://example.supabase.co/storage/v1/object/public/post-images/user-2/steal.png",
+			"https://evil.example.com/image.png",
+		];
+
+		for (const url of foreignUrls) {
+			const result = await insertPostWithHashtags(client, "user-1", "bad image", null, [url]);
+			expect(result).toMatchObject({ status: 400 });
+		}
+		expect(insertedPosts).toHaveLength(0);
+	});
+
+	it("accepts up to 4 images from the poster's own folder", async () => {
+		const { client, insertedPosts } = createInsertPostClient(null);
+		const urls = [1, 2, 3, 4].map(
+			(n) => `https://example.supabase.co/storage/v1/object/public/post-images/user-1/${n}.png`,
+		);
+
+		const result = await insertPostWithHashtags(client, "user-1", "with images", null, urls);
+
+		expect(result).toEqual({ success: true, postId: "post-1" });
+		expect(insertedPosts).toContainEqual(expect.objectContaining({ image_urls: urls }));
+	});
 });

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -181,7 +181,7 @@ export async function insertPostWithHashtags(
 	}
 	for (const imageUrl of imageUrls) {
 		const storagePath = typeof imageUrl === "string" ? publicUrlToStoragePath(imageUrl, "post-images") : null;
-		if (!storagePath || !storagePath.startsWith(`${userId}/`)) {
+		if (!storagePath?.startsWith(`${userId}/`)) {
 			return fail(400, { message: "添付画像のURLが不正です" });
 		}
 	}

--- a/src/lib/server/actions.ts
+++ b/src/lib/server/actions.ts
@@ -18,6 +18,7 @@ import type { AnimeExchangeShare, AnimeStatus, BroadcastRoomMuteDuration } from 
 import { eventScheduledAtIsoFromBroadcastInput } from "$lib/utils/event-time";
 import { extractHashtags } from "$lib/utils/hashtag";
 
+const MAX_POST_IMAGES = 4;
 const reportStatuses = new Set(["open", "reviewing", "resolved", "rejected"]);
 const moderationStatuses = new Set(["active", "restricted", "banned"]);
 const animeExchangeErrorMessages = {
@@ -172,6 +173,18 @@ export async function insertPostWithHashtags(
 		return fail(400, { message: "本文、画像、アニメ引用、またはトレード結果を追加してください" });
 	}
 	if (content.length > 280) return fail(400, { message: "280文字以内で入力してください" });
+
+	// 画像は自分のフォルダにアップロードされた post-images の URL のみ、最大4枚まで受け付ける
+	// （クライアント側の4枚制限・アップロードAPIの検査を直接POSTで迂回されるのを防ぐ）
+	if (imageUrls.length > MAX_POST_IMAGES) {
+		return fail(400, { message: `画像は${MAX_POST_IMAGES}枚まで添付できます` });
+	}
+	for (const imageUrl of imageUrls) {
+		const storagePath = typeof imageUrl === "string" ? publicUrlToStoragePath(imageUrl, "post-images") : null;
+		if (!storagePath || !storagePath.startsWith(`${userId}/`)) {
+			return fail(400, { message: "添付画像のURLが不正です" });
+		}
+	}
 
 	if (parentId) {
 		const { data: parent } = await supabase.from("posts").select("id").eq("id", parentId).maybeSingle();

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -63,6 +63,8 @@ export const API_RATE_RULES: RateRule[] = [
 	{ name: "reaction", pattern: /^\/api\/posts\/[^/]+\/reactions$/, limit: 60, windowMs: 60_000 },
 	{ name: "search", pattern: /^\/api\/(anime|users)\/search/, limit: 30, windowMs: 10_000 },
 	{ name: "anime-count", pattern: /^\/api\/anime\/count$/, limit: 30, windowMs: 10_000 },
+	// 全件エクスポート系はDB走査・巨大レスポンスを伴うため厳しめに絞る（通常はCDNキャッシュが受ける）
+	{ name: "data-export", pattern: /^\/api\/data\//, methods: ["GET"], limit: 2, windowMs: 60_000 },
 	{ name: "room-posts", pattern: /^\/api\/rooms\/posts$/, limit: 60, windowMs: 60_000 },
 	{
 		name: "room-experiment-visit",

--- a/supabase/migrations/118_beta_write_rls.sql
+++ b/supabase/migrations/118_beta_write_rls.sql
@@ -1,0 +1,246 @@
+-- クローズドβの資格検査をDB層（RLS）にも適用する。
+--
+-- これまでβゲートは SvelteKit の hooks.server.ts でしか適用されておらず、
+-- 公開 Supabase URL + publishable key で直接サインアップしたユーザーが
+-- REST API 経由で投稿・いいね・フォロー等を実行できた（Codex監査 P1-1）。
+-- 招待フロー上 signup 自体は無効化できないため、書き込み系 RLS ポリシーに
+-- 「βメンバーまたは管理者」の条件を追加して直接アクセスを遮断する。
+--
+-- β終了時（一般公開時）の締め出しを防ぐため、判定は app_config テーブルの
+-- closed_beta フラグで切り替えられるようにする。一般公開する際は
+--   UPDATE public.app_config SET value = 'false'::jsonb WHERE key = 'closed_beta';
+-- を実行すること（PUBLIC_CLOSED_BETA 環境変数の無効化とセットで行う）。
+-- ローカル開発でβゲートを外している場合も同じ UPDATE を実行する。
+
+-- ----------------------------------------------------------------
+-- 1. アプリ全体設定テーブル（サーバー管理者のみ書き込み可）
+-- ----------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.app_config (
+    key   text PRIMARY KEY,
+    value jsonb NOT NULL
+);
+
+ALTER TABLE public.app_config ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "app_config: 誰でも読める" ON public.app_config;
+CREATE POLICY "app_config: 誰でも読める"
+    ON public.app_config FOR SELECT USING (true);
+-- INSERT/UPDATE/DELETE ポリシーは意図的に作らない（service_role のみ書き込み可）。
+
+INSERT INTO public.app_config (key, value)
+VALUES ('closed_beta', 'true'::jsonb)
+ON CONFLICT (key) DO NOTHING;
+
+-- ----------------------------------------------------------------
+-- 2. β資格判定関数
+-- ----------------------------------------------------------------
+-- closed_beta が無効なら常に true。有効なら JWT の app_metadata.beta_member
+-- または管理者のみ true。SECURITY DEFINER は app_config の将来的な
+-- RLS 変更に依存しないための保険（現状 SELECT は公開）。
+CREATE OR REPLACE FUNCTION public.has_beta_write_access()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        NOT COALESCE(
+            (SELECT (value #>> '{}')::boolean FROM public.app_config WHERE key = 'closed_beta'),
+            false
+        )
+        OR COALESCE((auth.jwt() -> 'app_metadata' ->> 'beta_member')::boolean, false)
+        OR public.is_current_user_admin();
+$$;
+
+REVOKE ALL ON FUNCTION public.has_beta_write_access() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.has_beta_write_access() TO anon, authenticated, service_role;
+
+-- ----------------------------------------------------------------
+-- 3. ユーザーコンテンツ書き込みポリシーへβ検査を追加
+--    （039_account_moderation.sql の各ポリシーの条件 + β検査）
+-- ----------------------------------------------------------------
+DROP POLICY IF EXISTS "posts_insert_active_users" ON public.posts;
+CREATE POLICY "posts_insert_active_users"
+    ON public.posts FOR INSERT
+    WITH CHECK (
+        auth.uid() = user_id
+        AND public.is_profile_active_for_writes(user_id)
+        AND public.has_beta_write_access()
+    );
+
+DROP POLICY IF EXISTS "likes_insert_active_users" ON public.likes;
+CREATE POLICY "likes_insert_active_users"
+    ON public.likes FOR INSERT
+    WITH CHECK (
+        auth.uid() = user_id
+        AND public.is_profile_active_for_writes(user_id)
+        AND public.has_beta_write_access()
+        AND EXISTS (
+            SELECT 1
+            FROM public.posts p
+            WHERE p.id = post_id
+              AND public.can_view_profile_content(p.user_id)
+        )
+    );
+
+DROP POLICY IF EXISTS "reposts_insert_active_users" ON public.reposts;
+CREATE POLICY "reposts_insert_active_users"
+    ON public.reposts FOR INSERT
+    WITH CHECK (
+        auth.uid() = user_id
+        AND public.is_profile_active_for_writes(user_id)
+        AND public.has_beta_write_access()
+        AND EXISTS (
+            SELECT 1
+            FROM public.posts p
+            WHERE p.id = post_id
+              AND public.can_view_profile_content(p.user_id)
+        )
+    );
+
+DROP POLICY IF EXISTS "follows_insert_active_users" ON public.follows;
+CREATE POLICY "follows_insert_active_users"
+    ON public.follows FOR INSERT
+    WITH CHECK (
+        (
+            auth.uid() = follower_id
+            OR (
+                auth.uid() = following_id
+                AND EXISTS (
+                    SELECT 1
+                    FROM public.follow_requests fr
+                    WHERE fr.requester_id = follower_id
+                      AND fr.target_id = following_id
+                      AND fr.status = 'pending'
+                )
+            )
+        )
+        AND public.is_profile_active_for_writes(follower_id)
+        AND public.has_beta_write_access()
+    );
+
+DROP POLICY IF EXISTS "follow_requests_insert_active_users" ON public.follow_requests;
+CREATE POLICY "follow_requests_insert_active_users" ON public.follow_requests
+    FOR INSERT WITH CHECK (
+        auth.uid() = requester_id
+        AND public.is_profile_active_for_writes(requester_id)
+        AND public.has_beta_write_access()
+        AND EXISTS (
+            SELECT 1
+            FROM public.profiles p
+            WHERE p.id = target_id
+              AND p.is_private = true
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM public.follows f
+            WHERE f.follower_id = requester_id
+              AND f.following_id = target_id
+        )
+    );
+
+DROP POLICY IF EXISTS "bookmarks_insert_active_users" ON public.bookmarks;
+CREATE POLICY "bookmarks_insert_active_users" ON public.bookmarks
+    FOR INSERT WITH CHECK (
+        auth.uid() = user_id
+        AND public.is_profile_active_for_writes(user_id)
+        AND public.has_beta_write_access()
+    );
+
+DROP POLICY IF EXISTS "hashtags: 認証済みユーザーが追加可" ON public.hashtags;
+CREATE POLICY "hashtags: 認証済みユーザーが追加可"
+    ON public.hashtags FOR INSERT
+    WITH CHECK (
+        auth.role() = 'authenticated'
+        AND public.has_beta_write_access()
+        AND char_length(name) BETWEEN 1 AND 100
+    );
+
+-- post_hashtags は 120_hashtag_integrity.sql で所有権検査と合わせて再作成する。
+
+DROP POLICY IF EXISTS "user_anime_list: 自分のみ編集可能" ON public.user_anime_list;
+CREATE POLICY "user_anime_list: 自分のみ編集可能"
+    ON public.user_anime_list FOR INSERT
+    WITH CHECK (auth.uid() = user_id AND public.has_beta_write_access());
+
+DROP POLICY IF EXISTS "user_anime_list: 自分のみ更新可能" ON public.user_anime_list;
+CREATE POLICY "user_anime_list: 自分のみ更新可能"
+    ON public.user_anime_list FOR UPDATE
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id AND public.has_beta_write_access());
+
+DROP POLICY IF EXISTS "muted_words: users can insert own rows" ON public.muted_words;
+CREATE POLICY "muted_words: users can insert own rows"
+    ON public.muted_words FOR INSERT
+    WITH CHECK (auth.uid() = user_id AND public.has_beta_write_access());
+
+DROP POLICY IF EXISTS "anime_recommendations: users can insert own recommendations"
+    ON public.anime_recommendations;
+CREATE POLICY "anime_recommendations: users can insert own recommendations"
+    ON public.anime_recommendations FOR INSERT
+    WITH CHECK (auth.uid() = recommender_id AND public.has_beta_write_access());
+
+DROP POLICY IF EXISTS "reports_insert_own" ON public.reports;
+CREATE POLICY "reports_insert_own" ON public.reports
+    FOR INSERT WITH CHECK (auth.uid() = reporter_id AND public.has_beta_write_access());
+
+-- ----------------------------------------------------------------
+-- 4. Storage の書き込みポリシーにもβ検査を追加
+--    （直接 Storage API による無制限アップロードの一次遮断。
+--      クォータ・件数制限は別途サーバー側で管理する）
+-- ----------------------------------------------------------------
+DROP POLICY IF EXISTS "authenticated users can upload post images" ON storage.objects;
+CREATE POLICY "authenticated users can upload post images"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+    bucket_id = 'post-images'
+    AND auth.uid()::text = (storage.foldername(name))[1]
+    AND public.has_beta_write_access()
+);
+
+DROP POLICY IF EXISTS "authenticated users can upload their own avatar" ON storage.objects;
+CREATE POLICY "authenticated users can upload their own avatar"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+    bucket_id = 'profile-avatars'
+    AND auth.uid()::text = (storage.foldername(name))[1]
+    AND public.has_beta_write_access()
+);
+
+DROP POLICY IF EXISTS "users can update their own avatar" ON storage.objects;
+CREATE POLICY "users can update their own avatar"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+    bucket_id = 'profile-avatars'
+    AND auth.uid()::text = (storage.foldername(name))[1]
+    AND public.has_beta_write_access()
+);
+
+DROP POLICY IF EXISTS "users can upload their own profile header" ON storage.objects;
+CREATE POLICY "users can upload their own profile header"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+    bucket_id = 'profile-headers'
+    AND auth.uid()::text = (storage.foldername(name))[1]
+    AND public.has_beta_write_access()
+);
+
+DROP POLICY IF EXISTS "users can update their own profile header" ON storage.objects;
+CREATE POLICY "users can update their own profile header"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+    bucket_id = 'profile-headers'
+    AND auth.uid()::text = (storage.foldername(name))[1]
+    AND public.has_beta_write_access()
+);
+
+-- 注意: profiles の INSERT/UPDATE は意図的に対象外。
+-- 招待コード償還〜オンボーディング完了（プロフィール作成）の間は JWT に
+-- beta_member が反映されていない可能性があり、ここでβ検査を要求すると
+-- 正規の新規ユーザーのオンボーディングが壊れるため。

--- a/supabase/migrations/119_mylist_privacy_rls.sql
+++ b/supabase/migrations/119_mylist_privacy_rls.sql
@@ -1,0 +1,27 @@
+-- 非公開マイリストを RLS で保護する（Codex監査 P1-2）。
+--
+-- これまで user_anime_list の SELECT ポリシーは無条件 true で、UI 側の
+-- profiles.list_is_public 検査だけが頼りだった。Supabase REST を直接叩けば
+-- 非公開ユーザーの視聴状態・評価・進捗を取得できたため、
+-- 「本人 OR（対象プロフィールを閲覧可能 AND リスト公開中）」に変更する。
+--
+-- ランキングビュー（anime_popularity / anime_trending / anime_top_rated）は
+-- security_invoker を指定していない通常ビュー＝ビュー所有者（postgres）の
+-- 権限で実行され RLS の影響を受けないため、非公開リストも含む集計は
+-- 従来どおり動作する（行レベル情報は返さないので安全）。
+
+DROP POLICY IF EXISTS "user_anime_list: 誰でも読める" ON public.user_anime_list;
+CREATE POLICY "user_anime_list: 本人または公開リストのみ読める"
+    ON public.user_anime_list FOR SELECT
+    USING (
+        auth.uid() = user_id
+        OR (
+            public.can_view_profile_content(user_id)
+            AND EXISTS (
+                SELECT 1
+                FROM public.profiles p
+                WHERE p.id = user_id
+                  AND p.list_is_public = true
+            )
+        )
+    );

--- a/supabase/migrations/120_hashtag_integrity.sql
+++ b/supabase/migrations/120_hashtag_integrity.sql
@@ -1,0 +1,125 @@
+-- ハッシュタグ関連の整合性・可視性を強化する（Codex監査 P1-3）。
+--
+-- 1) post_hashtags の INSERT が「認証済み」だけで投稿所有者を確認しておらず、
+--    他人の投稿へ任意のタグを関連付けてトレンドを操作できた。
+--    投稿所有者本人（＋β資格・アカウント有効）のみに制限する。
+-- 2) hashtags.name に長さ制限がなく、直接 API から巨大タグを蓄積できた。
+--    CHECK 制約（NOT VALID: 既存行は検証せず新規行にのみ適用）を追加する。
+--    ※ RLS 側の長さ検査は 118_beta_write_rls.sql で追加済み。
+-- 3) get_trending_hashtags が SECURITY DEFINER のまま非公開・管理者非表示・
+--    BAN ユーザーの投稿を集計しており、非公開投稿由来のタグが漏えいし得た。
+--    トレンドは「公開プロフィールの表示可能な投稿」だけを集計する。
+
+-- ----------------------------------------------------------------
+-- 1. post_hashtags: 投稿所有者のみ関連付け可
+-- ----------------------------------------------------------------
+DROP POLICY IF EXISTS "post_hashtags: 認証済みユーザーが追加可" ON public.post_hashtags;
+CREATE POLICY "post_hashtags: 投稿の所有者のみ追加可"
+    ON public.post_hashtags FOR INSERT
+    WITH CHECK (
+        auth.uid() IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM public.posts p
+            WHERE p.id = post_id
+              AND p.user_id = auth.uid()
+        )
+        AND public.is_profile_active_for_writes(auth.uid())
+        AND public.has_beta_write_access()
+    );
+
+-- ----------------------------------------------------------------
+-- 2. hashtags.name の長さ制約（新規行のみ）
+-- ----------------------------------------------------------------
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'hashtags_name_length'
+          AND conrelid = 'public.hashtags'::regclass
+    ) THEN
+        ALTER TABLE public.hashtags
+            ADD CONSTRAINT hashtags_name_length
+            CHECK (char_length(name) BETWEEN 1 AND 100) NOT VALID;
+    END IF;
+END $$;
+
+-- ----------------------------------------------------------------
+-- 3. トレンド集計から非公開・非表示・BAN 由来の投稿を除外
+--    （093_event_room_links_trending.sql の完全な置き換え）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_trending_hashtags(limit_count integer DEFAULT 10)
+RETURNS TABLE(name text, post_count bigint)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH visible_posts AS (
+        -- トレンドに乗せてよい投稿: 直近24時間・管理者非表示でない・
+        -- 公開プロフィール・BAN されていない作者のもの
+        SELECT p.id, p.broadcast_room_session_id, p.event_id
+        FROM   public.posts p
+        JOIN   public.profiles pr ON pr.id = p.user_id
+        WHERE  p.created_at > now() - interval '24 hours'
+          AND  NOT p.hidden_by_admin
+          AND  pr.is_private = false
+          AND  NOT EXISTS (
+                   SELECT 1
+                   FROM public.account_moderation am
+                   WHERE am.user_id = p.user_id
+                     AND am.status = 'banned'
+               )
+    ),
+    tagged_posts AS (
+        SELECT lower(h.name) AS name, ph.post_id
+        FROM   public.hashtags h
+        JOIN   public.post_hashtags ph ON ph.hashtag_id = h.id
+        JOIN   visible_posts p         ON p.id = ph.post_id
+
+        UNION
+
+        -- 放送ルームのルームリンク: アニメの公式ハッシュタグ(なければタイトル正規化)で集計
+        SELECT room_tag.name, p.id AS post_id
+        FROM   visible_posts p
+        JOIN   public.broadcast_room_sessions brs ON brs.id = p.broadcast_room_session_id
+        JOIN   public.anime a                     ON a.id = brs.anime_id
+        LEFT JOIN LATERAL (
+            SELECT lower(regexp_replace(btrim(official_tags.tag), '^#+', '')) AS name
+            FROM   unnest(coalesce(a.official_hashtag, ARRAY[]::text[])) AS official_tags(tag)
+            WHERE  length(regexp_replace(btrim(official_tags.tag), '^#+', '')) > 0
+            LIMIT  1
+        ) official ON true
+        CROSS JOIN LATERAL (
+            SELECT lower(
+                regexp_replace(
+                    regexp_replace(a.title, '[[:space:]]+', '', 'g'),
+                    '[^[:alnum:]_]',
+                    '',
+                    'g'
+                )
+            ) AS name
+        ) fallback
+        CROSS JOIN LATERAL (
+            SELECT coalesce(nullif(official.name, ''), nullif(fallback.name, '')) AS name
+        ) room_tag
+        WHERE  p.broadcast_room_session_id IS NOT NULL
+          AND  room_tag.name IS NOT NULL
+          AND  (NOT a.hidden_by_admin OR public.is_current_user_admin())
+
+        UNION
+
+        -- イベントルームのルームリンク: イベントに設定されたタグで集計(中止イベントは除外)
+        SELECT lower(regexp_replace(btrim(e.hashtag), '^#+', '')) AS name, p.id AS post_id
+        FROM   visible_posts p
+        JOIN   public.events e ON e.id = p.event_id
+        WHERE  p.event_id IS NOT NULL
+          AND  NOT e.is_cancelled
+          AND  length(regexp_replace(btrim(e.hashtag), '^#+', '')) > 0
+    )
+    SELECT tagged_posts.name, COUNT(DISTINCT tagged_posts.post_id) AS post_count
+    FROM   tagged_posts
+    GROUP  BY tagged_posts.name
+    ORDER  BY post_count DESC, tagged_posts.name ASC
+    LIMIT  limit_count;
+$$;

--- a/supabase/migrations/121_rpc_input_limits.sql
+++ b/supabase/migrations/121_rpc_input_limits.sql
@@ -1,0 +1,192 @@
+-- 公開 RPC の入力・出力上限と可視性検査を追加する（Codex監査 P1-4 / P1-5）。
+--
+-- 1) get_post_counts: 任意長の UUID 配列を受け取り、SECURITY DEFINER で
+--    RLS を迂回して集計していた。配列長を 200 件に制限し、呼び出し元が
+--    閲覧できる投稿（can_view_profile_content + 管理者非表示でない）だけを
+--    集計対象にする。
+-- 2) get_post_reaction_users: ページングなしで反応者全件を返していた。
+--    limit/offset 引数（上限 100 件）を追加する。既存クライアントは
+--    既定値で動作する（Supabase RPC は名前付き引数のため互換）。
+-- 3) posts.image_urls: 4枚制限がクライアントにしかなかったため、
+--    DB 制約（NOT VALID: 新規行にのみ適用）を追加する。
+
+-- ----------------------------------------------------------------
+-- 1. get_post_counts の強化（シグネチャ不変・実装を plpgsql 化）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_post_counts(
+    p_post_ids  uuid[],
+    p_user_id   uuid DEFAULT NULL
+)
+RETURNS TABLE(
+    post_id         uuid,
+    like_count      bigint,
+    repost_count    bigint,
+    reply_count     bigint,
+    liked_by_me     boolean,
+    reposted_by_me  boolean,
+    bookmarked_by_me boolean
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF coalesce(cardinality(p_post_ids), 0) > 200 THEN
+        RAISE EXCEPTION 'too many post ids (max 200)';
+    END IF;
+
+    RETURN QUERY
+    WITH ids AS (
+        -- 呼び出し元が閲覧できる投稿だけを集計対象にする
+        SELECT DISTINCT p.id
+        FROM public.posts p
+        WHERE p.id = ANY(p_post_ids)
+          AND public.can_view_profile_content(p.user_id)
+          AND (NOT p.hidden_by_admin OR public.is_current_user_admin())
+    ),
+    like_counts AS (
+        SELECT l.post_id, COUNT(*) AS cnt
+        FROM likes l
+        JOIN ids ON ids.id = l.post_id
+        GROUP BY l.post_id
+    ),
+    repost_counts AS (
+        SELECT r.post_id, COUNT(*) AS cnt
+        FROM reposts r
+        JOIN ids ON ids.id = r.post_id
+        GROUP BY r.post_id
+    ),
+    reply_counts AS (
+        SELECT po.parent_id, COUNT(*) AS cnt
+        FROM posts po
+        JOIN ids ON ids.id = po.parent_id
+        GROUP BY po.parent_id
+    ),
+    user_likes AS (
+        SELECT l.post_id
+        FROM likes l
+        JOIN ids ON ids.id = l.post_id
+        WHERE l.user_id = p_user_id
+          AND p_user_id = auth.uid()
+    ),
+    user_reposts AS (
+        SELECT r.post_id
+        FROM reposts r
+        JOIN ids ON ids.id = r.post_id
+        WHERE r.user_id = p_user_id
+          AND p_user_id = auth.uid()
+    ),
+    user_bookmarks AS (
+        SELECT b.post_id
+        FROM bookmarks b
+        JOIN ids ON ids.id = b.post_id
+        WHERE b.user_id = p_user_id
+          AND p_user_id = auth.uid()
+    )
+    SELECT
+        ids.id                          AS post_id,
+        COALESCE(lc.cnt,  0)           AS like_count,
+        COALESCE(rc.cnt,  0)           AS repost_count,
+        COALESCE(rpc.cnt, 0)           AS reply_count,
+        (ul.post_id  IS NOT NULL)      AS liked_by_me,
+        (ur.post_id  IS NOT NULL)      AS reposted_by_me,
+        (ub.post_id  IS NOT NULL)      AS bookmarked_by_me
+    FROM ids
+    LEFT JOIN like_counts    lc  ON lc.post_id   = ids.id
+    LEFT JOIN repost_counts  rc  ON rc.post_id   = ids.id
+    LEFT JOIN reply_counts   rpc ON rpc.parent_id = ids.id
+    LEFT JOIN user_likes     ul  ON ul.post_id   = ids.id
+    LEFT JOIN user_reposts   ur  ON ur.post_id   = ids.id
+    LEFT JOIN user_bookmarks ub  ON ub.post_id   = ids.id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION get_post_counts(uuid[], uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_post_counts(uuid[], uuid) TO anon, authenticated, service_role;
+
+-- ----------------------------------------------------------------
+-- 2. get_post_reaction_users に limit/offset を追加
+--    （引数が増えるため DROP して作り直す）
+-- ----------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.get_post_reaction_users(uuid, text);
+
+CREATE FUNCTION public.get_post_reaction_users(
+    target_post_id uuid,
+    action_type text,
+    p_limit integer DEFAULT 100,
+    p_offset integer DEFAULT 0
+)
+RETURNS TABLE (
+    user_id uuid,
+    username text,
+    display_name text,
+    avatar_url text,
+    reacted_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    post_author_id uuid;
+    effective_limit integer := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 100);
+    effective_offset integer := GREATEST(COALESCE(p_offset, 0), 0);
+BEGIN
+    IF action_type NOT IN ('like', 'repost') THEN
+        RAISE EXCEPTION 'invalid reaction type';
+    END IF;
+
+    SELECT p.user_id INTO post_author_id
+    FROM public.posts p
+    WHERE p.id = target_post_id
+      AND public.can_view_profile_content(p.user_id)
+      AND (NOT p.hidden_by_admin OR public.is_current_user_admin());
+
+    IF post_author_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    IF action_type = 'like' AND post_author_id != auth.uid() THEN
+        RETURN;
+    END IF;
+
+    IF action_type = 'like' THEN
+        RETURN QUERY
+        SELECT l.user_id, p.username, p.display_name, p.avatar_url, l.created_at
+        FROM public.likes l
+        JOIN public.profiles p ON p.id = l.user_id
+        WHERE l.post_id = target_post_id
+        ORDER BY l.created_at DESC
+        LIMIT effective_limit OFFSET effective_offset;
+    ELSE
+        RETURN QUERY
+        SELECT r.user_id, p.username, p.display_name, p.avatar_url, r.created_at
+        FROM public.reposts r
+        JOIN public.profiles p ON p.id = r.user_id
+        WHERE r.post_id = target_post_id
+        ORDER BY r.created_at DESC
+        LIMIT effective_limit OFFSET effective_offset;
+    END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_post_reaction_users(uuid, text, integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_post_reaction_users(uuid, text, integer, integer) TO anon, authenticated, service_role;
+
+-- ----------------------------------------------------------------
+-- 3. posts.image_urls の枚数上限（新規行のみ）
+-- ----------------------------------------------------------------
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'posts_image_urls_max_4'
+          AND conrelid = 'public.posts'::regclass
+    ) THEN
+        ALTER TABLE public.posts
+            ADD CONSTRAINT posts_image_urls_max_4
+            CHECK (cardinality(image_urls) <= 4) NOT VALID;
+    END IF;
+END $$;


### PR DESCRIPTION
## 概要

Codexによる全量検査のP1指摘（1〜5）を修正し、6にも緩和策を入れました。アプリを経由しない直接Supabase API（REST / Storage / RPC）からの迂回経路をDB層で遮断します。

## 修正内容

### Migration 118 — クローズドβのRLS層での強制（指摘1）
- `app_config` テーブル + `closed_beta` フラグ + `has_beta_write_access()` を新設
- ユーザーコンテンツのINSERT系ポリシー（posts / likes / reposts / follows / follow_requests / bookmarks / hashtags / user_anime_list / muted_words / anime_recommendations / reports）にβ資格検査を追加
- Storage（post-images / profile-avatars / profile-headers）の書き込みポリシーにも同検査を追加（指摘5の一部）
- 一般公開時は `UPDATE app_config SET value='false' WHERE key='closed_beta'` で一括解除（締め出し防止）
- profiles の INSERT/UPDATE は招待償還〜オンボーディング間のJWT未反映を考慮して対象外（ファイル内コメント参照）

### Migration 119 — 非公開マイリストの保護（指摘2）
- `user_anime_list` の SELECT を「本人 OR（閲覧可能プロフィール AND リスト公開中）」に変更
- ランキングビューは所有者権限で動く通常ビューのため集計は従来どおり動作

### Migration 120 — ハッシュタグ整合性（指摘3）
- `post_hashtags` INSERT を投稿所有者のみに制限（他人の投稿へのタグ改ざん防止）
- `hashtags.name` に長さ制約（1〜100、NOT VALID）
- `get_trending_hashtags` から非公開プロフィール・管理者非表示・BANユーザー由来の投稿を除外

### Migration 121 — 公開RPCの入出力上限（指摘4・5）
- `get_post_counts`: 配列200件上限（超過はエラー）+ 可視性検査（can_view_profile_content + hidden_by_admin）
- `get_post_reaction_users`: limit/offset引数追加（上限100件、既存呼び出しは既定値で互換）
- `posts.image_urls` に4枚上限のCHECK制約（NOT VALID）

### サーバーコード
- `insertPostWithHashtags`: image_urls をサーバー側で検証（最大4枚・自分の post-images フォルダのURLのみ）（指摘5）
- `/api/data/*` にレート制限ルール追加（2回/分、通常はCDNキャッシュが受ける）（指摘6の緩和）

## 適用手順（重要）

マイグレーション運用は手動のため、マージ後に **118 → 119 → 120 → 121 の順で Dashboard SQL Editor から適用**してください。
- 118のStorageポリシー再作成が `must be owner of table objects` で失敗する場合は、該当ポリシーのみDashboardのStorage Policies UIで編集してください
- ローカル開発でβゲートを使わない場合は `closed_beta` を false に更新

## 対応しなかった指摘（P2中心・別途対応推奨）

- **指摘6（完全対応）**: カタログJSONの静的生成+オブジェクトストレージ配信は設計変更のため未対応（レート制限で緩和済み)
- **指摘7・8**: フィルター付き一覧・タイムラインのSQL/RPC化+カーソルページング（性能改善リファクタ）
- **指摘9**: レート制限のDurable Objects/KV化（インフラ作業）
- **指摘10**: マイグレーション履歴のベースライン化（リモート棚卸しが前提。114〜117もCLI履歴未登録）
- **指摘11**: パスワード最小長等はプロダクションのDashboard設定の確認・変更が必要（config.tomlはローカル用）。なお「公開signupの無効化」は招待フロー（signup→償還）と両立しないため、本PRのRLS層ゲートが恒久対策

## 検証

- `pnpm check`: 0エラー
- `pnpm test`: 168件全通過（画像URL検証の新規テスト3件を含む）
- `pnpm lint`: 既存警告1件のみ（今回の変更起因なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)