### PR TITLE
AniListシーズン取得にタイムアウトを追加（#207のレビュー対応）

### DIFF
--- a/scripts/import-jikan-season.ts
+++ b/scripts/import-jikan-season.ts
@@ -700,6 +700,9 @@ export async function fetchAniListSeasonMalIds(year: number, season: SeasonName)
 					page,
 				},
 			}),
+			// AniList が応答を返さない場合に無期限待ちしないための打ち切り。
+			// abort は呼び出し元の catch に流れ、保存済みIDのみでのフォールバックに到達する
+			signal: AbortSignal.timeout(30_000),
 		});
 
 		const payload = (await response.json()) as AniListSeasonResponse;


### PR DESCRIPTION
PR #207 の CodeRabbit 指摘対応の cherry-pick。AniList無応答時に保存済みIDフォールバックへ有限時間で到達させます。