### PR TITLE
Codexレビュー(PR #203)指摘の修正: 取り込み整合・カタログ静的配信・通知タブ

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"import:wikidata-studios": "node --env-file-if-exists=.env --experimental-strip-types scripts/import-wikidata-studio-names.ts",
 		"import:syobocal": "node --env-file-if-exists=.env --experimental-strip-types scripts/import-syobocal.ts",
 		"sync:syobocal-programs": "node --env-file-if-exists=.env --experimental-strip-types scripts/import-syobocal.ts --sync-programs",
-		"resolve:anime-catalog": "node --env-file-if-exists=.env --experimental-strip-types scripts/resolve-anime-catalog.ts"
+		"resolve:anime-catalog": "node --env-file-if-exists=.env --experimental-strip-types scripts/resolve-anime-catalog.ts",
+		"export:anime-catalog": "node --env-file-if-exists=.env --experimental-strip-types scripts/export-anime-catalog.ts"
 	},
 	"simple-git-hooks": {
 		"pre-commit": "pnpm check:biome"

--- a/scripts/export-anime-catalog.ts
+++ b/scripts/export-anime-catalog.ts
@@ -1,0 +1,42 @@
+// anime-offline-database 由来レコードの ODbL 公開 JSON を事前生成して
+// public-data バケット（migration 123）へアップロードする。
+// syobocal-sync ワークフローの週次インポート成功後に実行され、
+// /api/data/anime-catalog はこの成果物をストリーミング配信する。
+
+import { createClient } from "@supabase/supabase-js";
+import {
+	ANIME_CATALOG_EXPORT_BUCKET,
+	ANIME_CATALOG_EXPORT_OBJECT,
+	buildAnimeCatalogExport,
+} from "../src/lib/anime-catalog-export.ts";
+
+function getSupabaseClient() {
+	const supabaseUrl = process.env["PUBLIC_SUPABASE_URL"] ?? process.env["SUPABASE_URL"];
+	const serviceRoleKey = process.env["SUPABASE_SECRET_KEY"] ?? process.env["SUPABASE_SERVICE_ROLE_KEY"];
+	if (!supabaseUrl || !serviceRoleKey) {
+		throw new Error(
+			"Set PUBLIC_SUPABASE_URL (or SUPABASE_URL) and SUPABASE_SECRET_KEY (or SUPABASE_SERVICE_ROLE_KEY) before running the exporter.",
+		);
+	}
+	return createClient(supabaseUrl, serviceRoleKey, {
+		auth: { persistSession: false, autoRefreshToken: false },
+	});
+}
+
+async function main() {
+	const supabase = getSupabaseClient();
+	const payload = await buildAnimeCatalogExport(supabase);
+	const body = JSON.stringify(payload);
+	console.log(`Built catalog export: ${payload["count"]} records, ${(body.length / 1024 / 1024).toFixed(1)} MiB.`);
+
+	const { error } = await supabase.storage
+		.from(ANIME_CATALOG_EXPORT_BUCKET)
+		.upload(ANIME_CATALOG_EXPORT_OBJECT, body, { contentType: "application/json", upsert: true });
+	if (error) throw new Error(`Could not upload the catalog export: ${error.message}`);
+	console.log(`Uploaded ${ANIME_CATALOG_EXPORT_BUCKET}/${ANIME_CATALOG_EXPORT_OBJECT}.`);
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/scripts/import-jikan-season.ts
+++ b/scripts/import-jikan-season.ts
@@ -1287,6 +1287,32 @@ async function upsertJikanSourceRecords(rows: AnimeImportRow[], animeByMalId: Ma
 	}
 }
 
+/**
+ * 完全取得に成功したシーズンについて、今回の取得結果に存在しない既存の jikan
+ * レコードを削除する。延期で別シーズンへ移動した作品やブロックフィルターで
+ * 除外済みの作品が古いシーズンに残り続けると、resolver が保存済み season 値で
+ * 候補抽出するため延期前のシーズンに掲載され続ける。
+ */
+async function reconcileSeasonSourceRecords(rows: AnimeImportRow[], year: number, season: string) {
+	const supabase = getSupabaseClient();
+	const seasonValue = `${year}-${season}`;
+	const keepIds = rows.map((row) => row.mal_id);
+	// biome-ignore lint/suspicious/noExplicitAny: jsonb path filter is not covered by the local ImportDatabase type
+	let query = (supabase.from("anime_source_records") as any)
+		.delete()
+		.eq("source", "jikan")
+		.eq("normalized_data->>season", seasonValue);
+	if (keepIds.length > 0) query = query.not("mal_id", "in", `(${keepIds.join(",")})`);
+	const { data, error } = await query.select("mal_id");
+	if (error) throw new Error(`Could not reconcile stale Jikan records for ${seasonValue}: ${error.message}`);
+	const staleIds = ((data ?? []) as { mal_id: number }[]).map((row) => row.mal_id);
+	if (staleIds.length > 0) {
+		console.warn(`Removed ${staleIds.length} stale Jikan records for ${seasonValue}: ${staleIds.join(", ")}`);
+	} else {
+		console.log(`No stale Jikan records for ${seasonValue}.`);
+	}
+}
+
 async function main() {
 	const { year, season, dryRun, enrichLinks, fallbackAnilist } = parseArgs(process.argv.slice(2));
 
@@ -1299,11 +1325,13 @@ async function main() {
 	console.log(`Starting Jikan season import: ${year} ${season}${dryRun ? " (dry-run)" : ""}`);
 	let fetchResult: SeasonFetchResult;
 	let linksAlreadyEnriched = false;
+	let usedAniListFallback = false;
 
 	if (fallbackAnilist) {
 		console.log("Using AniList MAL ID fallback source.");
 		fetchResult = await fetchSeasonAnimeViaAniList(year, season);
 		linksAlreadyEnriched = true;
+		usedAniListFallback = true;
 	} else {
 		try {
 			fetchResult = await fetchSeasonAnime(year, season);
@@ -1315,6 +1343,7 @@ async function main() {
 			);
 			fetchResult = await fetchSeasonAnimeViaAniList(year, season);
 			linksAlreadyEnriched = true;
+			usedAniListFallback = true;
 		}
 	}
 
@@ -1355,6 +1384,15 @@ async function main() {
 	}
 
 	await upsertJikanSourceRecords(rows, new Map(filteredAnimes.map((anime) => [anime.mal_id, anime])));
+
+	// 完全取得に成功したときだけ、今回の結果に無い既存レコードを整合させる。
+	// 部分取得（チェックポイント残あり）や AniList フォールバックの結果で削除すると
+	// 取得漏れを「消えた作品」と誤認するため、その場合はスキップする。
+	if (!usedAniListFallback && fetchResult.failedMalIds.length === 0) {
+		await reconcileSeasonSourceRecords(rows, year, season);
+	} else {
+		console.warn(`Season reconcile skipped for ${year}-${season}: incomplete fetch or AniList fallback in use.`);
+	}
 
 	if (fetchResult.usesCheckpoint && fetchResult.failedMalIds.length === 0) {
 		await clearImportCheckpoint(year, season);

--- a/scripts/import-mal-season.ts
+++ b/scripts/import-mal-season.ts
@@ -443,6 +443,28 @@ async function main() {
 	}
 
 	await saveSourceRows(supabase, rows);
+	// 全対象IDの取得が完了した時点でのみここへ到達する（途中エラーは即throw）ため、
+	// 今回の結果に無い既存の mal レコード（404になったID・対象リストから外れたID）を
+	// このシーズンから削除して整合させる。残すと resolver が古い高優先度ソースを
+	// 採用し続ける。
+	{
+		const seasonValue = `${options.year}-${options.season}`;
+		const keepIds = rows.map((row) => row.mal_id);
+		// biome-ignore lint/suspicious/noExplicitAny: jsonb path filter is not covered by the local ImportDatabase type
+		let staleQuery = (supabase.from("anime_source_records") as any)
+			.delete()
+			.eq("source", "mal")
+			.eq("normalized_data->>season", seasonValue);
+		if (keepIds.length > 0) staleQuery = staleQuery.not("mal_id", "in", `(${keepIds.join(",")})`);
+		const { data: staleRows, error: staleError } = await staleQuery.select("mal_id");
+		if (staleError) {
+			throw new Error(`Could not reconcile stale MAL records for ${seasonValue}: ${staleError.message}`);
+		}
+		const staleIds = ((staleRows ?? []) as { mal_id: number }[]).map((row) => row.mal_id);
+		if (staleIds.length > 0) {
+			console.warn(`Removed ${staleIds.length} stale MAL records for ${seasonValue}: ${staleIds.join(", ")}`);
+		}
+	}
 	// Clear the checkpoint so a future re-run refreshes from the live API
 	// instead of replaying this run's cached snapshots.
 	try {

--- a/src/lib/anime-catalog-export.ts
+++ b/src/lib/anime-catalog-export.ts
@@ -1,0 +1,96 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+	ANIME_OFFLINE_DBCL_URL,
+	ANIME_OFFLINE_LICENSE_URL,
+	ANIME_OFFLINE_ODBL_URL,
+	ANIME_OFFLINE_REPOSITORY_URL,
+	ANIPOLIS_TRANSFORMATION_URL,
+} from "./anime-offline-database.ts";
+
+const PAGE_SIZE = 1_000;
+
+/** 事前生成した成果物を置く公開バケットとオブジェクトパス（migration 123 で作成） */
+export const ANIME_CATALOG_EXPORT_BUCKET = "public-data";
+export const ANIME_CATALOG_EXPORT_OBJECT = "anime-catalog.json";
+
+type SourceRecordRow = {
+	mal_id: number;
+	source: "anime_offline_database" | "jikan" | "mal" | "wikidata" | "syobocal" | "manual";
+	source_version: string;
+	source_url: string;
+	source_updated_at: string | null;
+	normalized_data: Record<string, unknown>;
+	imported_at: string;
+};
+
+type SourceRecordDatabase = {
+	public: {
+		Tables: {
+			anime_source_records: {
+				Row: SourceRecordRow;
+				Insert: SourceRecordRow;
+				Update: Partial<SourceRecordRow>;
+			};
+		};
+	};
+};
+
+/**
+ * anime-offline-database 由来レコードだけを集めた ODbL 派生データの公開 JSON を
+ * 組み立てる。定期ワークフロー（scripts/export-anime-catalog.ts）が成果物を
+ * Storage へ事前生成し、/api/data/anime-catalog はそれを配信する。
+ * このリクエスト時生成はワークフロー用と、成果物が未生成の場合のフォールバック。
+ */
+export async function buildAnimeCatalogExport(supabase: SupabaseClient): Promise<Record<string, unknown>> {
+	const rows: Array<Record<string, unknown>> = [];
+	const sourceReader = supabase as unknown as SupabaseClient<SourceRecordDatabase>;
+
+	for (let start = 0; ; start += PAGE_SIZE) {
+		const { data, error } = await sourceReader
+			.from("anime_source_records")
+			.select("mal_id,source_version,source_url,source_updated_at,normalized_data,imported_at")
+			.eq("source", "anime_offline_database")
+			.order("mal_id", { ascending: true })
+			.range(start, start + PAGE_SIZE - 1);
+
+		if (error) throw new Error(`anime catalog export query failed: ${error.message}`);
+
+		rows.push(...(data ?? []));
+		if (!data || data.length < PAGE_SIZE) break;
+	}
+
+	const sourceUrls = [
+		...new Set(rows.map((row) => row["source_url"]).filter((url): url is string => typeof url === "string")),
+	].sort();
+	const sourceVersions = [
+		...new Set(
+			rows
+				.map((row) => row["source_version"])
+				.filter((version): version is string => typeof version === "string"),
+		),
+	].sort();
+	const data = rows.map((row) => row["normalized_data"]);
+
+	return {
+		name: "Anipolis ODbL derivative of anime-offline-database",
+		scope: "anime-offline-database derived records only",
+		is_complete_anipolis_catalog: false,
+		excluded_sources: ["wikidata", "jikan", "mal", "syobocal", "manual"],
+		exclusion_reason: "Third-party and manually curated data are kept outside this ODbL derivative.",
+		generated_at: new Date().toISOString(),
+		license: {
+			name: "Open Database License 1.0 and Database Contents License 1.0",
+			odbl: ANIME_OFFLINE_ODBL_URL,
+			dbcl: ANIME_OFFLINE_DBCL_URL,
+			upstream_license: ANIME_OFFLINE_LICENSE_URL,
+		},
+		source: {
+			repository: ANIME_OFFLINE_REPOSITORY_URL,
+			versions: sourceVersions,
+			release_assets: sourceUrls,
+		},
+		transformation: ANIPOLIS_TRANSFORMATION_URL,
+		count: data.length,
+		data,
+	};
+}

--- a/src/routes/api/data/anime-catalog/+server.ts
+++ b/src/routes/api/data/anime-catalog/+server.ts
@@ -1,97 +1,37 @@
-import type { SupabaseClient } from "@supabase/supabase-js";
 import { json } from "@sveltejs/kit";
 import {
-	ANIME_OFFLINE_DBCL_URL,
-	ANIME_OFFLINE_LICENSE_URL,
-	ANIME_OFFLINE_ODBL_URL,
-	ANIME_OFFLINE_REPOSITORY_URL,
-	ANIPOLIS_TRANSFORMATION_URL,
-} from "$lib/anime-offline-database";
+	ANIME_CATALOG_EXPORT_BUCKET,
+	ANIME_CATALOG_EXPORT_OBJECT,
+	buildAnimeCatalogExport,
+} from "$lib/anime-catalog-export";
 import type { RequestHandler } from "./$types";
 
-const PAGE_SIZE = 1_000;
+const CACHE_CONTROL = "public, max-age=3600, s-maxage=86400";
 
-type SourceRecordRow = {
-	mal_id: number;
-	source: "anime_offline_database" | "jikan" | "mal" | "wikidata" | "syobocal" | "manual";
-	source_version: string;
-	source_url: string;
-	source_updated_at: string | null;
-	normalized_data: Record<string, unknown>;
-	imported_at: string;
-};
-
-type SourceRecordDatabase = {
-	public: {
-		Tables: {
-			anime_source_records: {
-				Row: SourceRecordRow;
-				Insert: SourceRecordRow;
-				Update: Partial<SourceRecordRow>;
-			};
-		};
-	};
-};
-
-export const GET: RequestHandler = async ({ locals: { supabase } }) => {
-	const rows: Array<Record<string, unknown>> = [];
-	const sourceReader = supabase as unknown as SupabaseClient<SourceRecordDatabase>;
-
-	for (let start = 0; ; start += PAGE_SIZE) {
-		const { data, error } = await sourceReader
-			.from("anime_source_records")
-			.select("mal_id,source_version,source_url,source_updated_at,normalized_data,imported_at")
-			.eq("source", "anime_offline_database")
-			.order("mal_id", { ascending: true })
-			.range(start, start + PAGE_SIZE - 1);
-
-		if (error) {
-			return json({ error: "anime catalog could not be generated" }, { status: 500 });
+export const GET: RequestHandler = async ({ locals: { supabase }, fetch }) => {
+	// 通常経路: syobocal-sync ワークフローが事前生成した成果物をストリーミング配信する。
+	// リクエスト時に全レコードをDB走査してメモリ展開しない（カタログ増加への耐性）。
+	const { data } = supabase.storage.from(ANIME_CATALOG_EXPORT_BUCKET).getPublicUrl(ANIME_CATALOG_EXPORT_OBJECT);
+	try {
+		const artifact = await fetch(data.publicUrl);
+		if (artifact.ok && artifact.body) {
+			return new Response(artifact.body, {
+				headers: {
+					"Content-Type": "application/json",
+					"Cache-Control": CACHE_CONTROL,
+				},
+			});
 		}
-
-		rows.push(...(data ?? []));
-		if (!data || data.length < PAGE_SIZE) break;
+	} catch (error) {
+		console.error("anime catalog artifact fetch failed:", error);
 	}
 
-	const sourceUrls = [
-		...new Set(rows.map((row) => row["source_url"]).filter((url): url is string => typeof url === "string")),
-	].sort();
-	const sourceVersions = [
-		...new Set(
-			rows
-				.map((row) => row["source_version"])
-				.filter((version): version is string => typeof version === "string"),
-		),
-	].sort();
-	const data = rows.map((row) => row["normalized_data"]);
-
-	return json(
-		{
-			name: "Anipolis ODbL derivative of anime-offline-database",
-			scope: "anime-offline-database derived records only",
-			is_complete_anipolis_catalog: false,
-			excluded_sources: ["wikidata", "jikan", "mal", "syobocal", "manual"],
-			exclusion_reason: "Third-party and manually curated data are kept outside this ODbL derivative.",
-			generated_at: new Date().toISOString(),
-			license: {
-				name: "Open Database License 1.0 and Database Contents License 1.0",
-				odbl: ANIME_OFFLINE_ODBL_URL,
-				dbcl: ANIME_OFFLINE_DBCL_URL,
-				upstream_license: ANIME_OFFLINE_LICENSE_URL,
-			},
-			source: {
-				repository: ANIME_OFFLINE_REPOSITORY_URL,
-				versions: sourceVersions,
-				release_assets: sourceUrls,
-			},
-			transformation: ANIPOLIS_TRANSFORMATION_URL,
-			count: data.length,
-			data,
-		},
-		{
-			headers: {
-				"Cache-Control": "public, max-age=3600, s-maxage=86400",
-			},
-		},
-	);
+	// フォールバック: 成果物が未生成（初回デプロイ直後など）の場合のみ動的生成する。
+	try {
+		const payload = await buildAnimeCatalogExport(supabase);
+		return json(payload, { headers: { "Cache-Control": CACHE_CONTROL } });
+	} catch (error) {
+		console.error("anime catalog dynamic generation failed:", error);
+		return json({ error: "anime catalog could not be generated" }, { status: 500 });
+	}
 };

--- a/src/routes/notifications/+page.server.ts
+++ b/src/routes/notifications/+page.server.ts
@@ -32,10 +32,12 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
 	// 表示中タブのカテゴリのみ既読にする（他タブの未読バッジは残す）
 	await markCategoryNotificationsRead(supabase, user.id, tab);
 
-	const [normal, room, mylist, unreadCounts, trendingResult, animeTrending] = await Promise.all([
-		getNotifications(supabase, user.id, 50, NORMAL_TYPES),
-		getNotifications(supabase, user.id, 50, ROOM_TYPES),
-		getNotifications(supabase, user.id, 50, MYLIST_TYPES),
+	// タブは通常リンク遷移で毎回 load が走るため、表示するタブの一覧だけ取得する
+	// （非表示タブの分まで毎回50件×2カテゴリを取得しない）。未読バッジはカウント
+	// クエリ（getUnreadNotificationCountsByCategory）だけで賄える。
+	const typesByTab = { normal: NORMAL_TYPES, room: ROOM_TYPES, mylist: MYLIST_TYPES } as const;
+	const [activeList, unreadCounts, trendingResult, animeTrending] = await Promise.all([
+		getNotifications(supabase, user.id, 50, typesByTab[tab]),
 		getUnreadNotificationCountsByCategory(supabase, user.id),
 		supabase.rpc("get_trending_hashtags", { limit_count: 10 }),
 		getAnimeRankingTrending(supabase, 5),
@@ -43,7 +45,7 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
 
 	return {
 		tab,
-		notifications: { normal, room, mylist },
+		notifications: { normal: [], room: [], mylist: [], [tab]: activeList },
 		unreadCounts,
 		trending: trendingResult.data ?? [],
 		animeTrending,

--- a/supabase/migrations/123_public_data_bucket.sql
+++ b/supabase/migrations/123_public_data_bucket.sql
@@ -1,0 +1,20 @@
+-- 公開データ成果物（ODbLカタログJSON等）の配信用バケットを作成する。
+-- /api/data/anime-catalog がリクエストごとに全レコードをDB走査・メモリ展開して
+-- いた構成を、ワークフローで事前生成した静的成果物のストリーミング配信へ変更する。
+-- 書き込みは service_role のみ（scripts/export-anime-catalog.ts）。ユーザー
+-- ロール向けの INSERT/UPDATE/DELETE ポリシーは意図的に作らない。
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+    'public-data',
+    'public-data',
+    true,
+    52428800, -- 50MB
+    ARRAY['application/json']
+)
+ON CONFLICT (id) DO NOTHING;
+
+DROP POLICY IF EXISTS "public-data is publicly accessible" ON storage.objects;
+CREATE POLICY "public-data is publicly accessible"
+ON storage.objects FOR SELECT
+USING (bucket_id = 'public-data');


### PR DESCRIPTION
## 概要

PR #203 への Codex レビュー6件のうち5件を修正します（1件は見送り・理由後述）。本PRはコード部分で、ワークフロー変更（syobocal-sync.yml）はpush資格情報の workflow スコープ不足のため別送します。

## 修正内容

- **[P1] Jikanから消えた・移動した作品の残留**: 完全取得成功時（チェックポイント残なし・AniListフォールバック未使用）に限り、当該シーズンの取得結果に無い既存 jikan レコードを削除して整合。MAL側にも同様のreconcileを追加（404・対象外れID）
- **[P2] カタログAPIの全件メモリ展開**: `public-data` バケット（migration 123）に事前生成した成果物をストリーミング配信する構成へ変更。生成は `scripts/export-anime-catalog.ts`（週次ワークフローから実行）。成果物未生成時のみ従来の動的生成にフォールバック
- **[P2] 通知タブの全カテゴリ取得**: 表示中タブの一覧のみ取得（未読バッジはカウントクエリで維持）

## 別送（workflowスコープが必要）

- **[P1] MAL/Jikan失敗のジョブ成功扱い**: 失敗時に FAILED=1 を設定（resolveはキャッシュで続行しつつActionsは赤にする）
- **[P2] MAL→Jikanの実行順**: Jikan→MALへ入れ替え（MALの対象IDはJikan/ODbLレコード由来のため）
- カタログ成果物生成ステップの追加

## 見送り

- **[P1] マイグレーション番号の非連続**: 本リポジトリは意図的に手動適用運用（config.tomlでmigrations無効・CLAUDE.md明記）で、本番DBには112〜122適用済み。「後から古い番号を挿入する」状況は発生しない（招待リリースで112/116〜121のファイルがmasterへ追加されるだけで、DBへの適用は完了済み）

## 適用が必要なもの

マージ後、**migration 123（public-dataバケット作成）** をDashboardで手動適用してください。未適用でもAPIは動的生成へフォールバックするため壊れません。

検証: pnpm check 0エラー / 172テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)